### PR TITLE
xtask: re-sign binaries after pdump fingerprint patch on macOS

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -386,6 +386,26 @@ fn run_fresh_build(options: &FreshBuildOptions) -> Result<()> {
     patch_primary_executable_fingerprint(options, &paths)?;
     copy_executable_role_images(options, &paths)?;
 
+    // macOS: re-sign all role binaries after patching.  Patching the pdump
+    // fingerprint modifies the executable image in-place, which invalidates
+    // the code signature.  Without a fresh ad-hoc signature the kernel sends
+    // SIGKILL when the binary is executed (exit status: signal 9).
+    #[cfg(target_os = "macos")]
+    {
+        for bin in [&paths.temacs, &paths.bootstrap, &paths.final_bin] {
+            if bin.exists() {
+                let status = std::process::Command::new("codesign")
+                    .args(["--force", "--sign", "-", bin.to_str().unwrap()])
+                    .status()?;
+                if !status.success() {
+                    return Err(
+                        format!("codesign failed on {}", bin.display()).into()
+                    );
+                }
+            }
+        }
+    }
+
     if !options.dry_run {
         ensure_binaries_exist(&paths)?;
     }


### PR DESCRIPTION
## Problem

On macOS (Apple Silicon), `cargo xtask fresh-build --release` fails with:

```
error: command failed with status signal: 9 (SIGKILL):
  neomacs-temacs --batch -l loadup --temacs=pbootstrap
```

## Root Cause

The `patch_primary_executable_fingerprint` step modifies the executable binary in-place to embed the pdump fingerprint. On macOS, any in-place modification of a signed binary invalidates its code signature. When the kernel subsequently tries to execute the binary, it detects the invalid signature and sends SIGKILL.

## Fix

After `copy_executable_role_images` copies the patched `final_bin` to the `temacs` and `bootstrap` roles, re-sign all three binaries using an ad-hoc signature (`codesign --force --sign -`). Ad-hoc signing requires no certificate and is sufficient for local execution.

This fix is gated behind `#[cfg(target_os = macos)]` and has no effect on Linux builds.