### PR TITLE
Fix backward comment skip success handling

### DIFF
--- a/neovm-core/src/emacs_core/syntax.rs
+++ b/neovm-core/src/emacs_core/syntax.rs
@@ -1422,9 +1422,12 @@ fn maybe_skip_comment_backward(
         buffer: buf,
         point: start_byte,
     };
-    let _ = forward_comment_backward(&mut scanner, 1, honor_properties);
-    let next = buffer_byte_to_char_pos(buf, scanner.point_emacs_byte_pos());
-    (next < idx).then_some(next)
+    if forward_comment_backward(&mut scanner, 1, honor_properties) {
+        let next = buffer_byte_to_char_pos(buf, scanner.point_emacs_byte_pos());
+        (next < idx).then_some(next)
+    } else {
+        None
+    }
 }
 
 fn skip_sexp_ignored_forward(

--- a/neovm-core/src/emacs_core/syntax_test.rs
+++ b/neovm-core/src/emacs_core/syntax_test.rs
@@ -988,6 +988,34 @@ fn backward_sexp_motion_skips_nested_block_comments() {
 }
 
 #[test]
+fn backward_comment_skip_requires_matching_comment_start() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::eval::Context::new();
+    replace_current_buffer_text(&mut eval, "ab");
+    builtin_modify_syntax_entry(
+        &mut eval,
+        vec![Value::fixnum('a' as i64), Value::string("w 3")],
+    )
+    .expect("install first two-char comment-end syntax");
+    builtin_modify_syntax_entry(
+        &mut eval,
+        vec![Value::fixnum('b' as i64), Value::string("w 4")],
+    )
+    .expect("install second two-char comment-end syntax");
+
+    let buf = eval.buffers.current_buffer().expect("current buffer");
+    let entry = SyntaxTable::for_buffer(buf)
+        .get_entry('b')
+        .expect("syntax entry for b");
+    assert_eq!(entry.class, SyntaxClass::Word);
+    assert!(entry.flags.contains(SyntaxFlags::COMMENT_END_SECOND));
+    assert_eq!(
+        maybe_skip_comment_backward(buf, 2, false, entry.class, entry.flags),
+        None
+    );
+}
+
+#[test]
 fn sexp_motion_respects_parse_sexp_ignore_comments_for_block_comments() {
     crate::test_utils::init_test_tracing();
     let mut eval = crate::emacs_core::eval::Context::new();


### PR DESCRIPTION
Follow-up to #134 and the Gemini Code Assist review comment on `maybe_skip_comment_backward`.

## Summary

- Only return a backward comment skip when `forward_comment_backward` reports success.
- Prevent unmatched two-character comment-end probes from treating the scanner's restored point as a successful skip.
- Add a focused regression for a two-character comment end without a matching comment start.

## Validation

- `git diff --check`
- `cargo fmt --check`
- `cargo test -p neovm-core backward_comment_skip_requires_matching_comment_start -- --nocapture`
- `cargo test -p neovm-core emacs_core::syntax::tests -- --nocapture`
  - `111 passed; 0 failed`
