### PR TITLE
feat: add macOS support for neomacs GPU display engine

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2804,6 +2804,11 @@ CPPFLAGS="$CPPFLAGS -x objective-c"
 CFLAGS="$CFLAGS -x objective-c"
 GNU_OBJC_CFLAGS=""
 LIBS_GNUSTEP=
+dnl When building with neomacs display engine, skip NS (Cocoa/GNUstep) detection
+dnl entirely.  Neomacs uses its own Rust display engine (winit + wgpu/Metal).
+if test "${with_neomacs}" = "yes"; then
+  with_ns=no
+fi
 if test "${with_ns}" != no; then
   # macfont.o requires macuvs.h which is absent after 'make extraclean',
   # so avoid NS_IMPL_COCOA if macuvs.h is absent.
@@ -4009,21 +4014,50 @@ if test "$window_system" = "neomacs"; then
   else
     AC_MSG_ERROR([cairo required for Neomacs but not found.])
   fi
-  dnl EGL is required for DMA-BUF zero-copy in webkit/video
-  PKG_CHECK_MODULES([EGL], [egl], [], [AC_MSG_ERROR([EGL required for Neomacs zero-copy rendering])])
+  dnl EGL is required for DMA-BUF zero-copy on Linux; macOS uses Metal instead.
+  EGL_CFLAGS=""
+  EGL_LIBS=""
+  case $opsys in
+    darwin)
+      dnl EGL not available on macOS; Metal is used for rendering.
+      ;;
+    *)
+      PKG_CHECK_MODULES([EGL], [egl], [], [AC_MSG_ERROR([EGL required for Neomacs zero-copy rendering])])
+      ;;
+  esac
   dnl WPE WebKit for browser embedding (optional)
   HAVE_NEOMACS_WEBKIT=no
   PKG_CHECK_MODULES([WPEWEBKIT], [wpe-webkit-2.0], [HAVE_NEOMACS_WEBKIT=yes], [AC_MSG_WARN([WPE WebKit not found, webkit support disabled])])
   PKG_CHECK_MODULES([WPEBACKEND], [wpebackend-fdo-1.0], [], [AC_MSG_WARN([wpebackend-fdo not found])])
   dnl Wayland-server is needed for wl_shm_buffer functions (SHM fallback mode)
   PKG_CHECK_MODULES([WAYLAND_SERVER], [wayland-server], [], [AC_MSG_WARN([wayland-server not found])])
-  dnl xkbcommon for key name resolution
-  PKG_CHECK_MODULES([XKBCOMMON], [xkbcommon], [], [AC_MSG_ERROR([xkbcommon required for Neomacs])])
+  dnl xkbcommon for key name resolution (Linux; macOS uses native key APIs)
+  XKBCOMMON_CFLAGS=""
+  XKBCOMMON_LIBS=""
+  case $opsys in
+    darwin)
+      dnl xkbcommon not needed on macOS.
+      ;;
+    *)
+      PKG_CHECK_MODULES([XKBCOMMON], [xkbcommon], [], [AC_MSG_ERROR([xkbcommon required for Neomacs])])
+      ;;
+  esac
   NEOMACS_CFLAGS="$GSTREAMER_CFLAGS $CAIRO_CFLAGS $GLIB_CFLAGS $EGL_CFLAGS $XKBCOMMON_CFLAGS"
-  NEOMACS_LIBS="$NEOMACS_LIBS $GSTREAMER_LIBS $CAIRO_LIBS $GLIB_LIBS $EGL_LIBS $XKBCOMMON_LIBS -lpthread -lm -ldl"
+  case $opsys in
+    darwin)
+      dnl macOS: -ldl is part of libSystem; add macOS frameworks for neomacs
+      NEOMACS_LIBS="$NEOMACS_LIBS $GSTREAMER_LIBS $CAIRO_LIBS $GLIB_LIBS -lpthread -lm -framework AppKit -framework Metal -framework QuartzCore -framework CoreGraphics -framework Foundation"
+      ;;
+    *)
+      NEOMACS_LIBS="$NEOMACS_LIBS $GSTREAMER_LIBS $CAIRO_LIBS $GLIB_LIBS $EGL_LIBS $XKBCOMMON_LIBS -lpthread -lm -ldl"
+      ;;
+  esac
   if test "$HAVE_NEOMACS_WEBKIT" = yes; then
     NEOMACS_CFLAGS="$NEOMACS_CFLAGS $WPEWEBKIT_CFLAGS $WPEBACKEND_CFLAGS $WAYLAND_SERVER_CFLAGS"
     NEOMACS_LIBS="$NEOMACS_LIBS $WPEWEBKIT_LIBS $WPEBACKEND_LIBS $WAYLAND_SERVER_LIBS"
+    HAVE_WPE_WEBKIT=1
+  else
+    HAVE_WPE_WEBKIT=0
   fi
 fi
 AC_SUBST([NEOMACS_OBJ])
@@ -4031,6 +4065,7 @@ AC_SUBST([NEOMACS_LIBS])
 AC_SUBST([NEOMACS_CFLAGS])
 AC_SUBST([NEOMACS_PREBUILT])
 AC_SUBST([NEOMACS_RUST_DYLIB_EXT])
+AC_SUBST([HAVE_WPE_WEBKIT])
 
 AC_CHECK_FUNCS([malloc_trim])
 

--- a/rust/neomacs-display/src/ffi/mod.rs
+++ b/rust/neomacs-display/src/ffi/mod.rs
@@ -211,7 +211,7 @@ pub(crate) static TERMINAL_ID_COUNTER: std::sync::atomic::AtomicU32 = std::sync:
 // Threaded State
 // ============================================================================
 
-use crate::thread_comm::{EmacsComms, EffectUpdater, InputEvent, MenuBarItem, PopupMenuItem, RenderCommand, ThreadComms, ToolBarItem};
+use crate::thread_comm::{EmacsComms, EffectUpdater, InputEvent, MenuBarItem, PopupMenuItem, RenderCommand, RenderComms, ThreadComms, ToolBarItem};
 use crate::render_thread::{RenderThread, SharedImageDimensions, SharedMonitorInfo};
 
 /// Global state for threaded mode

--- a/rust/neomacs-display/src/render_thread/mod.rs
+++ b/rust/neomacs-display/src/render_thread/mod.rs
@@ -3513,7 +3513,7 @@ impl ApplicationHandler for RenderApp {
 }
 
 /// Run the render loop (called on render thread)
-fn run_render_loop(
+pub(crate) fn run_render_loop(
     comms: RenderComms,
     width: u32,
     height: u32,

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -345,10 +345,9 @@ else
 NEOMACS_RUST_PROFILE = release
 NEOMACS_CARGO_FLAGS = --release
 endif
-NEOMACS_CARGO_BACKEND_FLAGS = --features $(NEOVM_CORE_BACKEND_CARGO_FEATURE)
-# WPE WebKit is now a default feature - always enable the cargo feature
-# Note: wpe-webkit is included in the default features in Cargo.toml
-HAVE_WPE_WEBKIT = 1
+NEOMACS_CARGO_BACKEND_FLAGS = --no-default-features --features "video,neo-term,$(NEOVM_CORE_BACKEND_CARGO_FEATURE)"
+# WPE WebKit is Linux-only; disabled on macOS
+HAVE_WPE_WEBKIT = @HAVE_WPE_WEBKIT@
 NEOMACS_RUST_TARGET = $(NEOMACS_RUST_DIR)/target/$(NEOMACS_RUST_PROFILE)/$(NEOMACS_RUST_LIB)
 
 ## emacs.res if HAVE_W32

--- a/src/dispextern.h
+++ b/src/dispextern.h
@@ -158,9 +158,11 @@ typedef XImagePtr XImagePtr_or_DC;
 
 #include "neomacsgui.h"
 /* Following typedef needed to accommodate the MSDOS port, believe it or not.  */
+#if !defined(HAVE_NS) && !defined(HAVE_PGTK)
 typedef struct neomacs_display_info Display_Info;
 typedef Emacs_Pixmap XImagePtr;
 typedef XImagePtr XImagePtr_or_DC;
+#endif /* !HAVE_NS && !HAVE_PGTK */
 /* Emacs_Pix_Container and Emacs_Pix_Context are already defined by USE_CAIRO above */
 
 #ifdef HAVE_HAIKU

--- a/src/dispnew.c
+++ b/src/dispnew.c
@@ -6387,7 +6387,7 @@ buffer_posn_from_coords (struct window *w, int *x, int *y, struct display_pos *p
 	 webkit views embedded in buffer text.
 	 Format: (webkit :id N :width W :height H) */
       *object = CALLN (Flist, Qwebkit,
-		       QCid, make_fixnum (it.webkit_id),
+		       intern_c_string (":id"), make_fixnum (it.webkit_id),
 		       QCwidth, make_fixnum (it.video_width),
 		       QCheight, make_fixnum (it.video_height));
     }

--- a/src/neomacsgui.h
+++ b/src/neomacsgui.h
@@ -19,7 +19,8 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
 #ifndef __NEOMACSGUI_H__
 #define __NEOMACSGUI_H__
 
-/* Emulate XCharStruct.  */
+/* Emulate XCharStruct - only if not already provided by nsgui.h or pgtkgui.h.  */
+#if !defined(HAVE_NS) && !defined(HAVE_PGTK)
 typedef struct _XCharStruct
 {
   int rbearing;
@@ -41,6 +42,7 @@ typedef unichar XChar2b;
 
 #define XCHAR2B_BYTE2(chp) \
   (*(chp) & 0x00ff)
+#endif /* !HAVE_NS && !HAVE_PGTK */
 
 
 /* Cursor is an opaque pointer in Neomacs (we use GdkCursor internally) */
@@ -108,6 +110,8 @@ typedef struct
 #define PWinGravity	(1L << 9)	/* program specified window gravity */
 
 
+/* NativeRectangle and conversion macros - only if not already defined by nsgui.h.  */
+#ifndef HAVE_NS
 #define NativeRectangle XRectangle
 
 #define CONVERT_TO_EMACS_RECT(xr, nr)		\
@@ -127,6 +131,7 @@ typedef struct
    (nr).y      = (py),					\
    (nr).width  = (pwidth),				\
    (nr).height = (pheight))
+#endif /* !HAVE_NS */
 
 /* RGB pixel color type */
 typedef unsigned long RGB_PIXEL_COLOR;

--- a/src/neomacsterm.c
+++ b/src/neomacsterm.c
@@ -25,7 +25,9 @@ along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.  */
 #include <string.h>
 #include <stdint.h>
 #include <signal.h>
+#ifndef __APPLE__
 #include <xkbcommon/xkbcommon.h>
+#endif
 
 #include "lisp.h"
 #include "blockinput.h"
@@ -15788,9 +15790,15 @@ char *
 get_keysym_name (int keysym)
 {
   static char name_buf[64];
+#ifdef __APPLE__
+  /* macOS: no xkbcommon; use snprintf fallback.  */
+  snprintf (name_buf, sizeof name_buf, "key-%d", keysym);
+  return name_buf;
+#else
   if (xkb_keysym_get_name (keysym, name_buf, sizeof name_buf) > 0)
     return name_buf;
   return NULL;
+#endif
 }
 
 /* Set mouse pixel position on frame F.  */

--- a/src/neomacsterm.h
+++ b/src/neomacsterm.h
@@ -396,6 +396,11 @@ extern int neomacs_display_init_threaded_mode (int width, int height, const char
 extern int neomacs_display_is_threaded (void);
 extern void neomacs_display_shutdown_threaded_mode (void);
 
+/* macOS main-thread trampoline (Rust FFI) */
+#ifdef __APPLE__
+extern int neomacs_macos_main_thread_entry (int argc, char **argv);
+#endif
+
 /* Note: x_create_gc and x_free_gc are defined as static functions in xfaces.c */
 
 #endif /* _NEOMACSTERM_H_ */

--- a/src/nsgui.h
+++ b/src/nsgui.h
@@ -52,11 +52,13 @@ typedef struct _XCharStruct
   int descent;
 } XCharStruct;
 
+#ifndef USE_CAIRO
 #ifdef __OBJC__
 typedef id Emacs_Pixmap;
 #else
 typedef void *Emacs_Pixmap;
 #endif
+#endif /* !USE_CAIRO */
 
 #ifdef __OBJC__
 typedef NSCursor *Emacs_Cursor;


### PR DESCRIPTION
Port the neomacs Rust display engine (winit + wgpu/Metal) to macOS arm64 by resolving build-time conflicts and a runtime threading constraint.

Build fixes:
- Suppress NS/Cocoa detection when --with-neomacs is set
- Skip EGL and xkbcommon checks on macOS (Metal and native key APIs)
- Use macOS frameworks instead of -ldl for linking
- Disable WPE WebKit (Linux-only) via --no-default-features in cargo
- Guard header typedefs to prevent conflicts between nsgui.h and neomacsgui.h (XCharStruct, NativeRectangle, Display_Info, Emacs_Pixmap)
- Replace unavailable QCid symbol with intern_c_string(":id")
- Add xkbcommon include guard and get_keysym_name fallback for macOS

Runtime fix:
- Invert thread model on macOS where winit 0.30 requires EventLoop on the main thread: main() hands control to Rust via a trampoline that spawns Emacs on a child thread and runs the render loop on the main thread, coordinated through a condvar-based handoff in neomacs_display_init_threaded

# Neomacs PR Checklist

## Compatibility Checks

- [ ] Ran relevant vm-compat checks for changed areas (for example `make -C test/neovm/vm-compat check-one-neovm`, `check-all-neovm`, etc.).
- [ ] Ran `make -C test/neovm/vm-compat compat-progress` and attached output in PR notes.
- [ ] If stub annotations changed, ran `make -C test/neovm/vm-compat check-stub-budget` and confirmed `explicitly annotated function stubs` budget expectations.
- [ ] If case corpus changed, attached `make -C test/neovm/vm-compat check` or `check-neovm` outputs for changed case lists.
- [ ] If registry metadata changed, attached `check-builtin-registry-*` output (at least `check-builtin-registry-fboundp`).
