### PR TITLE
fix(image): prevent XBM image-size crash on missing query_colors hook

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -4979,10 +4979,15 @@ Create_Pixmap_From_Bitmap_Data (struct frame *f, struct image *img, char *data,
 				bool non_default_colors)
 {
 #ifdef USE_CAIRO
-  Emacs_Color fgbg[] = {{.pixel = fg}, {.pixel = bg}};
-  FRAME_TERMINAL (f)->query_colors (f, fgbg, ARRAYELTS (fgbg));
-  fg = lookup_rgb_color (f, fgbg[0].red, fgbg[0].green, fgbg[0].blue);
-  bg = lookup_rgb_color (f, fgbg[1].red, fgbg[1].green, fgbg[1].blue);
+  if (FRAME_TERMINAL (f)->query_colors)
+    {
+      Emacs_Color fgbg[] = {{.pixel = fg}, {.pixel = bg}};
+      FRAME_TERMINAL (f)->query_colors (f, fgbg, ARRAYELTS (fgbg));
+      fg = lookup_rgb_color (f, fgbg[0].red, fgbg[0].green, fgbg[0].blue);
+      bg = lookup_rgb_color (f, fgbg[1].red, fgbg[1].green, fgbg[1].blue);
+    }
+  /* Some terminals may not provide query_colors; in that case treat
+     FG and BG as already being RGB pixel values.  */
   img->pixmap
     = image_pix_container_create_from_bitmap_data (data, img->width,
 						   img->height, fg, bg);

--- a/test/src/image-tests.el
+++ b/test/src/image-tests.el
@@ -55,6 +55,14 @@
   (skip-when (display-images-p))
   (should-error (image-metadata (cdr (assq 'xbm image-tests--images)))))
 
+(ert-deftest image-tests-image-size/xbm-on-graphical-display ()
+  "XBM image-size should work on graphical displays without crashing."
+  (skip-unless (display-images-p))
+  (let* ((file (cdr (assq 'xbm image-tests--images)))
+         (spec `(image :type xbm :file ,file)))
+    (should (consp (image-size spec)))
+    (should (consp (image-size spec t)))))
+
 (ert-deftest image-tests-imagemagick-types ()
   (skip-unless (fboundp 'imagemagick-types))
   (when (fboundp 'imagemagick-types)


### PR DESCRIPTION
## Summary
- guard `Create_Pixmap_From_Bitmap_Data` so the `query_colors` hook is only called when present under `USE_CAIRO`
- keep a safe fallback path that treats `fg`/`bg` as already-RGB pixel values
- add a regression test for `image-size` on XBM specs in graphical sessions

Fixes #13.

## Test Plan
- `make -C src -j4 image.o`
- `./src/emacs -Q --batch -L test -l ert -l test/src/image-tests.el --eval "(ert-run-tests-batch-and-exit \"image-tests-\")"`

Notes:
- In this CI-less/headless environment, graphical XBM test is expected to skip (`image-tests-image-size/xbm-on-graphical-display`).
