### PR TITLE
ci(nix): harden pdump fingerprint and cache smoke builds

### DIFF
--- a/.github/workflows/nix-smoke.yml
+++ b/.github/workflows/nix-smoke.yml
@@ -18,7 +18,7 @@ jobs:
   nix-smoke:
     name: nix build and startup smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 240
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -26,16 +26,17 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
-          enable_kvm: false
           extra_nix_config: |
             accept-flake-config = true
-            substituters = https://nix-wpe-webkit.cachix.org https://cache.nixos.org/
-            trusted-public-keys = nix-wpe-webkit.cachix.org-1:ItCjHkz1Y5QcwqI9cTGNWHzcox4EqcXqKvOygxpwYHE= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://eval-exec.cachix.org https://nix-wpe-webkit.cachix.org https://cache.nixos.org/
+            trusted-public-keys = eval-exec.cachix.org-1:xvopUI7X7+Vt1gaSsWJ0PQFPP66vs8v5iIaz6boxf64= nix-wpe-webkit.cachix.org-1:ItCjHkz1Y5QcwqI9cTGNWHzcox4EqcXqKvOygxpwYHE= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
       - name: Build Neomacs with Nix
+        timeout-minutes: 120
         run: nix build --print-build-logs --accept-flake-config .#neomacs
 
       - name: Smoke test Nix-built Neomacs
+        timeout-minutes: 5
         run: |
           set -euo pipefail
           fingerprint="$(./result/bin/neomacs --fingerprint | tr -d '[:space:]')"

--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,7 @@
               let
                 base = builtins.baseNameOf path;
               in
-              !(builtins.elem base [ ".git" ".direnv" "target" "result" ]);
+              !(builtins.elem base [ ".git" ".direnv" ".github" "target" "result" "flake.nix" "flake.lock" ]);
           };
           pname = "neomacs";
           version = self.shortRev or self.dirtyShortRev or self.lastModifiedDate or "0.0.1";
@@ -140,7 +140,18 @@
             buildInputs = runtimeLibs;
             doCheck = false;
           };
-          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          depsArgs = commonArgs // {
+            # Keep the dependency-artifact derivation stable across commits.
+            # The final package still uses the git-derived version, but Rust
+            # dependency compilation should only change when Cargo metadata or
+            # build inputs change.
+            version = "0.0.0";
+            dummySrc = craneLib.mkDummySrc {
+              src = cargoSrc;
+              cleanCargoTomlFilter = craneLib.filters.cargoTomlAggressive;
+            };
+          };
+          cargoArtifacts = craneLib.buildDepsOnly depsArgs;
           hostEmulator = pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages;
           fingerprintRunner = lib.optionalString (hostEmulator != null) "${hostEmulator} ";
           linuxWrapArgs = lib.optionals pkgs.stdenv.isLinux [

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,14 @@
   description = "Neomacs - GPU-accelerated Emacs written in Rust with a modern, multithreaded architecture";
 
   nixConfig = {
-    extra-substituters = [ "https://nix-wpe-webkit.cachix.org" ];
-    extra-trusted-public-keys = [ "nix-wpe-webkit.cachix.org-1:ItCjHkz1Y5QcwqI9cTGNWHzcox4EqcXqKvOygxpwYHE=" ];
+    extra-substituters = [
+      "https://eval-exec.cachix.org"
+      "https://nix-wpe-webkit.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "eval-exec.cachix.org-1:xvopUI7X7+Vt1gaSsWJ0PQFPP66vs8v5iIaz6boxf64="
+      "nix-wpe-webkit.cachix.org-1:ItCjHkz1Y5QcwqI9cTGNWHzcox4EqcXqKvOygxpwYHE="
+    ];
   };
 
   inputs = {
@@ -135,6 +141,8 @@
             doCheck = false;
           };
           cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          hostEmulator = pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages;
+          fingerprintRunner = lib.optionalString (hostEmulator != null) "${hostEmulator} ";
           linuxWrapArgs = lib.optionals pkgs.stdenv.isLinux [
             "--set-default" "VK_DRIVER_FILES" "$(echo ${pkgs.mesa}/share/vulkan/icd.d/*.json | tr ' ' ':')"
             "--set-default" "WPE_BACKEND_LIBRARY" "${pkgs.libwpe-fdo}/lib/libWPEBackend-fdo-1.0.so"
@@ -167,7 +175,7 @@
                 echo "missing final pdump image: $final_pdump" >&2
                 exit 1
               fi
-              fingerprint="$(${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} $out/bin/neomacs --fingerprint | tr -d '[:space:]')"
+              fingerprint="$(${fingerprintRunner}$out/bin/neomacs --fingerprint | tr -d '[:space:]')"
               if ! [[ "$fingerprint" =~ ^[[:xdigit:]]{64}$ ]]; then
                 echo "invalid final pdump fingerprint: $fingerprint" >&2
                 exit 1

--- a/flake.nix
+++ b/flake.nix
@@ -167,7 +167,7 @@
                 echo "missing final pdump image: $final_pdump" >&2
                 exit 1
               fi
-              fingerprint="$($out/bin/neomacs --fingerprint | tr -d '[:space:]')"
+              fingerprint="$(${pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages} $out/bin/neomacs --fingerprint | tr -d '[:space:]')"
               if ! [[ "$fingerprint" =~ ^[[:xdigit:]]{64}$ ]]; then
                 echo "invalid final pdump fingerprint: $fingerprint" >&2
                 exit 1


### PR DESCRIPTION
## Summary

This PR now covers the Nix smoke/cross-build follow-up work around the pdump fingerprint and CI cache behavior:

- make pdump fingerprint extraction cross-build aware without breaking native builds
  - use `pkgs.stdenv.hostPlatform.emulator pkgs.buildPackages` when nixpkgs provides an emulator
  - run `$out/bin/neomacs --fingerprint` directly when the emulator is `null`
  - fixes the Gemini review concern that interpolating a `null` emulator breaks native evaluation
- tune the Nix smoke workflow
  - extend the job timeout to 240 minutes
  - keep the build step at 120 minutes
  - keep the startup smoke step bounded to 5 minutes
  - remove `enable_kvm: false` so `cachix/install-nix-action` keeps its default KVM behavior
- configure read-only binary caches for CI and flake users
  - add `eval-exec.cachix.org`, `nix-wpe-webkit.cachix.org`, and `cache.nixos.org` to the workflow `extra_nix_config`
  - add the `eval-exec` and `nix-wpe-webkit` public Cachix caches to `flake.nix` `nixConfig`
- improve cache stability for Rust dependency artifacts
  - give `craneLib.buildDepsOnly` separate `depsArgs` with a stable `version = "0.0.0"`
  - use `craneLib.mkDummySrc` with `craneLib.filters.cargoTomlAggressive` so the dependency-artifact derivation changes mainly when Cargo metadata/build inputs change
  - exclude `.github`, `flake.nix`, and `flake.lock` from the final packaged source so CI/Nix config-only edits do not unnecessarily perturb the final Neomacs package source hash

## Maintainer note: enabling writable Nix cache

This PR only configures **reading** from public binary caches. That is safe for fork PRs, but it can only substitute store paths that have already been published.

To make future runs faster, maintainers can optionally enable cache publishing from trusted workflows:

```yaml
- uses: cachix/cachix-action@v17
  with:
    name: eval-exec
    authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
```

Suggested setup:

1. Create or keep using the public `eval-exec` Cachix cache.
2. Add a repository secret named `CACHIX_AUTH_TOKEN` with permission to push to that cache.
3. Add `cachix/cachix-action@v17` after `cachix/install-nix-action@v31`.
4. Keep the existing `substituters`/`trusted-public-keys` config so PR jobs can read the cache.
5. Prefer publishing from trusted `push`/maintainer-branch workflows. GitHub does not expose repository secrets to untrusted fork PR code, and `pull_request_target` should only be used with extra care.

With the `buildDepsOnly` stabilization in this PR, the `neomacs-deps` layer should be more reusable across commits when `Cargo.lock` and dependency metadata do not change.

## Validation

- `git diff --check`
- workflow YAML parse check
- text assertions for the expected workflow/cache settings
- rough delimiter check for `flake.nix`

Local note: this machine does not currently have `nix`/`nix-instantiate`/`nixfmt` installed, so the actual Nix evaluation/build is left to CI.

Follow-up to https://github.com/eval-exec/neomacs/pull/136#discussion_r3471493507
