### PR TITLE
Pass display handle to wgpu instance

### DIFF
--- a/neomacs-display-runtime/src/render_thread/bootstrap.rs
+++ b/neomacs-display-runtime/src/render_thread/bootstrap.rs
@@ -4,7 +4,7 @@ use super::{
 use crate::thread_comm::{InputEvent, RenderComms};
 use neomacs_renderer_wgpu::{WgpuGlyphAtlas, WgpuRenderer};
 use std::sync::Arc;
-use winit::event_loop::{ControlFlow, EventLoop};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 #[cfg(target_os = "linux")]
 use winit::platform::wayland::EventLoopBuilderExtWayland;
 #[cfg(target_os = "linux")]
@@ -18,13 +18,10 @@ use crate::backend::wpe::sys::platform as plat;
 
 impl RenderApp {
     /// Initialize wgpu with the window
-    pub(super) fn init_wgpu(&mut self, window: Arc<Window>) {
+    pub(super) fn init_wgpu(&mut self, event_loop: &ActiveEventLoop, window: Arc<Window>) {
         tracing::info!("Initializing wgpu for render thread");
 
-        // Create wgpu instance
-        let mut instance_descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
-        instance_descriptor.backends = wgpu::Backends::all();
-        let instance = wgpu::Instance::new(instance_descriptor);
+        let instance = create_wgpu_instance(event_loop);
 
         // Create surface from window
         let surface = match instance.create_surface(window.clone()) {
@@ -215,6 +212,14 @@ impl RenderApp {
 
         tracing::debug!("Surface resized to {}x{}", width, height);
     }
+}
+
+pub(super) fn create_wgpu_instance(event_loop: &ActiveEventLoop) -> wgpu::Instance {
+    let display_handle = event_loop.owned_display_handle();
+    let mut instance_descriptor =
+        wgpu::InstanceDescriptor::new_with_display_handle_from_env(Box::new(display_handle));
+    instance_descriptor.backends = wgpu::Backends::all().with_env();
+    wgpu::Instance::new(instance_descriptor)
 }
 
 fn build_render_event_loop_impl(

--- a/neomacs-display-runtime/src/render_thread/lifecycle.rs
+++ b/neomacs-display-runtime/src/render_thread/lifecycle.rs
@@ -125,7 +125,7 @@ impl RenderApp {
                     );
 
                     // Initialize wgpu with the window
-                    self.init_wgpu(window.clone());
+                    self.init_wgpu(event_loop, window.clone());
 
                     // Enable IME input for CJK and compose support
                     window.set_ime_allowed(true);

--- a/neomacs-display-runtime/src/render_thread/multi_window.rs
+++ b/neomacs-display-runtime/src/render_thread/multi_window.rs
@@ -144,10 +144,7 @@ impl MultiWindowManager {
                     let phys = window.inner_size();
 
                     // Create surface for this window
-                    let mut instance_descriptor =
-                        wgpu::InstanceDescriptor::new_without_display_handle();
-                    instance_descriptor.backends = wgpu::Backends::all();
-                    let instance = wgpu::Instance::new(instance_descriptor);
+                    let instance = super::bootstrap::create_wgpu_instance(event_loop);
                     let surface = match instance.create_surface(window.clone()) {
                         Ok(s) => s,
                         Err(e) => {


### PR DESCRIPTION
## Summary

Pass winit's owned display handle into wgpu instance creation for GUI surfaces.

This changes both the primary render window and secondary GUI windows to create wgpu instances through a shared helper that uses `InstanceDescriptor::new_with_display_handle_from_env(...)`. The helper keeps the default all-backends behavior while allowing `WGPU_BACKEND` to influence backend selection for diagnostics such as `WGPU_BACKEND=gl`.

## Why

Issue #107 showed a Wayland/Haswell setup where Vulkan was rejected and GL was detected but reported as incompatible with the window surface. wgpu documents that GLES presentation, especially on Wayland, needs the platform display handle on the instance. The previous path used `new_without_display_handle()` everywhere.

## Validation

- `cargo fmt --check`
- `cargo check -p neomacs-display-runtime`
- pre-push hook: `cargo fmt --all --check`
- pre-push hook: `cargo check`