### PR TITLE
nix: ship a site-start startup stub

### DIFF
--- a/nix/neomacs.nix
+++ b/nix/neomacs.nix
@@ -266,12 +266,18 @@ in stdenv.mkDerivation {
 
   # Wrap the binary with required environment variables
   postInstall = if isLinux then ''
+    install -Dm644 ${./site-start.el} \
+      "$out/share/emacs/site-lisp/site-start.el"
+
     wrapProgram $out/bin/emacs \
       --set WPE_BACKEND_LIBRARY "${libwpe-fdo}/lib/libWPEBackend-fdo-1.0.so" \
       --set GIO_MODULE_DIR "${glib-networking}/lib/gio/modules" \
       --set WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS "1" \
       --prefix PATH : "${wpewebkit}/libexec/wpe-webkit-2.0"
   '' else ''
+    install -Dm644 ${./site-start.el} \
+      "$out/share/emacs/site-lisp/site-start.el"
+
     wrapProgram $out/bin/emacs \
       --set GIO_MODULE_DIR "${glib-networking}/lib/gio/modules"
   '';

--- a/nix/site-start.el
+++ b/nix/site-start.el
@@ -1,0 +1,9 @@
+;;; site-start.el --- Nix package startup stub  -*- lexical-binding: t; -*-
+
+;; Home Manager and other Nix-based Emacs integrations may expect the
+;; package site startup file to exist, even when the package does not need
+;; site-wide initialization of its own.
+
+(provide 'site-start)
+
+;;; site-start.el ends here


### PR DESCRIPTION
## Summary
- install a packaged site-start.el stub into $out/share/emacs/site-lisp
- keep the change Nix-only so runtime and GNU sources stay untouched
- avoid startup failures in Nix/Home Manager environments that expect a package site startup file

Fixes #60.