### PR TITLE
[codex] upgrade Rust toolchain to 1.96.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.1"


### PR DESCRIPTION
## Summary

- Update `rust-toolchain.toml` from Rust 1.95.0 to Rust 1.96.1.

## Why

Rust 1.96.1 includes the 1.96 stable toolchain plus point-release fixes, including Cargo HTTP retry/timeout handling and a rustc MIR optimization fix. Keeping the repository on the latest stable point release gives CI and local builds those fixes without adopting nightly-only features.

## Impact

Developers and CI will use Rust 1.96.1 when entering the workspace. No source code or Cargo dependency changes are included.

## Validation

- `rustc --version --verbose` reports `rustc 1.96.1 (31fca3adb 2026-06-26)`.
- `TMPDIR=$PWD/tmp/tui-issues cargo check -p neovm-core --all-targets`.
- Pre-push hook completed its broader cargo check before the branch was pushed.