### PR TITLE
ci(nix): add startup smoke test

### DIFF
--- a/.github/workflows/nix-smoke.yml
+++ b/.github/workflows/nix-smoke.yml
@@ -1,0 +1,53 @@
+name: nix smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nix-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nix-smoke:
+    name: nix build and startup smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          enable_kvm: false
+          extra_nix_config: |
+            accept-flake-config = true
+            substituters = https://nix-wpe-webkit.cachix.org https://cache.nixos.org/
+            trusted-public-keys = nix-wpe-webkit.cachix.org-1:ItCjHkz1Y5QcwqI9cTGNWHzcox4EqcXqKvOygxpwYHE= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+
+      - name: Build Neomacs with Nix
+        run: nix build --print-build-logs --accept-flake-config .#neomacs
+
+      - name: Smoke test Nix-built Neomacs
+        run: |
+          set -euo pipefail
+          fingerprint="$(./result/bin/neomacs --fingerprint | tr -d '[:space:]')"
+          if ! [[ "$fingerprint" =~ ^[0-9A-Fa-f]{64}$ ]]; then
+            echo "invalid Neomacs pdump fingerprint: $fingerprint" >&2
+            exit 1
+          fi
+
+          test -f ./result/bin/neomacs.pdump
+          test -f "./result/bin/neomacs-${fingerprint}.pdump"
+
+          # This exercises the installed wrapper from the Nix output and would
+          # fail with the issue #133 panic if the final pdump image was absent.
+          timeout 60s ./result/bin/neomacs --batch --quick --eval \
+            '(progn (princ "nix smoke ok\n") (kill-emacs 0))'

--- a/flake.nix
+++ b/flake.nix
@@ -161,6 +161,20 @@
               cp -r lisp "$out/share/neomacs/"
               cp -r etc "$out/share/neomacs/"
               chmod -R u+w "$out/share/neomacs"
+
+              final_pdump="target/release/neomacs.pdump"
+              if [ ! -f "$final_pdump" ]; then
+                echo "missing final pdump image: $final_pdump" >&2
+                exit 1
+              fi
+              fingerprint="$($out/bin/neomacs --fingerprint | tr -d '[:space:]')"
+              if ! [[ "$fingerprint" =~ ^[[:xdigit:]]{64}$ ]]; then
+                echo "invalid final pdump fingerprint: $fingerprint" >&2
+                exit 1
+              fi
+              install -m 0644 "$final_pdump" "$out/bin/neomacs.pdump"
+              install -m 0644 "$final_pdump" "$out/bin/neomacs-$fingerprint.pdump"
+
               wrapProgram "$out/bin/neomacs" \
                 --prefix LD_LIBRARY_PATH : "${pkgs.lib.makeLibraryPath runtimeLibs}" \
                 --set-default RUST_LOG info \


### PR DESCRIPTION
## Summary

- add a `nix smoke` GitHub Actions workflow using `cachix/install-nix-action@v31`
- build `.#neomacs`, assert both canonical and fingerprinted pdump files are present in the Nix result, then run a batch startup smoke test
- install the final `neomacs.pdump` image into the Nix package output next to the wrapped binary so the Nix-built executable can start

Closes https://github.com/eval-exec/neomacs/issues/133

## Validation

- `git diff --check`
- `python - <<'PY' ... yaml.safe_load('.github/workflows/nix-smoke.yml') ... PY`
- `gh act push -W .github/workflows/nix-smoke.yml -j nix-smoke -n`
- Tried a real local `gh act` run with `--privileged`; Nix installed and started the build, but the local container build was stopped after several minutes because it was rebuilding/downloading the full dependency graph. The dry-run validates the workflow wiring; the PR workflow should exercise the full `nix build` smoke path on GitHub-hosted runners.
