### PR TITLE
fix(nix): set mainProgram so nix run launches emacs

### DIFF
--- a/nix/neomacs.nix
+++ b/nix/neomacs.nix
@@ -249,6 +249,8 @@ in stdenv.mkDerivation {
     homepage = "https://github.com/eval-exec/neomacs";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
+    # `nix run` uses this when no explicit `apps.<system>.default` is defined.
+    mainProgram = "emacs";
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Summary
- set `meta.mainProgram = "emacs"` in `nix/neomacs.nix`
- ensure `nix run github:eval-exec/neomacs` resolves to the installed binary (`bin/emacs`) instead of missing `bin/neomacs`

## Verification
- `nix eval --raw .#packages.x86_64-linux.default.pname` -> `neomacs`
- `nix eval --raw .#packages.x86_64-linux.default.meta.mainProgram` -> `emacs` (was missing before this change)

Fixes #10