### PR TITLE
fix(flake.nix): modify the libclang to clang

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
               pkgs.texinfo
 
               # For bindgen (generates Rust bindings from C headers)
-              pkgs.llvmPackages.libclang
+              pkgs.llvmPackages.clang
             ];
 
             buildInputs = with pkgs; [
@@ -155,6 +155,7 @@
 
               # xdg-dbus-proxy for WebKit sandbox
               xdg-dbus-proxy
+              gcc
             ];
 
             # pkg-config paths for dev headers


### PR DESCRIPTION
modify the `pkgs.llvmPackages.libclang` dependency in the Nix environment to `pkgs.llvmPackages.clang` to fix the issue where Rust cannot find `<sys/types.h>` when generating code.