### PR TITLE
Fix Edebug and native font downloads

### DIFF
--- a/neovm-core/src/emacs_core/eval.rs
+++ b/neovm-core/src/emacs_core/eval.rs
@@ -16162,6 +16162,13 @@ impl Context {
         self.command_loop.recursive_depth.saturating_sub(1)
     }
 
+    /// Lisp-visible recursive-edit depth, matching GNU's
+    /// `command_loop_level + minibuf_level`.
+    pub(crate) fn recursion_depth(&self) -> usize {
+        self.recursive_command_loop_depth()
+            .saturating_add(self.minibuffers.depth())
+    }
+
     pub(crate) fn interactive_minibuffer_read_count(&self) -> u64 {
         self.interactive_minibuffer_read_count
     }

--- a/neovm-core/src/emacs_core/lread.rs
+++ b/neovm-core/src/emacs_core/lread.rs
@@ -286,59 +286,55 @@ pub(crate) fn eval_region_source_text_in_state(
     buffers: &crate::buffer::BufferManager,
     args: &[Value],
 ) -> Result<crate::heap_types::LispString, Flow> {
+    let (raw_start, raw_end) = eval_region_bounds_in_state(buffers, args)?;
+    let buffer = buffers
+        .current_buffer()
+        .ok_or_else(|| signal("error", vec![Value::string("No current buffer")]))?;
+
+    if raw_start >= raw_end {
+        return Ok(crate::heap_types::LispString::new(
+            String::new(),
+            buffer.get_multibyte(),
+        ));
+    }
+
+    let byte_range = EmacsByteRange::new(
+        buffer.lisp_pos_to_accessible_emacs_byte_pos(LispCharPos1::new(raw_start)),
+        buffer.lisp_pos_to_accessible_emacs_byte_pos(LispCharPos1::new(raw_end)),
+    );
+    Ok(buffer.buffer_substring_lisp_string_range(byte_range))
+}
+
+fn eval_region_bounds_in_state(
+    buffers: &crate::buffer::BufferManager,
+    args: &[Value],
+) -> Result<(i64, i64), Flow> {
     expect_min_args("eval-region", args, 2)?;
     expect_max_args("eval-region", args, 4)?;
 
-    let (source, start_char_pos, end_char_pos) = {
-        let buffer = buffers
-            .current_buffer()
-            .ok_or_else(|| signal("error", vec![Value::string("No current buffer")]))?;
-
-        let point_char_pos = buffer.point_lisp_char_pos().as_i64();
-        let max_char_pos = buffer.point_max_lisp_char_pos().as_i64();
-
-        let raw_start = if args[0].is_nil() {
-            point_char_pos
-        } else {
-            expect_integer_or_marker_in_buffers(buffers, &args[0])?
-        };
-        let raw_end = if args[1].is_nil() {
-            point_char_pos
-        } else {
-            expect_integer_or_marker_in_buffers(buffers, &args[1])?
-        };
-
-        if raw_start < 1 || raw_start > max_char_pos || raw_end < 1 || raw_end > max_char_pos {
-            return Err(signal(
-                LispCondition::ArgsOutOfRange,
-                vec![args[0], args[1]],
-            ));
-        }
-
-        if raw_start >= raw_end {
-            return Ok(crate::heap_types::LispString::new(
-                String::new(),
-                buffer.get_multibyte(),
-            ));
-        }
-
-        let start = LispCharPos1::new(raw_start);
-        let end = LispCharPos1::new(raw_end);
-        let byte_range = EmacsByteRange::new(
-            buffer.lisp_pos_to_accessible_emacs_byte_pos(start),
-            buffer.lisp_pos_to_accessible_emacs_byte_pos(end),
-        );
-        let text = buffer.buffer_substring_lisp_string_range(byte_range);
-        (text, raw_start, raw_end)
+    let buffer = buffers
+        .current_buffer()
+        .ok_or_else(|| signal("error", vec![Value::string("No current buffer")]))?;
+    let point_char_pos = buffer.point_lisp_char_pos().as_i64();
+    let max_char_pos = buffer.point_max_lisp_char_pos().as_i64();
+    let raw_start = if args[0].is_nil() {
+        point_char_pos
+    } else {
+        expect_integer_or_marker_in_buffers(buffers, &args[0])?
+    };
+    let raw_end = if args[1].is_nil() {
+        point_char_pos
+    } else {
+        expect_integer_or_marker_in_buffers(buffers, &args[1])?
     };
 
-    if start_char_pos >= end_char_pos {
-        return Ok(crate::heap_types::LispString::new(
-            String::new(),
-            source.is_multibyte(),
+    if raw_start < 1 || raw_start > max_char_pos || raw_end < 1 || raw_end > max_char_pos {
+        return Err(signal(
+            LispCondition::ArgsOutOfRange,
+            vec![args[0], args[1]],
         ));
     }
-    Ok(source)
+    Ok((raw_start, raw_end))
 }
 
 /// `(eval-buffer &optional BUFFER PRINTFLAG FILENAME UNIBYTE DO-ALLOW-PRINT)`
@@ -454,11 +450,115 @@ pub(crate) fn builtin_eval_buffer(eval: &mut super::eval::Context, args: Vec<Val
 ///
 /// Evaluate forms in the [START, END) region of the current buffer.
 pub(crate) fn builtin_eval_region(eval: &mut super::eval::Context, args: Vec<Value>) -> EvalResult {
+    if let Some(read_function) = args.get(3).copied().filter(|value| !value.is_nil()) {
+        let (start, end) = eval_region_bounds_in_state(&eval.buffers, &args)?;
+        if start >= end {
+            return Ok(Value::NIL);
+        }
+        return eval_region_with_read_function(eval, start, end, read_function);
+    }
+
     let source = eval_region_source_text_in_state(&eval.buffers, &args)?;
     if source.as_bytes().is_empty() {
         return Ok(Value::NIL);
     }
     eval_forms_from_lisp_source(eval, &source)
+}
+
+fn eval_region_with_read_function(
+    eval: &mut super::eval::Context,
+    start: i64,
+    end: i64,
+    read_function: Value,
+) -> EvalResult {
+    let buffer_id = {
+        let buffer = eval
+            .buffers
+            .current_buffer()
+            .ok_or_else(|| signal("error", vec![Value::string("No current buffer")]))?;
+        buffer.id
+    };
+    let buffer_value = Value::make_buffer(buffer_id);
+
+    let gc_roots = eval.save_specpdl_roots();
+    eval.push_specpdl_root(read_function);
+    eval.push_specpdl_root(buffer_value);
+    let result = (|| {
+        let mut next_start = start;
+        loop {
+            if next_start >= end {
+                return Ok(Value::NIL);
+            }
+
+            // GNU `readevalloop` saves the caller's excursion, switches to the
+            // source buffer, saves that buffer's point/restriction, and only
+            // then invokes READ-FUNCTION.  Crucially it captures the reader's
+            // advanced point *before* evaluating the returned form: Edebug's
+            // transformed form is allowed to move point without changing
+            // where the next read begins.
+            let iteration_specpdl = eval.specpdl.len();
+            eval.record_save_excursion();
+            let read_result = (|| -> Result<(Value, i64, bool), Flow> {
+                eval.set_current_buffer_unrecorded(buffer_id)?;
+                eval.record_save_excursion();
+                if let Some(state) = eval.buffers.save_current_restriction_state() {
+                    eval.specpdl
+                        .push(super::eval::SpecBinding::SaveRestriction { state });
+                }
+
+                let (accessible_start, start_byte, end_byte) = {
+                    let buffer = eval.buffers.get(buffer_id).ok_or_else(|| {
+                        signal("error", vec![Value::string("Reading from killed buffer")])
+                    })?;
+                    (
+                        buffer.accessible_emacs_byte_region().start(),
+                        buffer.lisp_pos_to_accessible_emacs_byte_pos(LispCharPos1::new(next_start)),
+                        buffer.lisp_pos_to_accessible_emacs_byte_pos(LispCharPos1::new(end)),
+                    )
+                };
+                let buffer = eval.buffers.get_mut(buffer_id).ok_or_else(|| {
+                    signal("error", vec![Value::string("Reading from killed buffer")])
+                })?;
+                buffer.narrow_to_emacs_byte_range(EmacsByteRange::new(accessible_start, end_byte));
+                buffer.goto_emacs_byte_pos(start_byte);
+
+                let form = eval.funcall_general(read_function, vec![buffer_value])?;
+                let after_read = eval
+                    .buffers
+                    .get(buffer_id)
+                    .ok_or_else(|| {
+                        signal("error", vec![Value::string("Reading from killed buffer")])
+                    })?
+                    .point_lisp_char_pos()
+                    .as_i64();
+                Ok((form, after_read, after_read >= end))
+            })();
+            eval.unbind_to(iteration_specpdl);
+
+            let (form, after_read, reached_end) = read_result?;
+            if after_read <= next_start {
+                return Err(signal(
+                    "error",
+                    vec![Value::string(
+                        "eval-region read function did not advance the input stream",
+                    )],
+                ));
+            }
+            next_start = after_read;
+
+            let form_roots = eval.save_specpdl_roots();
+            eval.push_specpdl_root(form);
+            let eval_result = eval.eval_value(&form);
+            eval.restore_specpdl_roots(form_roots);
+            eval_result?;
+            if reached_end {
+                return Ok(Value::NIL);
+            }
+        }
+    })();
+
+    eval.restore_specpdl_roots(gc_roots);
+    result
 }
 
 fn event_to_int(event: &Value) -> Option<i64> {

--- a/neovm-core/src/emacs_core/lread_test.rs
+++ b/neovm-core/src/emacs_core/lread_test.rs
@@ -306,6 +306,137 @@ fn eval_region_evaluates_forms_in_range() {
 }
 
 #[test]
+fn eval_region_uses_read_function_result_instead_of_source_text() {
+    crate::test_utils::init_test_tracing();
+    let mut ev = Context::new();
+    ev.eval_str(
+        r#"(fset 'lread-er-read-function
+                 (lambda (stream)
+                   (setq lread-er-read-function-got-buffer (bufferp stream))
+                   (goto-char (point-max))
+                   '(setq lread-er-read-function-result 'transformed)))"#,
+    )
+    .expect("define eval-region read function");
+    {
+        let buf = ev.buffers.current_buffer_mut().expect("current buffer");
+        buf.insert("(setq lread-er-read-function-result 'source)");
+        buf.goto_emacs_byte_pos(crate::buffer::EmacsBytePos::new(0));
+    }
+    let end = {
+        let buf = ev.buffers.current_buffer().expect("current buffer");
+        Value::fixnum(buf.z_lisp_char_pos().as_i64())
+    };
+
+    let result = builtin_eval_region(
+        &mut ev,
+        vec![
+            Value::fixnum(1),
+            end,
+            Value::NIL,
+            Value::symbol("lread-er-read-function"),
+        ],
+    )
+    .expect("eval-region with read function");
+
+    assert!(result.is_nil());
+    assert_eq!(
+        ev.obarray
+            .symbol_value("lread-er-read-function-result")
+            .copied(),
+        Some(Value::symbol("transformed"))
+    );
+    assert_eq!(
+        ev.obarray
+            .symbol_value("lread-er-read-function-got-buffer")
+            .copied(),
+        Some(Value::T)
+    );
+    assert_eq!(
+        ev.buffers
+            .current_buffer()
+            .expect("current buffer")
+            .point_lisp_char_pos()
+            .as_i64(),
+        1,
+        "eval-region preserves point"
+    );
+}
+
+#[test]
+fn eval_region_advances_from_reader_point_before_evaluating_returned_form() {
+    crate::test_utils::init_test_tracing();
+    let mut ev = Context::new();
+    ev.eval_str(
+        r#"(progn
+             (setq lread-er-point-reader-count 0)
+             (fset 'lread-er-point-reader
+                   (lambda (stream)
+                     (setq lread-er-point-reader-count
+                           (1+ lread-er-point-reader-count))
+                     (let ((form (read stream)))
+                       (list 'progn
+                             '(goto-char (point-min))
+                             form)))))"#,
+    )
+    .expect("define point-moving eval-region reader");
+    {
+        let buf = ev.buffers.current_buffer_mut().expect("current buffer");
+        buf.insert("(setq lread-er-point-a 1)\n(setq lread-er-point-b 2)");
+        buf.goto_emacs_byte_pos(crate::buffer::EmacsBytePos::new(0));
+    }
+    let end = {
+        let buf = ev.buffers.current_buffer().expect("current buffer");
+        Value::fixnum(buf.z_lisp_char_pos().as_i64())
+    };
+
+    let eval_result = builtin_eval_region(
+        &mut ev,
+        vec![
+            Value::fixnum(1),
+            end,
+            Value::NIL,
+            Value::symbol("lread-er-point-reader"),
+        ],
+    );
+    if let Err(flow) = eval_result {
+        match flow {
+            Flow::Signal(signal) => panic!(
+                "eval-region must keep the reader's stream point across evaluation: {} {:?}",
+                signal.symbol_name(),
+                signal.data
+            ),
+            other => panic!(
+                "eval-region must keep the reader's stream point across evaluation: {other:?}"
+            ),
+        }
+    }
+
+    assert_eq!(
+        ev.obarray.symbol_value("lread-er-point-a").copied(),
+        Some(Value::fixnum(1))
+    );
+    assert_eq!(
+        ev.obarray.symbol_value("lread-er-point-b").copied(),
+        Some(Value::fixnum(2))
+    );
+    assert_eq!(
+        ev.obarray
+            .symbol_value("lread-er-point-reader-count")
+            .copied(),
+        Some(Value::fixnum(2))
+    );
+    assert_eq!(
+        ev.buffers
+            .current_buffer()
+            .expect("current buffer")
+            .point_lisp_char_pos()
+            .as_i64(),
+        1,
+        "eval-region preserves point even when returned forms move it"
+    );
+}
+
+#[test]
 fn eval_region_preserves_unibyte_string_literals() {
     crate::test_utils::init_test_tracing();
     let mut ev = Context::new();

--- a/neovm-core/src/emacs_core/misc.rs
+++ b/neovm-core/src/emacs_core/misc.rs
@@ -918,15 +918,13 @@ pub(crate) fn builtin_mapbacktrace(
     Ok(Value::NIL)
 }
 
-/// `(recursion-depth)` -- return the current Lisp recursion depth.
-/// Uses the dynamic binding stack depth as a proxy (the true depth counter
-/// is private to the Context).
+/// `(recursion-depth)` -- return the current depth in recursive edits.
 pub(crate) fn builtin_recursion_depth(
-    _eval: &mut super::eval::Context,
+    eval: &mut super::eval::Context,
     args: Vec<Value>,
 ) -> EvalResult {
     expect_args("recursion-depth", &args, 0)?;
-    Ok(Value::fixnum(0))
+    Ok(Value::fixnum(eval.recursion_depth() as i64))
 }
 
 // ===========================================================================

--- a/neovm-core/src/emacs_core/misc_test.rs
+++ b/neovm-core/src/emacs_core/misc_test.rs
@@ -613,6 +613,33 @@ fn recursion_depth_zero() {
     assert!(eq_value(&result, &Value::fixnum(0)));
 }
 
+#[test]
+fn recursion_depth_counts_recursive_command_loops_like_gnu() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = super::super::eval::Context::new();
+    // Neomacs stores one raw command-loop level for GNU's visible top level.
+    // A second active level is therefore one recursive edit.
+    eval.command_loop.recursive_depth = 2;
+
+    let result = builtin_recursion_depth(&mut eval, vec![]).unwrap();
+
+    assert_eq!(result, Value::fixnum(1));
+}
+
+#[test]
+fn recursion_depth_includes_active_minibuffers_like_gnu() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = super::super::eval::Context::new();
+    eval.command_loop.recursive_depth = 2;
+    eval.minibuffers
+        .read_from_minibuffer(crate::buffer::BufferId(1), "Prompt: ", None, None)
+        .unwrap();
+
+    let result = builtin_recursion_depth(&mut eval, vec![]).unwrap();
+
+    assert_eq!(result, Value::fixnum(2));
+}
+
 // Regression tests for `backtrace-frame--internal` — the real
 // introspection primitive that walks the specpdl. GNU's
 // `backtrace_frame_apply` (eval.c:3984) reads each SPECPDL_BACKTRACE

--- a/neovm-core/src/emacs_core/process.rs
+++ b/neovm-core/src/emacs_core/process.rs
@@ -1914,31 +1914,44 @@ fn process_status_code_message(code: Value) -> String {
         .unwrap_or_else(|| "0".to_string())
 }
 
+/// The ambient inputs GNU's `set_network_socket_coding_system` consults when
+/// `make-network-process :coding` is nil.  Keeping them together prevents a
+/// connection path (TCP, local, datagram, deferred DNS/TLS) from silently
+/// omitting one level of the coding-system precedence chain.
+#[derive(Clone, Copy)]
+struct NetworkProcessCodingDefaults {
+    coding_system_for_read: Value,
+    coding_system_for_write: Value,
+    operation_coding_system: Value,
+    default_process_coding_system: Value,
+    current_buffer_multibyte: bool,
+}
+
 /// Resolve the (decode . encode) coding pair for a network process, mirroring
 /// GNU `set_network_socket_coding_system` (src/process.c:3291-3367).
 ///
 /// * An explicit `:coding` value supplies both directions (its car/cdr if a
 ///   cons, else the whole symbol for both).
-/// * When `:coding` is nil GNU does NOT fall back to `binary`.  Instead it
-///   consults `coding-system-for-read/write` and, failing those, the buffer's
-///   multibyteness:
+/// * When `:coding` is nil GNU does NOT immediately fall back to the process
+///   default.  It first consults `coding-system-for-read/write`, then the
+///   process/current buffer's multibyteness, then the operation coding pair,
+///   and finally `default-process-coding-system`.
+///
+/// In particular, `url-open-stream` dynamically binds
+/// `coding-system-for-read` to `binary`; losing that binding decodes font bytes
+/// as UTF-8 and makes the URL buffer shorter than its HTTP Content-Length.
+///
+/// The buffer-dependent fallbacks are:
 ///     - DECODE: if the process buffer (or, when absent, the default buffer)
 ///       is UNIBYTE, decode is left nil/raw so libraries receive bare CR LF;
-///       otherwise decode comes from `find-operation-coding-system`, which for
-///       a plain local socket has no alist entry and falls through to the car
+///       otherwise decode comes from `find-operation-coding-system` or the car
 ///       of `default-process-coding-system` (`utf-8-unix`).
-///     - ENCODE: comes from the cdr of `default-process-coding-system`.
-///
-/// `default_coding` is the runtime value of `default-process-coding-system`
-/// (a cons `(decode . encode)`, normally `(utf-8-unix . utf-8-unix)`); a nil
-/// or malformed value falls back to `binary`.  `buffer_multibyte` is the
-/// multibyteness of the process buffer (true when there is no buffer, since
-/// the default buffer is multibyte), matching GNU's `p->buffer` /
-/// `buffer_defaults` test.
+///     - ENCODE: a unibyte current buffer stays raw; otherwise use the operation
+///       coding or the default process coding's cdr.
 fn network_process_coding_pair(
     coding: Value,
-    default_coding: Value,
-    buffer_multibyte: bool,
+    defaults: NetworkProcessCodingDefaults,
+    process_buffer_multibyte: bool,
 ) -> (Value, Value) {
     if coding.is_cons() {
         return (coding.cons_car(), coding.cons_cdr());
@@ -1946,37 +1959,81 @@ fn network_process_coding_pair(
     if !coding.is_nil() {
         return (coding, coding);
     }
-    // `:coding` unspecified: derive from `default-process-coding-system`.
-    // GNU `set_network_socket_coding_system` (process.c:3331-3336, 3361-3366)
-    // uses the car/cdr of `Vdefault_process_coding_system` when it is a cons,
-    // and otherwise falls back to `Qnil` (NOT `binary`) — so an unset default
-    // yields a nil decode/encode, matching `(process-coding-system)` of `(nil)`.
-    let (default_decode, default_encode) = if default_coding.is_cons() {
-        (default_coding.cons_car(), default_coding.cons_cdr())
+    let (default_decode, default_encode) = if defaults.default_process_coding_system.is_cons() {
+        (
+            defaults.default_process_coding_system.cons_car(),
+            defaults.default_process_coding_system.cons_cdr(),
+        )
     } else {
         (Value::NIL, Value::NIL)
     };
-    // GNU leaves the decode side as nil (raw) for a unibyte buffer so the
-    // process receives bare bytes; a multibyte (or absent) buffer decodes via
-    // the default process coding system.
-    let decode = if buffer_multibyte {
-        default_decode
-    } else {
+
+    let decode = if !defaults.coding_system_for_read.is_nil() {
+        defaults.coding_system_for_read
+    } else if !process_buffer_multibyte {
         Value::NIL
+    } else if defaults.operation_coding_system.is_cons() {
+        defaults.operation_coding_system.cons_car()
+    } else {
+        default_decode
     };
-    (decode, default_encode)
+    let encode = if !defaults.coding_system_for_write.is_nil() {
+        defaults.coding_system_for_write
+    } else if !defaults.current_buffer_multibyte {
+        Value::NIL
+    } else if defaults.operation_coding_system.is_cons() {
+        defaults.operation_coding_system.cons_cdr()
+    } else {
+        default_encode
+    };
+    (decode, encode)
 }
 
 fn set_network_process_coding(
     proc: &mut Process,
     coding: Value,
-    default_coding: Value,
-    buffer_multibyte: bool,
+    defaults: NetworkProcessCodingDefaults,
+    process_buffer_multibyte: bool,
 ) {
-    let (decode, encode) = network_process_coding_pair(coding, default_coding, buffer_multibyte);
+    let (decode, encode) = network_process_coding_pair(coding, defaults, process_buffer_multibyte);
     proc.coding_decode = decode;
     proc.decoding_carryover.clear();
     proc.coding_encode = encode;
+}
+
+fn find_network_operation_coding_system(
+    eval: &mut super::eval::Context,
+    name: &LispString,
+    buffer: Value,
+    host: Value,
+    service: Value,
+) -> EvalResult {
+    if host.is_nil()
+        || service.is_nil()
+        || eval
+            .visible_variable_value_or_nil("network-coding-system-alist")
+            .is_nil()
+    {
+        return Ok(Value::NIL);
+    }
+
+    // GNU calls `(find-operation-coding-system 'open-network-stream NAME
+    // BUFFER HOST SERVICE)`.  Root every heap value because a user-supplied
+    // network-coding callback can run arbitrary Lisp and trigger GC.
+    let args = vec![
+        Value::symbol("open-network-stream"),
+        Value::heap_string(name.clone()),
+        buffer,
+        host,
+        service,
+    ];
+    let roots = eval.save_specpdl_roots();
+    for value in &args {
+        eval.push_specpdl_root(*value);
+    }
+    let result = super::builtins::builtin_find_operation_coding_system(eval, args);
+    eval.restore_specpdl_roots(roots);
+    result
 }
 
 fn explicit_process_coding_pair(coding: Value) -> (Value, Value) {
@@ -5078,6 +5135,23 @@ impl ProcessManager {
         if let Some(proc) = self.processes.get_mut(&id) {
             proc.pending_network_connect = None;
             proc.status = process_status_run_value();
+        }
+        let tls_parameters = self
+            .processes
+            .get(&id)
+            .map(|proc| proc.gnutls_boot_parameters)
+            .filter(|parameters| !parameters.is_nil())
+            .map(parse_make_network_tls_parameters)
+            .transpose()?
+            .flatten();
+        if let Some(parameters) = tls_parameters {
+            upgrade_process_to_tls::<RustlsBackend>(
+                self,
+                id,
+                &parameters.hostname,
+                "make-network-process",
+                signal_gnutls_boot_error,
+            )?;
         }
         self.register_socket_fd(id).ok();
         Ok(PendingNetworkConnectCompletion::Connected { sentinel })
@@ -8509,7 +8583,7 @@ pub(crate) fn builtin_gnutls_boot(eval: &mut super::eval::Context, args: Vec<Val
     let id = resolve_process_object_or_wrong_type_any_in_manager(&eval.processes, &args[0])?;
     let parameters = parse_gnutls_boot_parameters(args[1], args[2])?;
     upgrade_process_to_tls::<RustlsBackend>(
-        eval,
+        &mut eval.processes,
         id,
         &parameters.hostname,
         "gnutls-boot",
@@ -8628,7 +8702,7 @@ pub(crate) fn builtin_neomacs_open_tls_stream(
     )?;
     let id = resolve_process_or_wrong_type_any_in_manager(&eval.processes, &process)?;
     upgrade_process_to_tls::<RustlsBackend>(
-        eval,
+        &mut eval.processes,
         id,
         &host,
         "neomacs-open-tls-stream",
@@ -8638,14 +8712,13 @@ pub(crate) fn builtin_neomacs_open_tls_stream(
 }
 
 fn upgrade_process_to_tls<B: TlsClientBackend>(
-    eval: &mut super::eval::Context,
+    processes: &mut ProcessManager,
     id: ProcessId,
     host: &str,
     operation: &str,
     map_error: fn(TlsBackendError) -> Flow,
 ) -> Result<(), Flow> {
-    let proc = eval
-        .processes
+    let proc = processes
         .get_mut(id)
         .ok_or_else(|| signal("error", vec![Value::string("Process not found")]))?;
 
@@ -9200,7 +9273,8 @@ fn connect_network_process_at_explicit_address(
     socket_type: NetworkSocketType,
     socket_options: Vec<NetworkSocketOptionSpec>,
     tls_parameters: Option<super::tls::GnutlsBootParameters>,
-    default_process_coding: Value,
+    tls_parameters_value: Value,
+    default_process_coding: NetworkProcessCodingDefaults,
     network_buffer_multibyte: bool,
 ) -> EvalResult {
     let address = parse_network_address_spec(&explicit_address)?;
@@ -9517,6 +9591,9 @@ fn connect_network_process_at_explicit_address(
                             proc.status = process_status_failed_value(code);
                         }
                     }
+                    if proc.pending_network_connect.is_some() {
+                        proc.gnutls_boot_parameters = tls_parameters_value;
+                    }
                     apply_connection_process_flags(proc, noquery, stop);
                 }
                 if eval
@@ -9594,7 +9671,7 @@ fn connect_network_process_at_explicit_address(
             }
             if let Some(parameters) = tls_parameters.clone() {
                 upgrade_process_to_tls::<RustlsBackend>(
-                    eval,
+                    &mut eval.processes,
                     id,
                     &parameters.hostname,
                     "make-network-process",
@@ -10105,7 +10182,7 @@ fn connect_datagram_network_process(
     stop: bool,
     socket_type: NetworkSocketType,
     socket_options: Vec<NetworkSocketOptionSpec>,
-    default_process_coding: Value,
+    default_process_coding: NetworkProcessCodingDefaults,
     network_buffer_multibyte: bool,
 ) -> EvalResult {
     let port = parse_network_service_port(&service, server, socket_type)?;
@@ -10271,7 +10348,7 @@ fn listen_stream_network_process(
     server_backlog: Option<i32>,
     socket_type: NetworkSocketType,
     socket_options: Vec<NetworkSocketOptionSpec>,
-    default_process_coding: Value,
+    default_process_coding: NetworkProcessCodingDefaults,
     network_buffer_multibyte: bool,
 ) -> EvalResult {
     let port = parse_network_service_port(&service, true, socket_type)?;
@@ -10375,7 +10452,7 @@ fn connect_local_socket_process(
     socket_type: NetworkSocketType,
     socket_options: Vec<NetworkSocketOptionSpec>,
     tls_parameters: Option<super::tls::GnutlsBootParameters>,
-    default_process_coding: Value,
+    default_process_coding: NetworkProcessCodingDefaults,
     network_buffer_multibyte: bool,
     remote_address_value: Value,
 ) -> EvalResult {
@@ -10754,7 +10831,7 @@ fn connect_local_socket_process(
             }
             if let Some(parameters) = tls_parameters.clone() {
                 upgrade_process_to_tls::<RustlsBackend>(
-                    eval,
+                    &mut eval.processes,
                     id,
                     &parameters.hostname,
                     "make-network-process",
@@ -10993,13 +11070,22 @@ pub(crate) fn builtin_make_network_process(
         Value::NIL
     };
 
-    // Default coding resolution for `:coding nil`, mirroring GNU
-    // `set_network_socket_coding_system` (src/process.c:3291-3367): the decode
-    // side depends on the process buffer's multibyteness (raw for a unibyte
-    // buffer, `default-process-coding-system` otherwise) and a missing buffer
-    // uses the default buffer's multibyteness (multibyte by default).
-    let default_process_coding =
-        eval.visible_variable_value_or_nil("default-process-coding-system");
+    // Capture the dynamic coding environment once and pass it through every
+    // connection strategy.  GNU's `set_network_socket_coding_system` gives
+    // `coding-system-for-read/write` precedence over the operation/default
+    // codings; URL binds the read side to `binary` around this call.
+    let mut default_process_coding = NetworkProcessCodingDefaults {
+        coding_system_for_read: eval.visible_variable_value_or_nil("coding-system-for-read"),
+        coding_system_for_write: eval.visible_variable_value_or_nil("coding-system-for-write"),
+        operation_coding_system: Value::NIL,
+        default_process_coding_system: eval
+            .visible_variable_value_or_nil("default-process-coding-system"),
+        current_buffer_multibyte: eval
+            .buffers
+            .current_buffer()
+            .map(|buffer| buffer.get_multibyte())
+            .unwrap_or(true),
+    };
     let network_buffer_multibyte =
         match resolve_buffer_for_process_lookup_in_state(&eval.frames, &eval.buffers, &buffer) {
             Ok(Some(bid)) => eval
@@ -11037,6 +11123,7 @@ pub(crate) fn builtin_make_network_process(
             socket_type,
             socket_options,
             tls_parameters,
+            tls_parameters_val,
             default_process_coding,
             network_buffer_multibyte,
         );
@@ -11048,6 +11135,10 @@ pub(crate) fn builtin_make_network_process(
     let service = service.unwrap_or(Value::NIL);
     if service.is_nil() {
         return Err(signal_wrong_type_string(Value::NIL));
+    }
+    if coding_val.is_nil() {
+        default_process_coding.operation_coding_system =
+            find_network_operation_coding_system(eval, &name, buffer, host_value, service)?;
     }
 
     if family.is_local() {
@@ -11216,6 +11307,9 @@ pub(crate) fn builtin_make_network_process(
             } else if let Some(pending_dns) = pending_dns {
                 proc.pending_network_connect = Some(PendingNetworkConnect::Dns(pending_dns));
             }
+            if proc.pending_network_connect.is_some() {
+                proc.gnutls_boot_parameters = tls_parameters_val;
+            }
             apply_connection_process_flags(proc, noquery, stop);
         }
         if eval.processes.get(id).is_some_and(|proc| {
@@ -11289,7 +11383,7 @@ pub(crate) fn builtin_make_network_process(
 
     if let Some(parameters) = tls_parameters {
         upgrade_process_to_tls::<RustlsBackend>(
-            eval,
+            &mut eval.processes,
             id,
             &parameters.hostname,
             "make-network-process",
@@ -14341,6 +14435,7 @@ impl GcTrace for ProcessManager {
             roots.push(process.coding_decode);
             roots.push(process.coding_encode);
             roots.push(process.thread);
+            roots.push(process.gnutls_boot_parameters);
         }
     }
 }

--- a/neovm-core/src/emacs_core/process_test.rs
+++ b/neovm-core/src/emacs_core/process_test.rs
@@ -5712,6 +5712,25 @@ fn process_coding_tty_and_kill_buffer_query_runtime_surface() {
 }
 
 #[test]
+fn make_network_process_honors_dynamic_coding_system_for_read_like_gnu() {
+    crate::test_utils::init_test_tracing();
+    let results = eval_all(
+        r#"(let ((default-process-coding-system '(utf-8-unix . utf-8-unix))
+                  (coding-system-for-read 'binary))
+             (let ((process
+                    (make-network-process
+                     :name "network-dynamic-read-coding"
+                     :server t
+                     :service 0)))
+               (unwind-protect
+                   (process-coding-system process)
+                 (delete-process process))))"#,
+    );
+
+    assert_eq!(results, ["OK (binary . utf-8-unix)"]);
+}
+
+#[test]
 fn process_list_network_serial_runtime_surface() {
     crate::test_utils::init_test_tracing();
     let results = bootstrap_eval_all(
@@ -6269,6 +6288,47 @@ fn make_network_process_nowait_tcp_loopback_opens_like_gnu() {
     assert_eq!(
         results[0],
         "OK ((connect (connect stop) t t) open (open listen connect stop) ((:cli \"open\" open)) t t)"
+    );
+}
+
+#[test]
+fn make_network_process_nowait_retains_tls_parameters_until_connect_completes() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+    let port = listener.local_addr().expect("listener address").port();
+    let tls_parameters = Value::list(vec![
+        Value::symbol("gnutls-x509pki"),
+        Value::keyword(":hostname"),
+        Value::string("localhost"),
+    ]);
+    let mut eval = Context::new();
+
+    let process = builtin_make_network_process(
+        &mut eval,
+        vec![
+            Value::keyword(":name"),
+            Value::string("nowait-tls-parameters"),
+            Value::keyword(":host"),
+            Value::string("127.0.0.1"),
+            Value::keyword(":service"),
+            Value::fixnum(i64::from(port)),
+            Value::keyword(":family"),
+            Value::symbol("ipv4"),
+            Value::keyword(":nowait"),
+            Value::T,
+            Value::keyword(":tls-parameters"),
+            tls_parameters,
+        ],
+    )
+    .expect("start deferred TLS connection");
+    let id = process.as_process_id().expect("network process id");
+
+    assert_eq!(
+        eval.processes
+            .get(id)
+            .expect("network process")
+            .gnutls_boot_parameters,
+        tls_parameters,
+        "the TCP completion path must still know that TLS negotiation is pending"
     );
 }
 

--- a/neovm-core/src/emacs_core/tls.rs
+++ b/neovm-core/src/emacs_core/tls.rs
@@ -391,7 +391,9 @@ impl TlsStream {
 
     pub(crate) fn read_process_output(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         match self {
-            Self::Rustls(stream) => rustls_read_process_output(stream, buf),
+            Self::Rustls(stream) => {
+                read_rustls_process_output(&mut stream.inner.conn, &mut stream.inner.sock, buf)
+            }
         }
     }
 
@@ -421,8 +423,9 @@ impl TlsStream {
     }
 }
 
-fn rustls_read_process_output(
-    stream: &mut RustlsTlsStream,
+pub(crate) fn read_rustls_process_output(
+    connection: &mut rustls::ClientConnection,
+    socket: &mut TcpStream,
     buf: &mut [u8],
 ) -> std::io::Result<usize> {
     if buf.is_empty() {
@@ -430,8 +433,19 @@ fn rustls_read_process_output(
     }
 
     loop {
-        match stream.inner.read(buf) {
-            Ok(n) => return Ok(n),
+        // Rustls may already have decrypted application data from a previous
+        // socket read. Drain it before asking the nonblocking socket for
+        // another TLS record: `rustls::Stream::read' flushes pending writes
+        // first and can return WouldBlock with plaintext still available.
+        match connection.reader().read(buf) {
+            Ok(read) => return Ok(read),
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(err) => return Err(err),
+        }
+
+        match connection.complete_io(socket) {
+            Ok(_) => {}
             Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(err) => return Err(err),
         }

--- a/neovm-core/src/emacs_core/tls_test.rs
+++ b/neovm-core/src/emacs_core/tls_test.rs
@@ -2,13 +2,22 @@ use super::tls::{
     GnutlsCredentialType, TlsBackendError, TlsCloseNotifyResult, TlsPeerStatus,
     certificate_details_value_pem, der_certificate_to_pem, format_x509_certificate_pem,
     gnutls_available_capabilities, gnutls_close_notify_result_value, gnutls_peer_status_to_value,
-    parse_gnutls_boot_parameters,
+    parse_gnutls_boot_parameters, read_rustls_process_output,
 };
 use super::value::Value;
 use crate::emacs_core::builtins::gnutls::{
     builtin_gnutls_error_fatalp, builtin_gnutls_error_string,
     builtin_gnutls_peer_status_warning_describe,
 };
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::{
+    ClientConfig, ClientConnection, DigitallySignedStruct, Error, ServerConfig, ServerConnection,
+    SignatureScheme,
+};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime, pem::PemObject};
+use std::io::{Cursor, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
 
 const TEST_CERTIFICATE_PEM: &str = concat!(
     "-----BEGIN CERTIFICATE-----\n",
@@ -43,6 +52,211 @@ const TEST_CERTIFICATE_PEM: &str = concat!(
     "Fcix40FKEeiE093Aj3cweMYxNLPgwgQP8Xu3kA5QEw==\n",
     "-----END CERTIFICATE-----\n",
 );
+
+#[derive(Debug)]
+struct AcceptAnyServerCertificate;
+
+impl ServerCertVerifier for AcceptAnyServerCertificate {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+        ]
+    }
+}
+
+#[test]
+fn nonblocking_tls_reads_drain_buffered_plaintext_before_waiting_for_ciphertext() {
+    let certificate = CertificateDer::from_pem_slice(include_bytes!(
+        "../../../test/lisp/net/network-stream-resources/cert.pem"
+    ))
+    .expect("test certificate");
+    let private_key = PrivateKeyDer::from_pem_slice(include_bytes!(
+        "../../../test/lisp/net/network-stream-resources/key.pem"
+    ))
+    .expect("test private key");
+    let server_config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![certificate], private_key)
+        .expect("server certificate and key");
+    let client_config = ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(AcceptAnyServerCertificate))
+        .with_no_client_auth();
+    let server_name = ServerName::try_from("localhost").expect("valid server name");
+    let mut connection =
+        ClientConnection::new(Arc::new(client_config), server_name).expect("TLS client connection");
+    let mut server_connection =
+        ServerConnection::new(Arc::new(server_config)).expect("TLS server connection");
+
+    for _ in 0..10 {
+        let mut client_wire = Vec::new();
+        connection
+            .write_tls(&mut client_wire)
+            .expect("write client handshake records");
+        if !client_wire.is_empty() {
+            server_connection
+                .read_tls(&mut Cursor::new(client_wire))
+                .expect("read client handshake records");
+            server_connection
+                .process_new_packets()
+                .expect("process client handshake records");
+        }
+
+        let mut server_wire = Vec::new();
+        server_connection
+            .write_tls(&mut server_wire)
+            .expect("write server handshake records");
+        if !server_wire.is_empty() {
+            connection
+                .read_tls(&mut Cursor::new(server_wire))
+                .expect("read server handshake records");
+            connection
+                .process_new_packets()
+                .expect("process server handshake records");
+        }
+        if !connection.is_handshaking() && !server_connection.is_handshaking() {
+            break;
+        }
+    }
+    assert!(
+        !connection.is_handshaking(),
+        "client handshake should finish"
+    );
+    assert!(
+        !server_connection.is_handshaking(),
+        "server handshake should finish"
+    );
+    // Flush post-handshake records (for example TLS 1.3 tickets and the
+    // client's Finished) before constructing the application-data scenario.
+    for _ in 0..4 {
+        let mut client_wire = Vec::new();
+        connection
+            .write_tls(&mut client_wire)
+            .expect("flush client post-handshake records");
+        if !client_wire.is_empty() {
+            server_connection
+                .read_tls(&mut Cursor::new(client_wire))
+                .expect("read client post-handshake records");
+            server_connection
+                .process_new_packets()
+                .expect("process client post-handshake records");
+        }
+
+        let mut server_wire = Vec::new();
+        server_connection
+            .write_tls(&mut server_wire)
+            .expect("flush server post-handshake records");
+        if !server_wire.is_empty() {
+            connection
+                .read_tls(&mut Cursor::new(server_wire))
+                .expect("read server post-handshake records");
+            connection
+                .process_new_packets()
+                .expect("process server post-handshake records");
+        }
+        if !connection.wants_write() && !server_connection.wants_write() {
+            break;
+        }
+    }
+
+    let expected = vec![b'x'; 8_000];
+    server_connection
+        .writer()
+        .write_all(&expected)
+        .expect("buffer TLS test plaintext");
+    let mut application_records = Vec::new();
+    server_connection
+        .write_tls(&mut application_records)
+        .expect("write TLS application records");
+    let application_records_len = application_records.len() as u64;
+    let mut application_records = Cursor::new(application_records);
+    let mut plaintext_bytes = 0;
+    while application_records.position() < application_records_len {
+        connection
+            .read_tls(&mut application_records)
+            .expect("read TLS application records");
+        plaintext_bytes = connection
+            .process_new_packets()
+            .expect("decrypt TLS application records")
+            .plaintext_bytes_to_read();
+        if plaintext_bytes == expected.len() {
+            break;
+        }
+    }
+    assert_eq!(plaintext_bytes, expected.len());
+
+    // Give the helper a live nonblocking socket with no bytes ready. The only
+    // readable bytes are the plaintext already buffered inside rustls.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind empty test socket");
+    let mut socket = TcpStream::connect(listener.local_addr().expect("listener address"))
+        .expect("connect empty test socket");
+    let (_peer, _) = listener.accept().expect("accept empty test socket");
+    socket
+        .set_nonblocking(true)
+        .expect("set TLS test client nonblocking");
+    // Make an outstanding TLS write hit WouldBlock. `rustls::Stream::read'
+    // flushes such writes before exposing already-decrypted plaintext.
+    let filler = vec![0; 65_536];
+    loop {
+        match socket.write(&filler) {
+            Ok(0) => panic!("test socket stopped accepting filler bytes"),
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(err) => panic!("fill test socket send buffer: {err}"),
+        }
+    }
+    connection
+        .writer()
+        .write_all(b"pending TLS transport write")
+        .expect("queue pending TLS write");
+    assert!(connection.wants_write(), "TLS write should remain queued");
+
+    let mut actual = Vec::new();
+    let mut chunk = vec![0; 65_536];
+    while actual.len() < expected.len() {
+        let read = read_rustls_process_output(&mut connection, &mut socket, &mut chunk)
+            .expect("buffered plaintext must not report WouldBlock");
+        assert!(read > 0, "the complete TLS payload should remain readable");
+        actual.extend_from_slice(&chunk[..read]);
+    }
+
+    assert_eq!(actual.len(), expected.len());
+    assert!(actual.iter().all(|byte| *byte == b'x'));
+}
 
 #[test]
 fn backend_errors_render_boundary_messages() {


### PR DESCRIPTION
Fixes #168 and #169.

## What changed

- Honor `eval-region`'s `READ-FUNCTION` callback with GNU-compatible live-buffer reader semantics, allowing Edebug to install instrumented forms.
- Implement Lisp-visible recursive edit depth from command-loop and minibuffer depth so Edebug stepping exits the correct recursive edit.
- Apply GNU's network coding-system precedence, including dynamic `coding-system-for-read` and `coding-system-for-write` bindings.
- Preserve TLS parameters through deferred `:nowait` TCP connection completion.
- Drain already-decrypted rustls plaintext before waiting for additional ciphertext.

## Root causes

Edebug instrumentation was discarded because Neomacs re-read and evaluated the original region instead of the form returned by its reader callback. Edebug stepping was additionally blocked by a hard-coded zero `recursion-depth`.

The nerd-icons font download was decoded as UTF-8 because the network process ignored URL's dynamic binary coding binding. The resulting buffer length never reached the HTTP `Content-Length`, so synchronous retrieval waited indefinitely.

## Validation

- GNU Edebug upstream ERT: 1/1 passed.
- Exact `nerd-icons-install-fonts` reproduction downloaded 2,507,556 bytes with the expected SHA-256.
- 32 focused `cargo nextest` regressions passed.
- Release build passed.
- Pre-push `cargo fmt --all --check` and full `cargo check` passed.