### PR TITLE
fix(load): honor EMACSLOADPATH at runtime

### DIFF
--- a/neovm-core/src/emacs_core/load.rs
+++ b/neovm-core/src/emacs_core/load.rs
@@ -4201,7 +4201,7 @@ fn finalize_cached_bootstrap_eval(
     let lisp_dir = project_root.join("lisp");
     eval.set_variable(
         "load-path",
-        Value::list(bootstrap_load_path_entries(&lisp_dir)),
+        Value::list(runtime_load_path_entries(&lisp_dir)),
     );
 
     let etc_dir = project_root.join("etc");
@@ -4301,6 +4301,44 @@ pub(crate) fn bootstrap_load_path_entries(lisp_dir: &Path) -> Vec<Value> {
         }
     }
     load_path_entries
+}
+
+/// Build the runtime `load-path` from `EMACSLOADPATH` and Neomacs' bundled
+/// Lisp directories.  As in GNU `init_lread` (`src/lread.c`), an empty path
+/// element stands for the entire default load path rather than the current
+/// directory.  If there is no empty element, keep the defaults at the end:
+/// unlike an installed GNU Emacs, Neomacs currently has no launcher wrapper
+/// that appends its versioned Lisp directory to `EMACSLOADPATH`.
+fn runtime_load_path_entries(lisp_dir: &Path) -> Vec<Value> {
+    runtime_load_path_entries_from_os(lisp_dir, std::env::var_os("EMACSLOADPATH"))
+}
+
+/// Testable core of [`runtime_load_path_entries`].
+pub(crate) fn runtime_load_path_entries_from_os(
+    lisp_dir: &Path,
+    emacs_load_path: Option<std::ffi::OsString>,
+) -> Vec<Value> {
+    let default_load_path = bootstrap_load_path_entries(lisp_dir);
+    let Some(emacs_load_path) = emacs_load_path else {
+        return default_load_path;
+    };
+
+    let mut load_path = Vec::new();
+    let mut included_defaults = false;
+    for dir in std::env::split_paths(&emacs_load_path) {
+        if dir.as_os_str().is_empty() {
+            load_path.extend(default_load_path.iter().cloned());
+            included_defaults = true;
+        } else {
+            load_path.push(Value::string(
+                crate::emacs_core::fileio::host_path_to_lisp_file_name_string(&dir),
+            ));
+        }
+    }
+    if !included_defaults {
+        load_path.extend(default_load_path);
+    }
+    load_path
 }
 
 fn lisp_directory_name_from_host_path(path: &Path) -> String {

--- a/neovm-core/src/emacs_core/load_test.rs
+++ b/neovm-core/src/emacs_core/load_test.rs
@@ -70,6 +70,74 @@ fn bootstrap_load_path_entries_use_gnu_windows_file_name_syntax() {
     assert!(first.ends_with("/lisp"));
 }
 
+fn load_path_entry_strings(entries: &[Value]) -> Vec<String> {
+    entries
+        .iter()
+        .map(|entry| {
+            entry
+                .as_lisp_string()
+                .map(|name| crate::emacs_core::emacs_char::to_utf8_lossy(name.as_bytes()))
+                .expect("load-path entry should be a string")
+        })
+        .collect()
+}
+
+#[test]
+fn runtime_load_path_uses_defaults_when_emacsloadpath_is_unset() {
+    let temp = tempdir().expect("tempdir");
+    let lisp_dir = temp.path().join("lisp");
+    std::fs::create_dir_all(&lisp_dir).expect("create lisp dir");
+
+    let entries = runtime_load_path_entries_from_os(&lisp_dir, None);
+    assert_eq!(
+        load_path_entry_strings(&entries),
+        vec![crate::emacs_core::fileio::host_path_to_lisp_file_name_string(&lisp_dir)]
+    );
+}
+
+#[test]
+fn runtime_load_path_splices_defaults_at_empty_emacsloadpath_elements() {
+    let temp = tempdir().expect("tempdir");
+    let lisp_dir = temp.path().join("lisp");
+    let before = temp.path().join("before");
+    let after = temp.path().join("after");
+    std::fs::create_dir_all(&lisp_dir).expect("create lisp dir");
+
+    let emacs_load_path =
+        std::env::join_paths([before.as_path(), std::path::Path::new(""), after.as_path()])
+            .expect("join EMACSLOADPATH");
+    let entries = runtime_load_path_entries_from_os(&lisp_dir, Some(emacs_load_path));
+
+    assert_eq!(
+        load_path_entry_strings(&entries),
+        vec![
+            crate::emacs_core::fileio::host_path_to_lisp_file_name_string(&before),
+            crate::emacs_core::fileio::host_path_to_lisp_file_name_string(&lisp_dir),
+            crate::emacs_core::fileio::host_path_to_lisp_file_name_string(&after),
+        ]
+    );
+}
+
+#[test]
+fn runtime_load_path_without_empty_element_appends_defaults() {
+    let temp = tempdir().expect("tempdir");
+    let lisp_dir = temp.path().join("lisp");
+    let custom = temp.path().join("custom");
+    std::fs::create_dir_all(&lisp_dir).expect("create lisp dir");
+
+    let entries = runtime_load_path_entries_from_os(
+        &lisp_dir,
+        Some(std::env::join_paths([custom.as_path()]).expect("join EMACSLOADPATH")),
+    );
+    assert_eq!(
+        load_path_entry_strings(&entries),
+        vec![
+            crate::emacs_core::fileio::host_path_to_lisp_file_name_string(&custom),
+            crate::emacs_core::fileio::host_path_to_lisp_file_name_string(&lisp_dir),
+        ]
+    );
+}
+
 #[test]
 fn stale_preloaded_face_doc_ref_restore_is_idempotent() {
     let mut eval = Context::new();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -734,7 +734,8 @@ fn run_aot_preload_dry_run_gate(
         )
         .into());
     }
-    let status = Command::new(&paths.temacs)
+    let mut command = Command::new(&paths.temacs);
+    command
         .current_dir(&options.repo_root)
         .args([
             OsStr::new("--batch"),
@@ -742,8 +743,9 @@ fn run_aot_preload_dry_run_gate(
             OsStr::new("loadup"),
             OsStr::new("--temacs=pdump"),
         ])
-        .envs(envs.iter().map(|(k, v)| (k, v)))
-        .status()?;
+        .envs(envs.iter().map(|(k, v)| (k, v)));
+    remove_build_time_emacs_env(&mut command);
+    let status = command.status()?;
     if !status.success() {
         return Err(format!(
             "aot-preload dry-run: --temacs=pdump exited with {}",
@@ -2630,6 +2632,7 @@ fn run_command(
     command.current_dir(cwd);
     command.args(args.iter().map(OsString::as_os_str));
     command.envs(envs.iter().map(|(key, value)| (key, value)));
+    remove_build_time_emacs_env(&mut command);
     if program.file_name() == Some(OsStr::new("cargo")) {
         remove_outer_cargo_env(&mut command);
     }
@@ -2651,6 +2654,17 @@ fn run_command(
         return Err(command_failure(program, args, status).into());
     }
     Ok(())
+}
+
+const BUILD_TIME_EMACS_ENV_VARS: [&str; 2] = ["EMACSLOADPATH", "EMACSNATIVELOADPATH"];
+
+/// Keep xtask's bootstrap, generation, compilation, and dump subprocesses
+/// isolated from the invoking user's installed Emacs packages.  GNU Emacs's
+/// build makefiles likewise unexport these variables before invoking Emacs.
+fn remove_build_time_emacs_env(command: &mut Command) {
+    for key in BUILD_TIME_EMACS_ENV_VARS {
+        command.env_remove(key);
+    }
 }
 
 fn remove_outer_cargo_env(command: &mut Command) {

--- a/xtask/src/main_test.rs
+++ b/xtask/src/main_test.rs
@@ -1285,6 +1285,29 @@ fn outer_cargo_env_filter_strips_package_build_vars_only() {
 }
 
 #[test]
+fn build_time_emacs_env_filter_covers_lisp_and_native_load_paths() {
+    assert_eq!(
+        BUILD_TIME_EMACS_ENV_VARS,
+        ["EMACSLOADPATH", "EMACSNATIVELOADPATH"]
+    );
+
+    let mut command = Command::new("neomacs");
+    for key in BUILD_TIME_EMACS_ENV_VARS {
+        command.env(key, "/user/profile");
+    }
+    remove_build_time_emacs_env(&mut command);
+
+    for key in BUILD_TIME_EMACS_ENV_VARS {
+        assert!(
+            command
+                .get_envs()
+                .any(|(candidate, value)| candidate == key && value.is_none()),
+            "{key} should be explicitly removed from build subprocesses"
+        );
+    }
+}
+
+#[test]
 fn unidata_generated_lisp_file_names_match_gnu_makefile_shape() {
     let contents = r#"
 (defconst unidata-file-alist


### PR DESCRIPTION
## Summary

- fix Neomacs startup with an existing Doom Emacs configuration on Guix
- initialize runtime `load-path` from `EMACSLOADPATH`
- splice Neomacs' bundled Lisp directories at empty path elements, following GNU Emacs semantics
- keep bundled defaults available when no empty element is present, since Neomacs has no installed launcher wrapper yet
- isolate xtask bootstrap, compilation, and dump subprocesses from user `EMACSLOADPATH` and `EMACSNATIVELOADPATH`
- add focused runtime and command-environment tests

## User-visible impact

Before this change, Neomacs discarded the Guix profile paths used by Doom Emacs during startup. Loading an existing Doom configuration then failed when its packaged dependencies could not be found.

With the runtime load path restored, the same Doom configuration starts successfully and Guix-provided packages such as `auto-minor-mode`, `doom-themes`, and `consult` remain discoverable.

This is not a Guix-specific runtime defect: the unfixed revision also discards `EMACSLOADPATH` in a local non-Guix build. Guix exposes the defect because its Emacs packages rely on `EMACSLOADPATH` to make profile dependencies available.

## Root cause

After loading the pdump image, `finalize_cached_bootstrap_eval` replaced `load-path` with only Neomacs' bundled Lisp directories. Package-manager paths exported through `EMACSLOADPATH` were therefore discarded at normal startup.

Once runtime support is restored, build subprocesses must not inherit a developer's installed packages. GNU Emacs' build makefiles similarly unexport these load-path variables.

This is complementary to #43: a Nix setup hook populates `EMACSLOADPATH`, while this change makes the Rust runtime consume it.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p neovm-core runtime_load_path_ --lib` (3 passed)
- `cargo test -p xtask build_time_emacs_env_filter_covers_lisp_and_native_load_paths` (1 passed)
- `git diff --check`
- Local non-Guix A/B: release build and final pdump completed for both the unfixed parent and this change, without invoking Guix
- Local non-Guix A/B: parent `a604c3a193fa` preserved the environment variable but omitted the probe directory from `load-path` (`PROBE=MISSING`)
- Local non-Guix A/B: fixed revision `2328e227eb78` included the same probe directory in `load-path` (`PROBE=PRESENT`)
- Local non-Guix: with `EMACSLOADPATH` unset, the fixed revision retained the bundled default path (`DEFAULT=PRESENT`)
- Guix remote: full release build and pdump pipeline completed successfully
- Guix remote: the existing Doom Emacs configuration completed startup successfully
- Guix remote: profile packages including `auto-minor-mode`, `doom-themes`, and `consult-recent-file` were discoverable at startup
- Guix remote: startup with `EMACSLOADPATH` unset retained the bundled default path

Related to #43, #118, and #122.
