### PR TITLE
docs: update minimum Rust version to 1.95

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/eval-exec/neomacs/actions/workflows/ci.yml"><img src="https://github.com/eval-exec/neomacs/actions/workflows/ci.yml/badge.svg" alt="CI"/></a>
   <a href="#features"><img src="https://img.shields.io/badge/status-alpha-blueviolet?style=for-the-badge" alt="Status: Alpha"/></a>
-  <a href="#building"><img src="https://img.shields.io/badge/rust-1.93.1-orange?style=for-the-badge&logo=rust" alt="Rust 1.93.1"/></a>
+  <a href="#building"><img src="https://img.shields.io/badge/rust-1.95.0-orange?style=for-the-badge&logo=rust" alt="Rust 1.95.0"/></a>
   <a href="#license"><img src="https://img.shields.io/badge/license-GPL--3.0-blue?style=for-the-badge" alt="License: GPL-3.0"/></a>
 </p>
 
@@ -346,7 +346,7 @@ and why Elisp is slow, see [docs/elisp-core-analysis.md](docs/elisp-core-analysi
 
 ### Prerequisites
 
-- **Rust** (stable, 1.93+)
+- **Rust** (stable, 1.95+)
 - **GStreamer** (optional, for video playback)
 - **WPE WebKit** (optional, for inline browser, Linux only)
 - **VA-API** (optional, for hardware video decode on Linux)


### PR DESCRIPTION
## Summary

- update the README Rust badge from 1.93.1 to 1.95.0
- update the documented minimum stable Rust version from 1.93 to 1.95

## Why

`rust-toolchain.toml` pins Rust 1.95.0, and the current codebase uses APIs stabilized in Rust 1.95. The previous README requirement could lead users and packagers to attempt unsupported Rust 1.93 builds.

## Validation

- `git diff --check`
- verified the README version matches `rust-toolchain.toml`
