### PR TITLE
fix(linux): add RUNPATHs for dlopen GUI libraries

### DIFF
--- a/neomacs-bin/build.rs
+++ b/neomacs-bin/build.rs
@@ -28,6 +28,33 @@ fn export_jit_shims_for_aot(target_os: &str) {
     }
 }
 
+/// Add RUNPATH entries for Linux libraries that the windowing/rendering stack
+/// opens with `dlopen` rather than linking into the executable.  Guix and Nix
+/// keep these libraries outside the system loader's default search path, so a
+/// successful build is otherwise liable to fail only when the GUI starts.
+fn emit_linux_runtime_dlopen_rpaths(target_os: &str) {
+    if target_os != "linux" {
+        return;
+    }
+
+    let mut emitted_paths = Vec::new();
+    for name in ["wayland-client", "xkbcommon", "vulkan", "egl"] {
+        let Ok(library) = pkg_config::Config::new().cargo_metadata(false).probe(name) else {
+            continue;
+        };
+        for path in library.link_paths {
+            if emitted_paths.contains(&path) {
+                continue;
+            }
+            println!(
+                "cargo:rustc-link-arg-bin=neomacs=-Wl,-rpath,{}",
+                path.display()
+            );
+            emitted_paths.push(path);
+        }
+    }
+}
+
 fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     println!("cargo:rerun-if-changed=../neovm-core/src/emacs_core/jit/shim_names.rs");
@@ -41,6 +68,8 @@ fn main() {
         }
         return;
     }
+
+    emit_linux_runtime_dlopen_rpaths(&target_os);
 
     let candidates: &[&str] = match target_os.as_str() {
         "linux" => &["ncursesw", "ncurses"],


### PR DESCRIPTION
## Summary

- probe the Linux GUI libraries loaded dynamically by winit/wgpu with `pkg-config`
- add their non-default library directories to the `neomacs` binary's RUNPATH
- avoid forcing direct linkage, and deduplicate paths shared by multiple packages
- leave non-Linux builds unchanged

## Root cause

Wayland, xkbcommon, Vulkan, and EGL are opened with `dlopen` rather than represented as direct ELF `NEEDED` dependencies. In store-based distributions such as Guix and Nix, their library directories are not part of the system loader's default search path. A direct Cargo build could therefore succeed but fail during GUI initialization unless `LD_LIBRARY_PATH` was set.

The observed failure progressed from a missing Wayland library, to missing xkbcommon, to wgpu surface initialization without the Vulkan/EGL loader paths. Supplying all four paths made the same artifact self-contained.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p neomacs --bin neomacs`
- `git diff --check`
- Guix remote: release/LTO build and matching pdump generation completed successfully
- Guix remote: `readelf -d` showed the Wayland, xkbcommon, Vulkan, and Mesa/EGL store directories in RUNPATH
- Guix remote: both quick and ordinary Wayland startup exited successfully with `LD_LIBRARY_PATH` unset
- Guix remote: winit created the event loop and wgpu initialized an Intel Iris Xe Vulkan adapter and surface

Related to #122.
