### PR TITLE
fix: guard JIT cache eviction in no-jit builds

### DIFF
--- a/neovm-core/src/emacs_core/symbol.rs
+++ b/neovm-core/src/emacs_core/symbol.rs
@@ -2064,13 +2064,15 @@ impl Obarray {
     }
 
     /// A specific function `id` was redefined (cell write / fmakunbound): bump the
-    /// epoch (the coarse "any binding may have changed" signal + JIT backstop) AND
-    /// precisely evict the JIT cache entries of callers that INLINED `id`, so an
-    /// unrelated redefinition no longer re-JITs every inlined function. Pure
-    /// optimization layered on the epoch backstop — see jit::cache::evict_inline_dependents.
-    fn note_function_redefined(&mut self, id: SymId) {
+    /// epoch (the coarse "any binding may have changed" signal + JIT backstop).
+    /// When JIT is enabled, also precisely evict the JIT cache entries of callers
+    /// that INLINED `id`, so an unrelated redefinition no longer re-JITs every
+    /// inlined function. Pure optimization layered on the epoch backstop — see
+    /// jit::cache::evict_inline_dependents.
+    fn note_function_redefined(&mut self, _id: SymId) {
         self.function_epoch = self.function_epoch.wrapping_add(1);
-        crate::emacs_core::jit::cache::evict_inline_dependents(id);
+        #[cfg(feature = "jit")]
+        crate::emacs_core::jit::cache::evict_inline_dependents(_id);
     }
 
     /// Set the function cell of a symbol by identity.


### PR DESCRIPTION
## Summary
- cfg-gate JIT cache eviction on the `jit` feature
- keep function epoch tracking active for interpreter-only builds
- rely on the existing `symbol_function_cell` test in both JIT and no-JIT configurations

## Testing
- `cargo fmt --check`
- `cargo check --no-default-features -p neomacs -p neovm-core`
- `cargo test -p neovm-core --no-default-features symbol_function_cell -- --exact`
- `cargo test -p neovm-core symbol_function_cell -- --exact`