### PR TITLE
Swap alacritty_terminal for rio-vt in neo-term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -64,31 +64,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "alacritty_terminal"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda177466b9524d59f1b12f0dd30b68696788e9992a7e959021c4a0ed96fcf59"
-dependencies = [
- "base64",
- "bitflags 2.13.1",
- "home",
- "libc",
- "log",
- "miow",
- "parking_lot",
- "piper",
- "polling",
- "regex-automata",
- "rustix 1.1.4",
- "rustix-openpty",
- "serde",
- "signal-hook 0.4.4",
- "unicode-width",
- "vte",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -182,7 +157,7 @@ checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
  "bitflags 2.13.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
 ]
 
@@ -487,7 +462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "miniz_oxide",
  "object 0.37.3",
@@ -587,7 +562,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -803,6 +778,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
@@ -971,6 +952,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "corcovado"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a4e7a18574e1b7884f6c3c8e3b153c2ed01ad5b4a91a1076f64a87674927e37"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "libc",
+ "miow 0.5.0",
+ "slab",
+ "socket2",
+ "tracing",
+ "windows 0.42.0",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1339,7 +1339,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -1558,6 +1558,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,7 +1626,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "socket2",
  "windows-sys 0.60.2",
@@ -1656,7 +1677,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -1971,6 +1992,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags 1.3.2",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,12 +2032,6 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -2054,7 +2085,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
 ]
@@ -2065,7 +2096,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
@@ -2077,7 +2108,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
 ]
@@ -2261,7 +2292,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4527e1b9bae8d29ce137bde5b8eec8ae8f78f13ad00fc6e70cbe227d6ad027"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2340,7 +2371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08353a8a382be9a49b15fb9c46b3abd6f8a6e6439e1eaedc87d08f1abdcfad1"
 dependencies = [
  "atomic_refcell",
- "cfg-if",
+ "cfg-if 1.0.4",
  "glib",
  "gstreamer",
  "gstreamer-base-sys",
@@ -2366,7 +2397,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85d09343b4c23d64b3ef35f1f644598860cc9a4617e7ccded141de97cd528608"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "glib-sys",
  "gobject-sys",
  "libc",
@@ -2379,7 +2410,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7907cb8a73edc98cf279e5de7370bb2c245b7bedf623ba8c7e59648cd4739133"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-channel",
  "glib",
  "gstreamer",
@@ -2409,7 +2440,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "crunchy",
  "num-traits",
  "zerocopy",
@@ -2510,7 +2541,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "windows-link",
 ]
@@ -2621,6 +2652,109 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -2761,6 +2895,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2811,7 +2954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-sys 0.3.1",
  "log",
@@ -2826,7 +2969,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "combine",
  "jni-macros",
  "jni-sys 0.4.1",
@@ -2894,7 +3037,7 @@ version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
@@ -3002,7 +3145,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -3012,7 +3155,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -3084,6 +3227,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -3204,7 +3353,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "rayon",
 ]
 
@@ -3268,6 +3417,15 @@ dependencies = [
 
 [[package]]
 name = "miow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "miow"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
@@ -3300,7 +3458,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
  "bitflags 2.13.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "codespan-reporting",
  "half",
@@ -3324,7 +3482,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.10.0",
  "bitflags 2.13.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "codespan-reporting",
  "half",
@@ -3474,13 +3632,12 @@ dependencies = [
 name = "neomacs-display-runtime"
 version = "0.0.14"
 dependencies = [
- "alacritty_terminal",
  "arboard",
  "ash",
  "bindgen",
  "bitflags 2.13.1",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cosmic-text",
  "crossbeam-channel",
  "crossterm",
@@ -3502,6 +3659,7 @@ dependencies = [
  "portable-pty",
  "raw-window-handle",
  "resvg",
+ "rio-vt",
  "serde_json",
  "smithay-clipboard",
  "thiserror 2.0.18",
@@ -3733,7 +3891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
 ]
 
@@ -3744,7 +3902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.13.1",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.1.1",
  "libc",
 ]
@@ -4320,6 +4478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "option-operations"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4416,7 +4580,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
@@ -4482,6 +4646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -4575,17 +4740,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4644,7 +4798,7 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
@@ -4695,6 +4849,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4717,7 +4880,7 @@ checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
 dependencies = [
  "aligned-vec",
  "backtrace",
- "cfg-if",
+ "cfg-if 1.0.4",
  "findshlibs",
  "inferno 0.11.21",
  "libc",
@@ -5066,7 +5229,7 @@ dependencies = [
  "av1-grain",
  "bitstream-io",
  "built",
- "cfg-if",
+ "cfg-if 1.0.4",
  "interpolate_name",
  "itertools 0.14.0",
  "libc",
@@ -5179,6 +5342,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5272,11 +5446,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rio-grapheme-width"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864187dd73f3f562c87937e80e81cf7c872423491fc9704cfffd2489ac19edf0"
+dependencies = [
+ "phf 0.13.1",
+ "ucd-trie",
+]
+
+[[package]]
+name = "rio-graphics"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816d070320ab65bb6efadc6b208e3de8cc73a28161fe9c509419d8583160bdf4"
+dependencies = [
+ "rustc-hash 2.1.3",
+ "tracing",
+]
+
+[[package]]
+name = "rio-vt"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2774f471f1b614bb2ba64808c5fb3d00a00e5031109f5a3eb3ba4f8deb9d40e"
+dependencies = [
+ "base64",
+ "bitflags 2.13.1",
+ "bytemuck",
+ "corcovado",
+ "cursor-icon",
+ "flate2",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "regex",
+ "regex-automata",
+ "rio-grapheme-width",
+ "rio-graphics",
+ "rustc-hash 2.1.3",
+ "serde",
+ "simdutf",
+ "smallvec",
+ "teletypewriter",
+ "tracing",
+ "unicode-width-16",
+ "url",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5381,17 +5606,6 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustix-openpty"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de16c7c59892b870a6336f185dc10943517f1327447096bbb7bb32cd85e2393"
-dependencies = [
- "errno",
- "libc",
- "rustix 1.1.4",
 ]
 
 [[package]]
@@ -5616,7 +5830,7 @@ version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcdbc46aa3882ec3d48ec2b5abcb4f0d863a13d7599265f3faa6d851f23c12f3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "winapi",
 ]
@@ -5627,7 +5841,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest",
 ]
@@ -5638,7 +5852,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cpufeatures",
  "digest",
 ]
@@ -5738,6 +5952,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
+]
+
+[[package]]
+name = "simdutf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f542752c7335a9174e7bb81112c3ca1415a7a6b6ec2c3e840aca347a30f9141"
+dependencies = [
+ "bitflags 2.13.1",
+ "cc",
 ]
 
 [[package]]
@@ -5911,7 +6135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "psm",
  "windows-sys 0.61.2",
@@ -6158,6 +6382,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "teletypewriter"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f842f7caef17bcea4023e8f1b50ff46067c688ecdb899070cae00746317420bc"
+dependencies = [
+ "corcovado",
+ "dirs",
+ "iovec",
+ "libc",
+ "miow 0.6.1",
+ "parking_lot",
+ "signal-hook 0.4.4",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6225,7 +6466,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -6302,7 +6543,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "log",
  "tiny-skia-path 0.11.4",
 ]
@@ -6316,7 +6557,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "log",
  "png",
  "tiny-skia-path 0.12.0",
@@ -6342,6 +6583,16 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -6728,6 +6979,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-width-16"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eba15036aa0f5bf8ed6cd12a624ddb61fd50b0779b1c05d89b663bcaed7b5c2"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6760,6 +7017,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "usvg"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6786,6 +7055,12 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -6850,11 +7125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
- "bitflags 2.13.1",
- "cursor-icon",
- "log",
  "memchr",
- "serde",
 ]
 
 [[package]]
@@ -6915,7 +7186,7 @@ version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -6980,7 +7251,7 @@ version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5684ba160951baad06a725696f3c590e2fb0e8067c2aebee27bf7f9259058e85"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "wasmtime-internal-core",
  "windows-sys 0.61.2",
@@ -7165,7 +7436,7 @@ dependencies = [
  "arrayvec",
  "bitflags 2.13.1",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "document-features",
  "hashbrown 0.17.0",
@@ -7258,7 +7529,7 @@ dependencies = [
  "ash",
  "bitflags 2.13.1",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "gpu-allocator",
  "gpu-descriptor",
@@ -7292,7 +7563,7 @@ dependencies = [
  "bitflags 2.13.1",
  "block2 0.6.2",
  "bytemuck",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases 0.2.1",
  "glow",
  "glutin_wgl_sys",
@@ -7451,6 +7722,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
@@ -7577,6 +7863,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7905,6 +8206,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8031,6 +8338,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8057,10 +8387,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,7 @@ gstreamer-app = "0.25"
 gstreamer-allocators = "0.25"
 
 # Terminal emulation
-alacritty_terminal = "0.26"
+rio-vt = "0.5.3"
 parking_lot = "0.12"
 portable-pty = "0.9"
 smallvec = "1.13"

--- a/neomacs-display-runtime/Cargo.toml
+++ b/neomacs-display-runtime/Cargo.toml
@@ -62,7 +62,7 @@ neomacs-layout-engine.workspace = true
 neomacs-renderer-wgpu.workspace = true
 
 # Terminal emulation (neo-term)
-alacritty_terminal = { workspace = true, optional = true }
+rio-vt = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 portable-pty = { workspace = true, optional = true }
 
@@ -94,7 +94,7 @@ wpe-webkit = [
 ]
 # GPU-accelerated terminal emulator
 neo-term = [
-    "alacritty_terminal",
+    "dep:rio-vt",
     "parking_lot",
     "portable-pty",
     "neomacs-display-protocol/neo-term",

--- a/neomacs-display-runtime/src/render_thread/media.rs
+++ b/neomacs-display-runtime/src/render_thread/media.rs
@@ -676,7 +676,7 @@ impl RenderApp {
         out: &mut Vec<FrameGlyph>,
         faces: &mut HashMap<FaceId, Face>,
     ) {
-        use alacritty_terminal::term::cell::Flags as CellFlags;
+        use rio_vt::crosswords::style::StyleFlags as CellFlags;
         let row_role = if is_overlay {
             GlyphRowRole::ModeLine
         } else {
@@ -866,7 +866,7 @@ mod tests {
     use crate::core::frame_glyphs::FrameGlyphBuffer;
     use crate::core::types::Color;
     use crate::terminal::content::{RenderCell, RenderCursor, TerminalContent};
-    use alacritty_terminal::term::cell::Flags as CellFlags;
+    use rio_vt::crosswords::style::StyleFlags as CellFlags;
 
     #[test]
     fn terminal_glyph_expansion_uses_frame_metrics() {

--- a/neomacs-display-runtime/src/terminal/colors.rs
+++ b/neomacs-display-runtime/src/terminal/colors.rs
@@ -1,7 +1,7 @@
-//! Color conversion from alacritty_terminal colors to neomacs Color.
+//! Color conversion from rio-vt colors to neomacs Color.
 
 use crate::core::types::Color;
-use alacritty_terminal::vte::ansi::{Color as AnsiColor, NamedColor};
+use rio_vt::config::colors::{AnsiColor, NamedColor};
 
 /// Default 256-color palette (standard ANSI + extended colors).
 /// First 16 are the standard terminal colors, 16-231 are the 6x6x6 color cube,
@@ -71,7 +71,7 @@ static COLOR_256: once_cell::sync::Lazy<[Color; 256]> = once_cell::sync::Lazy::n
     colors
 });
 
-/// Convert an alacritty AnsiColor to a neomacs Color.
+/// Convert a rio-vt AnsiColor to a neomacs Color.
 ///
 /// `default_fg` and `default_bg` are used when the color is `Named(Foreground)`
 /// or `Named(Background)`.
@@ -102,14 +102,14 @@ fn named_to_color(named: NamedColor, default_fg: &Color, default_bg: &Color) -> 
         NamedColor::Magenta => COLOR_256[5],
         NamedColor::Cyan => COLOR_256[6],
         NamedColor::White => COLOR_256[7],
-        NamedColor::BrightBlack => COLOR_256[8],
-        NamedColor::BrightRed => COLOR_256[9],
-        NamedColor::BrightGreen => COLOR_256[10],
-        NamedColor::BrightYellow => COLOR_256[11],
-        NamedColor::BrightBlue => COLOR_256[12],
-        NamedColor::BrightMagenta => COLOR_256[13],
-        NamedColor::BrightCyan => COLOR_256[14],
-        NamedColor::BrightWhite => COLOR_256[15],
+        NamedColor::LightBlack => COLOR_256[8],
+        NamedColor::LightRed => COLOR_256[9],
+        NamedColor::LightGreen => COLOR_256[10],
+        NamedColor::LightYellow => COLOR_256[11],
+        NamedColor::LightBlue => COLOR_256[12],
+        NamedColor::LightMagenta => COLOR_256[13],
+        NamedColor::LightCyan => COLOR_256[14],
+        NamedColor::LightWhite => COLOR_256[15],
         _ => *default_fg,
     }
 }

--- a/neomacs-display-runtime/src/terminal/colors_test.rs
+++ b/neomacs-display-runtime/src/terminal/colors_test.rs
@@ -345,7 +345,7 @@ fn test_named_white() {
 fn test_named_bright_black() {
     let fg = Color::WHITE;
     let bg = Color::BLACK;
-    let c = ansi_to_color(&AnsiColor::Named(NamedColor::BrightBlack), &fg, &bg);
+    let c = ansi_to_color(&AnsiColor::Named(NamedColor::LightBlack), &fg, &bg);
     assert_color_rgb(&c, 127, 127, 127);
 }
 
@@ -353,7 +353,7 @@ fn test_named_bright_black() {
 fn test_named_bright_white() {
     let fg = Color::WHITE;
     let bg = Color::BLACK;
-    let c = ansi_to_color(&AnsiColor::Named(NamedColor::BrightWhite), &fg, &bg);
+    let c = ansi_to_color(&AnsiColor::Named(NamedColor::LightWhite), &fg, &bg);
     assert_color_rgb(&c, 255, 255, 255);
 }
 
@@ -479,7 +479,7 @@ fn test_spec_color_conversion() {
     let fg = Color::WHITE;
     let bg = Color::BLACK;
     let c = ansi_to_color(
-        &AnsiColor::Spec(alacritty_terminal::vte::ansi::Rgb {
+        &AnsiColor::Spec(rio_vt::config::colors::ColorRgb {
             r: 128,
             g: 64,
             b: 32,
@@ -497,14 +497,14 @@ fn test_spec_color_extremes() {
     let bg = Color::BLACK;
 
     let black = ansi_to_color(
-        &AnsiColor::Spec(alacritty_terminal::vte::ansi::Rgb { r: 0, g: 0, b: 0 }),
+        &AnsiColor::Spec(rio_vt::config::colors::ColorRgb { r: 0, g: 0, b: 0 }),
         &fg,
         &bg,
     );
     assert_color_eq(&black, 0.0, 0.0, 0.0);
 
     let white = ansi_to_color(
-        &AnsiColor::Spec(alacritty_terminal::vte::ansi::Rgb {
+        &AnsiColor::Spec(rio_vt::config::colors::ColorRgb {
             r: 255,
             g: 255,
             b: 255,

--- a/neomacs-display-runtime/src/terminal/content.rs
+++ b/neomacs-display-runtime/src/terminal/content.rs
@@ -1,14 +1,17 @@
 //! Terminal content extraction — snapshot of terminal state for rendering.
 //!
 //! Each frame, the render thread extracts a `TerminalContent` from the
-//! `alacritty_terminal::Term` and converts cells to rendering primitives.
+//! `rio_vt::crosswords::Crosswords` and converts cells to rendering
+//! primitives.
 
 use super::colors::ansi_to_color;
 use crate::core::types::Color;
-use alacritty_terminal::grid::Dimensions;
-use alacritty_terminal::index::{Column, Line, Point};
-use alacritty_terminal::term::Term;
-use alacritty_terminal::term::cell::Flags as CellFlags;
+use rio_vt::config::colors::{AnsiColor, ColorRgb, NamedColor};
+use rio_vt::crosswords::pos::{Column, Line};
+use rio_vt::crosswords::square::{ContentTag, Square, Wide};
+use rio_vt::crosswords::style::{Style, StyleFlags as CellFlags};
+use rio_vt::crosswords::{Crosswords, Mode};
+use rio_vt::event::EventListener;
 
 /// A single cell ready for GPU rendering.
 #[derive(Debug, Clone)]
@@ -51,12 +54,40 @@ pub struct TerminalContent {
     pub default_fg: Color,
 }
 
+/// Resolve a square's fg color, bg color, and style flags. Squares store a
+/// packed style id (or a bg-only fast path) rather than inline colors, so
+/// the per-grid style table is consulted for full styling.
+fn square_style(square: &Square, styles: &[Style]) -> (AnsiColor, AnsiColor, CellFlags) {
+    match square.content_tag() {
+        ContentTag::Codepoint => {
+            let style = styles
+                .get(square.style_id() as usize)
+                .copied()
+                .unwrap_or_default();
+            (style.fg, style.bg, style.flags)
+        }
+        ContentTag::BgPalette => (
+            AnsiColor::Named(NamedColor::Foreground),
+            AnsiColor::Indexed(square.bg_palette_index()),
+            CellFlags::empty(),
+        ),
+        ContentTag::BgRgb => {
+            let (r, g, b) = square.bg_rgb();
+            (
+                AnsiColor::Named(NamedColor::Foreground),
+                AnsiColor::Spec(ColorRgb { r, g, b }),
+                CellFlags::empty(),
+            )
+        }
+    }
+}
+
 impl TerminalContent {
-    /// Extract renderable content from an alacritty Term.
-    pub fn from_term<T: alacritty_terminal::event::EventListener>(term: &Term<T>) -> Self {
-        let grid = term.grid();
-        let num_cols = grid.columns();
-        let num_lines = grid.screen_lines();
+    /// Extract renderable content from a rio-vt terminal.
+    pub fn from_term<T: EventListener>(term: &Crosswords<T>) -> Self {
+        let num_cols = term.columns();
+        let num_lines = term.screen_lines();
+        let styles = term.grid.style_set.styles();
 
         let default_fg = Color::WHITE;
         let default_bg = Color::BLACK;
@@ -64,19 +95,23 @@ impl TerminalContent {
         let mut cells = Vec::with_capacity(num_cols * num_lines);
 
         for row_idx in 0..num_lines {
-            let line = Line(row_idx as i32);
+            let row = &term.grid[Line(row_idx as i32)];
             for col_idx in 0..num_cols {
-                let point = Point::new(line, Column(col_idx));
-                let cell = &grid[point];
+                let square = &row[Column(col_idx)];
 
-                let c = cell.c;
                 // Skip wide char spacers (second cell of double-width character)
-                if cell.flags.contains(CellFlags::WIDE_CHAR_SPACER) {
+                if matches!(square.wide(), Wide::Spacer | Wide::LeadingSpacer) {
                     continue;
                 }
 
-                let fg = ansi_to_color(&cell.fg, &default_fg, &default_bg);
-                let bg = ansi_to_color(&cell.bg, &default_fg, &default_bg);
+                let c = match square.c() {
+                    '\0' => ' ',
+                    c => c,
+                };
+
+                let (sq_fg, sq_bg, flags) = square_style(square, styles);
+                let fg = ansi_to_color(&sq_fg, &default_fg, &default_bg);
+                let bg = ansi_to_color(&sq_bg, &default_fg, &default_bg);
 
                 cells.push(RenderCell {
                     col: col_idx,
@@ -84,18 +119,16 @@ impl TerminalContent {
                     c,
                     fg,
                     bg,
-                    flags: cell.flags,
+                    flags,
                 });
             }
         }
 
-        let cursor_point = term.grid().cursor.point;
+        let cursor_pos = term.cursor().pos;
         let cursor = RenderCursor {
-            col: cursor_point.column.0,
-            row: cursor_point.line.0 as usize,
-            visible: term
-                .mode()
-                .contains(alacritty_terminal::term::TermMode::SHOW_CURSOR),
+            col: cursor_pos.col.0,
+            row: cursor_pos.row.0.max(0) as usize,
+            visible: term.mode().contains(Mode::SHOW_CURSOR),
         };
 
         TerminalContent {
@@ -110,19 +143,18 @@ impl TerminalContent {
 }
 
 /// Extract text from a terminal grid region as a String.
-pub fn extract_text<T: alacritty_terminal::event::EventListener>(
-    term: &Term<T>,
+pub fn extract_text<T: EventListener>(
+    term: &Crosswords<T>,
     start_row: usize,
     start_col: usize,
     end_row: usize,
     end_col: usize,
 ) -> String {
-    let grid = term.grid();
-    let num_cols = grid.columns();
+    let num_cols = term.columns();
+    let num_lines = term.screen_lines();
     let mut text = String::new();
 
     for row in start_row..=end_row {
-        let line = Line(row as i32);
         let col_start = if row == start_row { start_col } else { 0 };
         let col_end = if row == end_row {
             end_col
@@ -130,12 +162,17 @@ pub fn extract_text<T: alacritty_terminal::event::EventListener>(
             num_cols.saturating_sub(1)
         };
 
-        for col in col_start..=col_end {
-            let point = Point::new(line, Column(col));
-            if line.0 < grid.screen_lines() as i32 && col < num_cols {
-                let cell = &grid[point];
-                if !cell.flags.contains(CellFlags::WIDE_CHAR_SPACER) {
-                    text.push(cell.c);
+        if row < num_lines {
+            let line = &term.grid[Line(row as i32)];
+            for col in col_start..=col_end {
+                if col < num_cols {
+                    let square = &line[Column(col)];
+                    if !matches!(square.wide(), Wide::Spacer | Wide::LeadingSpacer) {
+                        text.push(match square.c() {
+                            '\0' => ' ',
+                            c => c,
+                        });
+                    }
                 }
             }
         }

--- a/neomacs-display-runtime/src/terminal/mod.rs
+++ b/neomacs-display-runtime/src/terminal/mod.rs
@@ -1,6 +1,6 @@
 //! Neo-term: GPU-accelerated terminal emulator for Neomacs.
 //!
-//! Uses `alacritty_terminal` for VT parsing and terminal state,
+//! Uses `rio-vt` for VT parsing and terminal state,
 //! renders cells directly via the wgpu pipeline.
 
 pub mod colors;
@@ -20,7 +20,7 @@ pub type SharedTerminals = std::sync::Arc<
         std::collections::HashMap<
             TerminalId,
             std::sync::Arc<
-                parking_lot::FairMutex<alacritty_terminal::term::Term<view::NeomacsEventProxy>>,
+                parking_lot::FairMutex<rio_vt::crosswords::Crosswords<view::NeomacsEventProxy>>,
             >,
         >,
     >,

--- a/neomacs-display-runtime/src/terminal/view.rs
+++ b/neomacs-display-runtime/src/terminal/view.rs
@@ -1,6 +1,6 @@
-//! TerminalView: manages a single terminal instance (Term + PTY).
+//! TerminalView: manages a single terminal instance (Crosswords + PTY).
 //!
-//! Each TerminalView wraps an `alacritty_terminal::Term`, spawns a PTY
+//! Each TerminalView wraps a `rio_vt::crosswords::Crosswords`, spawns a PTY
 //! child process (shell) via `portable-pty`, and runs a reader thread
 //! to feed PTY output into the terminal state.
 
@@ -9,50 +9,21 @@ use std::io::{Read, Write};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
-use parking_lot::FairMutex;
+use parking_lot::{FairMutex, Mutex};
 use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
 
-use alacritty_terminal::event::{Event as TermEvent, EventListener};
-use alacritty_terminal::grid::Dimensions;
-use alacritty_terminal::term::{Config as TermConfig, Term};
-use alacritty_terminal::vte::ansi;
+use rio_vt::ansi::CursorShape;
+use rio_vt::crosswords::{Crosswords, CrosswordsSize};
+use rio_vt::event::{EventListener, RioEvent, WindowId};
+use rio_vt::performer::handler::Processor;
 
 use super::content::TerminalContent;
 use super::{TerminalId, TerminalMode};
 
-/// Grid dimensions for Term::new() and Term::resize().
-///
-/// alacritty_terminal's `WindowSize` doesn't implement `Dimensions`,
-/// so we provide our own wrapper.
-struct TermGridSize {
-    columns: usize,
-    screen_lines: usize,
-}
+/// Scrollback history limit, matching the previous emulator default.
+const SCROLLBACK_HISTORY: usize = 10_000;
 
-impl TermGridSize {
-    fn new(cols: u16, rows: u16) -> Self {
-        Self {
-            columns: cols as usize,
-            screen_lines: rows as usize,
-        }
-    }
-}
-
-impl Dimensions for TermGridSize {
-    fn total_lines(&self) -> usize {
-        self.screen_lines
-    }
-
-    fn screen_lines(&self) -> usize {
-        self.screen_lines
-    }
-
-    fn columns(&self) -> usize {
-        self.columns
-    }
-}
-
-/// Event listener that bridges alacritty events to neomacs.
+/// Event listener that bridges rio-vt events to neomacs.
 #[derive(Clone)]
 pub struct NeomacsEventProxy {
     id: TerminalId,
@@ -60,6 +31,8 @@ pub struct NeomacsEventProxy {
     wakeup: Arc<std::sync::atomic::AtomicBool>,
     /// Signals that the terminal child process has exited.
     exited: Arc<std::sync::atomic::AtomicBool>,
+    /// Replies the terminal wants written back to the PTY (DA/DSR/CPR).
+    pending_writes: Arc<Mutex<Vec<u8>>>,
 }
 
 impl NeomacsEventProxy {
@@ -68,6 +41,7 @@ impl NeomacsEventProxy {
             id,
             wakeup: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             exited: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            pending_writes: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -86,25 +60,41 @@ impl NeomacsEventProxy {
     pub fn is_exited(&self) -> bool {
         self.exited.load(std::sync::atomic::Ordering::Relaxed)
     }
+
+    fn notify_wakeup(&self) {
+        self.wakeup
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn notify_exit(&self) {
+        tracing::info!("Terminal {}: child process exited", self.id);
+        self.exited
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Drain replies queued for write-back to the PTY.
+    fn take_pending_writes(&self) -> Vec<u8> {
+        std::mem::take(&mut *self.pending_writes.lock())
+    }
 }
 
 impl EventListener for NeomacsEventProxy {
-    fn send_event(&self, event: TermEvent) {
+    fn event(&self) -> (Option<RioEvent>, bool) {
+        (None, false)
+    }
+
+    fn send_event(&self, event: RioEvent, _window_id: WindowId) {
         match event {
-            TermEvent::Wakeup => {
-                self.wakeup
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
+            RioEvent::PtyWrite(_route, text) => {
+                self.pending_writes
+                    .lock()
+                    .extend_from_slice(text.as_bytes());
             }
-            TermEvent::Title(title) => {
+            RioEvent::Title(title) => {
                 tracing::debug!("Terminal {}: title changed to '{}'", self.id, title);
             }
-            TermEvent::Bell => {
+            RioEvent::Bell => {
                 tracing::debug!("Terminal {}: bell", self.id);
-            }
-            TermEvent::Exit => {
-                tracing::info!("Terminal {}: child process exited", self.id);
-                self.exited
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
             }
             _ => {}
         }
@@ -116,15 +106,16 @@ pub struct TerminalView {
     pub id: TerminalId,
     pub mode: TerminalMode,
     /// The terminal state (shared with PTY reader).
-    pub term: Arc<FairMutex<Term<NeomacsEventProxy>>>,
+    pub term: Arc<FairMutex<Crosswords<NeomacsEventProxy>>>,
     /// Event proxy for wakeup notifications.
     pub event_proxy: NeomacsEventProxy,
     /// PTY master handle used for resize and I/O.
     pty: Box<dyn MasterPty + Send>,
     /// Child process handle. Kept alive for the lifetime of the terminal.
     _pty_child: Box<dyn portable_pty::Child + Send + Sync>,
-    /// PTY master (for writing input to the shell).
-    pty_writer: Box<dyn Write + Send>,
+    /// PTY master (for writing input to the shell). Shared with the reader
+    /// thread, which flushes the terminal's own replies (DA/DSR/CPR).
+    pty_writer: Arc<Mutex<Box<dyn Write + Send>>>,
     /// Reader thread handle.
     _reader_thread: Option<JoinHandle<()>>,
     /// Cached content from last extraction.
@@ -150,11 +141,15 @@ impl TerminalView {
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let event_proxy = NeomacsEventProxy::new(id);
 
-        // Create the terminal with our Dimensions-compatible size
-        let config = TermConfig::default();
-        let grid_size = TermGridSize::new(cols, rows);
-
-        let term = Term::new(config, &grid_size, event_proxy.clone());
+        let grid_size = CrosswordsSize::new(cols.max(1) as usize, rows.max(1) as usize);
+        let term = Crosswords::new(
+            grid_size,
+            CursorShape::Block,
+            event_proxy.clone(),
+            WindowId::from(0),
+            0,
+            SCROLLBACK_HISTORY,
+        );
         let term = Arc::new(FairMutex::new(term));
 
         // Create PTY and spawn shell using portable-pty.
@@ -199,27 +194,43 @@ impl TerminalView {
             .take_writer()
             .map_err(|e| format!("Failed to take PTY writer: {}", e))?;
 
-        // Spawn reader thread: reads from PTY, feeds into term via ansi::Processor
+        let pty_writer: Arc<Mutex<Box<dyn Write + Send>>> =
+            Arc::new(Mutex::new(Box::new(pty_write_file)));
+
+        // Spawn reader thread: reads from PTY, feeds into term via Processor
         let term_clone = Arc::clone(&term);
         let proxy_clone = event_proxy.clone();
+        let writer_clone = Arc::clone(&pty_writer);
         let reader_thread = thread::Builder::new()
             .name(format!("neo-term-{}-pty", id))
             .spawn(move || {
                 let mut reader = pty_read_file;
-                let mut processor: ansi::Processor = ansi::Processor::new();
+                let mut processor = Processor::default();
                 let mut buf = [0u8; 4096];
                 loop {
                     match reader.read(&mut buf) {
                         Ok(0) => {
                             // PTY closed (child exited)
-                            proxy_clone.send_event(TermEvent::Exit);
+                            proxy_clone.notify_exit();
                             break;
                         }
                         Ok(n) => {
-                            let mut term = term_clone.lock();
-                            processor.advance(&mut *term, &buf[..n]);
+                            {
+                                let mut term = term_clone.lock();
+                                processor.advance(&mut *term, &buf[..n]);
+                            }
+                            // Answer the terminal's queries (DA/DSR/CPR)
+                            let replies = proxy_clone.take_pending_writes();
+                            if !replies.is_empty() {
+                                let mut writer = writer_clone.lock();
+                                if let Err(e) =
+                                    writer.write_all(&replies).and_then(|_| writer.flush())
+                                {
+                                    tracing::warn!("Terminal {} PTY reply write failed: {}", id, e);
+                                }
+                            }
                             // Signal that content changed
-                            proxy_clone.send_event(TermEvent::Wakeup);
+                            proxy_clone.notify_wakeup();
                         }
                         Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {
                             continue;
@@ -230,7 +241,10 @@ impl TerminalView {
                             continue;
                         }
                         Err(e) => {
+                            // Treat a dead PTY like an exited child so the
+                            // render thread reports it to Emacs.
                             tracing::warn!("Terminal {} PTY read error: {}", id, e);
+                            proxy_clone.notify_exit();
                             break;
                         }
                     }
@@ -244,7 +258,7 @@ impl TerminalView {
             event_proxy,
             pty: pty_pair.master,
             _pty_child: pty_child,
-            pty_writer: Box::new(pty_write_file),
+            pty_writer,
             _reader_thread: Some(reader_thread),
             last_content: None,
             dirty: true,
@@ -257,13 +271,14 @@ impl TerminalView {
 
     /// Write input data to the terminal's PTY (keyboard input from user).
     pub fn write(&mut self, data: &[u8]) -> std::io::Result<()> {
-        self.pty_writer.write_all(data)?;
-        self.pty_writer.flush()
+        let mut writer = self.pty_writer.lock();
+        writer.write_all(data)?;
+        writer.flush()
     }
 
     /// Resize the terminal grid and PTY.
     pub fn resize(&mut self, cols: u16, rows: u16) {
-        let grid_size = TermGridSize::new(cols, rows);
+        let grid_size = CrosswordsSize::new(cols.max(1) as usize, rows.max(1) as usize);
         let mut term = self.term.lock();
         term.resize(grid_size);
         drop(term);
@@ -312,9 +327,8 @@ impl TerminalView {
     /// Get all visible text.
     pub fn get_visible_text(&self) -> String {
         let term = self.term.lock();
-        let grid = term.grid();
-        let cols = grid.columns();
-        let rows = grid.screen_lines();
+        let cols = term.columns();
+        let rows = term.screen_lines();
         super::content::extract_text(&*term, 0, 0, rows.saturating_sub(1), cols.saturating_sub(1))
     }
 }


### PR DESCRIPTION
This swaps neo-term's VT backend from alacritty_terminal to [rio-vt](https://crates.io/crates/rio-vt), the terminal core we extracted from [Rio](https://github.com/raphamorim/rio). portable-pty stays as the PTY layer, so the change is contained to the terminal module plus the two CellFlags imports in the renderer.

What changed:

- `view.rs`: `Term` becomes `rio_vt::crosswords::Crosswords`; the `TermGridSize` shim is gone since rio-vt's `CrosswordsSize` implements its `Dimensions` directly.
- `content.rs`: cells are resolved from rio-vt's packed cell + per-grid style table into the same `RenderCell` shape. `RenderCell.flags` is now rio-vt's `StyleFlags`, which has the same BOLD/ITALIC/UNDERLINE/STRIKEOUT bits the renderer checks.
- `colors.rs`: same conversion logic; only the named-color variants are spelled `Light*` instead of `Bright*`.
- One behavior fix that fell out of the migration: the old event listener dropped `PtyWrite` events, so the terminal never answered DA/DSR/CPR queries from apps running inside it. The reader thread now flushes those replies back to the PTY, which makes things like vim's terminal probing behave.

Why rio-vt: actively maintained, safe Rust, same alacritty lineage for grid/escape semantics, correct unicode width + grapheme clustering, and it parses shell integration (OSC 7/133) natively if neomacs wants prompt-aware features later. Inline image protocols (sixel/kitty/iterm2) are also decoded by the core behind a feature flag, which could pair nicely with the GPU pipeline here. Throughput is on par with or ahead of alacritty_terminal on parsing-heavy workloads; benchmarks against alacritty_terminal and vt100 live at https://github.com/raphamorim/rio-vt-benchmark.
