### PR TITLE
Fix #179 load streams and stale resize crossfades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,6 +3744,7 @@ name = "neomacs-gui-tests"
 version = "0.0.15"
 dependencies = [
  "getrandom 0.4.3",
+ "image",
  "serde_json",
 ]
 

--- a/neomacs-display-protocol/src/frame_glyphs.rs
+++ b/neomacs-display-protocol/src/frame_glyphs.rs
@@ -1014,10 +1014,68 @@ pub struct FrameGlyphBuffer {
     pub fringe_bitmaps: HashMap<u16, FringeBitmapData>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WindowPresentationDelta {
+    GeometryChanged,
+    BufferChanged,
+    ViewportScrolled { direction: ScrollDirection },
+    TextMetricsChanged,
+    Unchanged,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScrollDirection {
+    TowardBufferStart,
+    TowardBufferEnd,
+}
+
+impl ScrollDirection {
+    const fn render_sign(self) -> i32 {
+        match self {
+            Self::TowardBufferStart => -1,
+            Self::TowardBufferEnd => 1,
+        }
+    }
+}
+
+fn classify_window_presentation_delta(
+    prev: &WindowInfo,
+    curr: &WindowInfo,
+) -> WindowPresentationDelta {
+    let bounds_changed = (prev.bounds.x - curr.bounds.x).abs() > 2.0
+        || (prev.bounds.y - curr.bounds.y).abs() > 2.0
+        || (prev.bounds.width - curr.bounds.width).abs() > 2.0
+        || (prev.bounds.height - curr.bounds.height).abs() > 2.0;
+    if bounds_changed {
+        return WindowPresentationDelta::GeometryChanged;
+    }
+
+    if prev.buffer_id != 0 && curr.buffer_id != 0 && prev.buffer_id != curr.buffer_id {
+        return WindowPresentationDelta::BufferChanged;
+    }
+
+    if prev.window_start != curr.window_start {
+        let direction = if curr.window_start > prev.window_start {
+            ScrollDirection::TowardBufferEnd
+        } else {
+            ScrollDirection::TowardBufferStart
+        };
+        return WindowPresentationDelta::ViewportScrolled { direction };
+    }
+
+    if (prev.char_height - curr.char_height).abs() > 1.0 {
+        return WindowPresentationDelta::TextMetricsChanged;
+    }
+
+    WindowPresentationDelta::Unchanged
+}
+
 /// Derive a transition hint by comparing previous/current window metadata.
 ///
 /// This centralizes transition geometry decisions outside any concrete glyph
-/// buffer materialization path.
+/// buffer materialization path. Geometry deltas are deliberately non-animating:
+/// retained pixels from different presentation extents are not compatible
+/// transition inputs.
 pub fn derive_window_transition_hint(
     prev: &WindowInfo,
     curr: &WindowInfo,
@@ -1026,68 +1084,49 @@ pub fn derive_window_transition_hint(
         return None;
     }
 
-    if prev.buffer_id != 0 && curr.buffer_id != 0 && prev.buffer_id != curr.buffer_id {
-        return Some(WindowTransitionHint {
-            window_id: curr.window_id,
-            bounds: curr.bounds,
-            kind: WindowTransitionKind::Crossfade,
-            effect: None,
-            easing: None,
-        });
-    }
-
-    if prev.window_start != curr.window_start {
-        let top_chrome = curr.tab_line_height + curr.header_line_height;
-        let content_height = curr.bounds.height - curr.mode_line_height - top_chrome;
-        if content_height < 50.0 {
-            return None;
+    match classify_window_presentation_delta(prev, curr) {
+        WindowPresentationDelta::GeometryChanged | WindowPresentationDelta::Unchanged => None,
+        WindowPresentationDelta::BufferChanged | WindowPresentationDelta::TextMetricsChanged => {
+            Some(WindowTransitionHint {
+                window_id: curr.window_id,
+                bounds: curr.bounds,
+                kind: WindowTransitionKind::Crossfade,
+                effect: None,
+                easing: None,
+            })
         }
+        WindowPresentationDelta::ViewportScrolled { direction } => {
+            let top_chrome = curr.tab_line_height + curr.header_line_height;
+            let content_height = curr.bounds.height - curr.mode_line_height - top_chrome;
+            if content_height < 50.0 {
+                return None;
+            }
 
-        let direction = if curr.window_start > prev.window_start {
-            1
-        } else {
-            -1
-        };
+            let content_bounds = Rect::new(
+                curr.bounds.x,
+                curr.bounds.y + top_chrome,
+                curr.bounds.width,
+                content_height,
+            );
 
-        let content_bounds = Rect::new(
-            curr.bounds.x,
-            curr.bounds.y + top_chrome,
-            curr.bounds.width,
-            content_height,
-        );
+            // Keep legacy estimate shape to preserve current feel.
+            let cols = (curr.bounds.width / curr.char_height).max(1.0);
+            let char_delta = (curr.window_start - prev.window_start).unsigned_abs() as f32;
+            let est_lines = (char_delta / cols).max(1.0);
+            let scroll_px = (est_lines * curr.char_height).min(content_height);
 
-        // Keep legacy estimate shape to preserve current feel.
-        let cols = (curr.bounds.width / curr.char_height).max(1.0);
-        let char_delta = (curr.window_start - prev.window_start).unsigned_abs() as f32;
-        let est_lines = (char_delta / cols).max(1.0);
-        let scroll_px = (est_lines * curr.char_height).min(content_height);
-
-        return Some(WindowTransitionHint {
-            window_id: curr.window_id,
-            bounds: content_bounds,
-            kind: WindowTransitionKind::ScrollSlide {
-                direction,
-                scroll_distance: scroll_px,
-            },
-            effect: None,
-            easing: None,
-        });
+            Some(WindowTransitionHint {
+                window_id: curr.window_id,
+                bounds: content_bounds,
+                kind: WindowTransitionKind::ScrollSlide {
+                    direction: direction.render_sign(),
+                    scroll_distance: scroll_px,
+                },
+                effect: None,
+                easing: None,
+            })
+        }
     }
-
-    if (prev.char_height - curr.char_height).abs() > 1.0
-        || (prev.bounds.width - curr.bounds.width).abs() > 2.0
-        || (prev.bounds.height - curr.bounds.height).abs() > 2.0
-    {
-        return Some(WindowTransitionHint {
-            window_id: curr.window_id,
-            bounds: curr.bounds,
-            kind: WindowTransitionKind::Crossfade,
-            effect: None,
-            easing: None,
-        });
-    }
-
-    None
 }
 
 impl FrameGlyphBuffer {

--- a/neomacs-display-protocol/src/frame_glyphs_test.rs
+++ b/neomacs-display-protocol/src/frame_glyphs_test.rs
@@ -941,6 +941,14 @@ fn derive_transition_hint_buffer_switch_crossfade() {
 }
 
 #[test]
+fn derive_transition_hint_skips_window_geometry_change() {
+    let prev = make_window_info(1, 100, 10, Rect::new(0.0, 0.0, 664.0, 646.0));
+    let curr = make_window_info(1, 100, 10, Rect::new(0.0, 0.0, 1100.0, 760.0));
+
+    assert_eq!(derive_window_transition_hint(&prev, &curr), None);
+}
+
+#[test]
 fn derive_transition_hint_scroll_slide() {
     let prev = make_window_info(1, 100, 10, Rect::new(0.0, 0.0, 800.0, 600.0));
     let curr = make_window_info(1, 100, 42, Rect::new(0.0, 0.0, 800.0, 600.0));

--- a/neomacs-gui-tests/Cargo.toml
+++ b/neomacs-gui-tests/Cargo.toml
@@ -12,4 +12,5 @@ publish = false
 
 [dependencies]
 getrandom.workspace = true
+image.workspace = true
 serde_json = "1"

--- a/neomacs-gui-tests/fixtures/resize-presentation.el
+++ b/neomacs-gui-tests/fixtures/resize-presentation.el
@@ -1,0 +1,26 @@
+;;; resize-presentation.el --- Resize presentation GUI fixture -*- lexical-binding: t -*-
+
+;; A saturated mode-line makes a stale presentation observable without
+;; comparing platform-dependent fonts or antialiasing pixel-for-pixel.
+(set-face-attribute 'default nil :foreground "#000000" :background "#ffffff")
+(set-face-attribute 'mode-line nil :foreground "#ffffff" :background "#ff0000")
+(set-face-attribute 'mode-line-inactive nil :foreground "#ffffff" :background "#ff0000")
+
+(switch-to-buffer (get-buffer-create "*neomacs-resize-presentation*"))
+(erase-buffer)
+(dotimes (row 100)
+  (insert (format "%03d %s\n"
+                  row
+                  (make-string 180 (+ ?A (% row 26))))))
+(goto-char (point-min))
+(setq-local truncate-lines nil)
+(setq-local mode-line-format '(" RESIZE PRESENTATION "))
+
+(let ((ready-path (getenv "NEOMACS_GUI_RESIZE_READY")))
+  (when ready-path
+    (make-directory (file-name-directory ready-path) t)
+    (with-temp-file ready-path
+      (insert "ready\n"))))
+
+;; Keep the process bounded if its Rust test driver exits unexpectedly.
+(run-at-time 45 nil (lambda () (kill-emacs 2)))

--- a/neomacs-gui-tests/tests/resize_presentation.rs
+++ b/neomacs-gui-tests/tests/resize_presentation.rs
@@ -1,0 +1,305 @@
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use neomacs_gui_tests::{DisplayHarness, GuiArtifactSet, GuiBackend};
+
+#[test]
+fn real_gui_resize_does_not_ghost_the_previous_presentation() {
+    if !x11_backend_requested() {
+        return;
+    }
+
+    require_tool("xdotool");
+    require_tool("import");
+
+    let workspace_root = workspace_root();
+    let binary = neomacs_binary(&workspace_root);
+    assert!(
+        binary.exists(),
+        "build {binary:?} before running the resize presentation test"
+    );
+
+    let backend = GuiBackend::LinuxX11;
+    let artifact_root = workspace_root.join("target/neomacs-gui-tests");
+    let session = DisplayHarness::for_backend(backend)
+        .start_session(&artifact_root)
+        .expect("display session should start");
+    let artifacts = GuiArtifactSet::new(&artifact_root, backend, "resize-presentation");
+    std::fs::create_dir_all(
+        artifacts
+            .png
+            .parent()
+            .expect("resize artifact should have a parent"),
+    )
+    .expect("resize artifact directory");
+    let before_png = artifacts
+        .png
+        .with_file_name("resize-presentation.before.png");
+    let ready_path = artifacts.png.with_file_name("resize-presentation.ready");
+    for path in [
+        &before_png,
+        &artifacts.png,
+        &artifacts.neomacs_log,
+        &ready_path,
+    ] {
+        let _ = std::fs::remove_file(path);
+    }
+
+    let stdout = std::fs::File::create(&artifacts.stdout).expect("create stdout artifact");
+    let stderr = std::fs::File::create(&artifacts.stderr).expect("create stderr artifact");
+    let mut command = Command::new(binary);
+    command
+        .args([
+            "-Q",
+            "-l",
+            workspace_root
+                .join("neomacs-gui-tests/fixtures/resize-presentation.el")
+                .to_str()
+                .expect("fixture path should be UTF-8"),
+        ])
+        .envs(session.env().iter().map(|(key, value)| (key, value)))
+        .env("WINIT_UNIX_BACKEND", "x11")
+        .env("NEOMACS_LOG_FILE", &artifacts.neomacs_log)
+        .env("NEOMACS_DUMP_FRAME_GLYPHS", "1")
+        .env("NEOMACS_GUI_RESIZE_READY", &ready_path)
+        .env("RUST_LOG", "info")
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+    let child = command.spawn().expect("start Neomacs resize fixture");
+    let pid = child.id();
+    let mut child = KillOnDrop(Some(child));
+
+    let window = wait_for_x11_window(pid, session.env(), Duration::from_secs(12));
+    run_x11_tool(session.env(), "xdotool", ["windowmap", "--sync", &window]);
+    wait_for_path(&ready_path, Duration::from_secs(12));
+    let (before, old_mode_rows) =
+        wait_for_red_mode_line(session.env(), &window, &before_png, Duration::from_secs(12));
+
+    let new_width = 1100_u32;
+    let new_height = 760_u32;
+    run_x11_tool(
+        session.env(),
+        "xdotool",
+        [
+            "windowsize",
+            "--sync",
+            &window,
+            &new_width.to_string(),
+            &new_height.to_string(),
+        ],
+    );
+    wait_for_log(
+        &artifacts.neomacs_log,
+        &format!("size={new_width}x{new_height}"),
+        Duration::from_secs(30),
+    );
+
+    // Allow one ordinary 60 Hz present after the correctly-sized display
+    // matrix arrives, while remaining well inside the historical 200 ms
+    // resize crossfade that exposed the stale presentation.
+    thread::sleep(Duration::from_millis(50));
+    capture_x11_window(session.env(), &window, &artifacts.png);
+
+    let resized = image::open(&artifacts.png)
+        .expect("decode resized window capture")
+        .to_rgba8();
+    assert_eq!(resized.dimensions(), (new_width, new_height));
+    let old_band_red_pixels = old_mode_rows
+        .iter()
+        .filter(|&&y| y < resized.height())
+        .flat_map(|&y| (0..before.width().min(resized.width())).map(move |x| (x, y)))
+        .filter(|&(x, y)| is_red_tinted(resized.get_pixel(x, y).0))
+        .count();
+
+    // The only red pixels in a current presentation belong to its new mode
+    // line near the bottom of the enlarged window. Red at the old mode-line
+    // rows proves that pixels from the old-size presentation are still being
+    // composed over the current one.
+    assert_eq!(
+        old_band_red_pixels,
+        0,
+        "resized GUI retained {old_band_red_pixels} red pixels at the old mode-line rows {:?}; \
+         before={} resized={} log={}",
+        old_mode_rows,
+        before_png.display(),
+        artifacts.png.display(),
+        artifacts.neomacs_log.display(),
+    );
+
+    if let Some(mut process) = child.0.take() {
+        let _ = process.kill();
+        let _ = process.wait();
+    }
+}
+
+fn x11_backend_requested() -> bool {
+    match std::env::var("NEOMACS_GUI_TEST_BACKEND").ok().as_deref() {
+        None => {
+            eprintln!("skipping resize presentation test; set NEOMACS_GUI_TEST_BACKEND=x11");
+            false
+        }
+        Some("x11" | "linux-x11") => true,
+        Some("wayland" | "linux-wayland" | "macos" | "windows") => {
+            eprintln!("skipping resize presentation test; native window capture is X11-only");
+            false
+        }
+        Some(other) => panic!("unsupported NEOMACS_GUI_TEST_BACKEND={other:?}"),
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("test crate should live below workspace root")
+        .to_path_buf()
+}
+
+fn neomacs_binary(workspace_root: &Path) -> PathBuf {
+    std::env::var_os("NEOMACS_GUI_TEST_BINARY")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root.join("target/release/neomacs"))
+}
+
+struct KillOnDrop(Option<Child>);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.0.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn require_tool(program: &str) {
+    assert!(
+        Command::new(program).arg("-version").output().is_ok(),
+        "{program} is required for the X11 resize presentation test"
+    );
+}
+
+fn wait_for_x11_window(pid: u32, display_env: &[(String, String)], timeout: Duration) -> String {
+    let started = Instant::now();
+    loop {
+        let output = Command::new("xdotool")
+            .args(["search", "--pid", &pid.to_string()])
+            .envs(display_env.iter().map(|(key, value)| (key, value)))
+            .output()
+            .expect("run xdotool search");
+        if output.status.success()
+            && let Some(window) = String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .rfind(|line| !line.is_empty())
+        {
+            return window.to_string();
+        }
+        assert!(
+            started.elapsed() < timeout,
+            "Neomacs PID {pid} did not create an X11 window within {timeout:?}"
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn wait_for_log(path: &Path, needle: &str, timeout: Duration) {
+    let started = Instant::now();
+    loop {
+        let contents = std::fs::read_to_string(path).unwrap_or_default();
+        if contents.contains(needle) {
+            return;
+        }
+        assert!(
+            started.elapsed() < timeout,
+            "{} did not contain {needle:?} within {timeout:?}; tail:\n{}",
+            path.display(),
+            contents
+                .lines()
+                .rev()
+                .take(30)
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_path(path: &Path, timeout: Duration) {
+    let started = Instant::now();
+    while !path.exists() {
+        assert!(
+            started.elapsed() < timeout,
+            "{} was not created within {timeout:?}",
+            path.display()
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn run_x11_tool<const N: usize>(display_env: &[(String, String)], program: &str, args: [&str; N]) {
+    let output = Command::new(program)
+        .args(args)
+        .envs(display_env.iter().map(|(key, value)| (key, value)))
+        .output()
+        .unwrap_or_else(|error| panic!("run {program}: {error}"));
+    assert!(
+        output.status.success(),
+        "{program} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn capture_x11_window(display_env: &[(String, String)], window: &str, output_path: &Path) {
+    let output = Command::new("import")
+        .args(["-window", window])
+        .arg(output_path)
+        .envs(display_env.iter().map(|(key, value)| (key, value)))
+        .output()
+        .expect("capture X11 window");
+    assert!(
+        output.status.success(),
+        "window capture failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn wait_for_red_mode_line(
+    display_env: &[(String, String)],
+    window: &str,
+    output_path: &Path,
+    timeout: Duration,
+) -> (image::RgbaImage, Vec<u32>) {
+    let started = Instant::now();
+    loop {
+        capture_x11_window(display_env, window, output_path);
+        let image = image::open(output_path)
+            .expect("decode pre-resize window capture")
+            .to_rgba8();
+        let rows = red_tinted_rows(&image);
+        if !rows.is_empty() {
+            return (image, rows);
+        }
+        assert!(
+            started.elapsed() < timeout,
+            "fixture did not visibly present its saturated red mode line in {} within {timeout:?}",
+            output_path.display()
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn red_tinted_rows(image: &image::RgbaImage) -> Vec<u32> {
+    (0..image.height())
+        .filter(|&y| {
+            let red_pixels = (0..image.width())
+                .filter(|&x| is_red_tinted(image.get_pixel(x, y).0))
+                .count();
+            red_pixels > image.width() as usize / 2
+        })
+        .collect()
+}
+
+fn is_red_tinted([red, green, blue, _alpha]: [u8; 4]) -> bool {
+    red >= 180 && red.saturating_sub(green) >= 10 && red.saturating_sub(blue) >= 10
+}

--- a/neovm-core/src/emacs_core/eval.rs
+++ b/neovm-core/src/emacs_core/eval.rs
@@ -983,6 +983,11 @@ fn hidden_internal_interpreter_environment_symbol() -> SymId {
     *HIDDEN_SYMBOL.get_or_init(|| intern_uninterned("internal-interpreter-environment"))
 }
 
+fn hidden_load_read_stream_token() -> LoadReadStreamToken {
+    static HIDDEN_SYMBOL: OnceLock<LoadReadStreamToken> = OnceLock::new();
+    *HIDDEN_SYMBOL.get_or_init(|| LoadReadStreamToken(intern_uninterned("get-file-char")))
+}
+
 fn default_directory_symbol() -> SymId {
     static SYMBOL: OnceLock<SymId> = OnceLock::new();
     *SYMBOL.get_or_init(|| intern("default-directory"))
@@ -1085,6 +1090,7 @@ fn cons_head_symbol_id(value: &Value) -> Option<SymId> {
 
 struct CoreEvalSymbols {
     internal_interpreter_environment_symbol: SymId,
+    load_read_stream_token: LoadReadStreamToken,
     compiler_function_overrides_symbol: SymId,
     quit_flag_symbol: SymId,
     inhibit_quit_symbol: SymId,
@@ -1100,6 +1106,7 @@ fn install_core_eval_symbols(obarray: &mut Obarray, reset_runtime_values: bool) 
     let internal_interpreter_environment_symbol = hidden_internal_interpreter_environment_symbol();
     obarray.set_symbol_value_id(internal_interpreter_environment_symbol, Value::NIL);
     obarray.make_special_id(internal_interpreter_environment_symbol);
+    let load_read_stream_token = hidden_load_read_stream_token();
 
     let compiler_function_overrides_symbol = internal_compiler_function_overrides_sym();
 
@@ -1128,6 +1135,7 @@ fn install_core_eval_symbols(obarray: &mut Obarray, reset_runtime_values: bool) 
 
     CoreEvalSymbols {
         internal_interpreter_environment_symbol,
+        load_read_stream_token,
         compiler_function_overrides_symbol,
         quit_flag_symbol,
         inhibit_quit_symbol,
@@ -1785,21 +1793,30 @@ pub(crate) struct BcFrame {
 /// the eval thread" seam — no diagnostics-specific type enters `neovm-core`.
 pub type EvalThreadTask = Box<dyn FnOnce(&mut Context) + Send + 'static>;
 
-/// Symbol `standard-input` is bound to during a `load`/`eval-buffer`
-/// readevalloop so `(read)` reads from the *same* stream the loader is
-/// consuming.  This mirrors GNU's `specbind (Qstandard_input, readcharfun)`
-/// (lread.c `readevalloop`), where `readcharfun` for a file load is the
-/// `get-file-char` reader over the currently-loading file.  When
-/// [`builtin_read`](super::reader::builtin_read) sees this symbol as its
-/// stream it reads the next top-level form from the active
-/// [`Context::load_read_cursors`] entry, advancing the shared cursor so the
-/// loader resumes *after* the consumed form (chemacs2's profile probe relies
-/// on this).
-pub(crate) const LOAD_READ_STREAM_SYMBOL: &str = "internal--load-read-stream";
+/// Opaque identity bound to `standard-input` during a `load`/`eval-buffer`
+/// readevalloop so `(read)` consumes the same stream as the loader.
+///
+/// GNU removes `Qget_file_char` from the obarray and recognizes it with
+/// `BASE_EQ`, so Lisp cannot manufacture the internal stream by interning its
+/// printed name.  Keep the `SymId` private behind a distinct Rust type for the
+/// same reason: call sites can bind or recognize this token, but cannot
+/// accidentally compare an arbitrary stream by symbol name.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct LoadReadStreamToken(SymId);
+
+impl LoadReadStreamToken {
+    pub(crate) fn as_lisp_value(self) -> Value {
+        Value::from_sym_id(self.0)
+    }
+
+    pub(crate) fn identifies(self, symbol: SymId) -> bool {
+        self.0 == symbol
+    }
+}
 
 /// One active load-read cursor: the heap `LispString` being read plus a byte
 /// offset into it that BOTH the readevalloop and `(read)` advance.  See
-/// [`LOAD_READ_STREAM_SYMBOL`] and [`Context::load_read_cursors`].
+/// [`LoadReadStreamToken`] and [`Context::load_read_cursors`].
 pub(crate) struct LoadReadCursor {
     /// Heap `LispString` Value being read.  Rooted for the cursor's lifetime
     /// via `push_specpdl_root` when the cursor is pushed.
@@ -1882,6 +1899,8 @@ pub struct Context {
     pub(crate) require_stack: Vec<SymId>,
     /// Files currently being loaded (mirrors `Vloads_in_progress` in lread.c).
     pub(crate) loads_in_progress: Vec<crate::heap_types::LispString>,
+    /// Uninterned, identity-only Lisp token for the active load stream.
+    pub(crate) load_read_stream_token: LoadReadStreamToken,
     /// Stack of active load-read cursors (nested loads).  Each entry pairs the
     /// heap `LispString` being read with a byte offset that BOTH the
     /// readevalloop AND `(read STREAM=standard-input)` advance — mirroring GNU's
@@ -5390,6 +5409,7 @@ impl Context {
             lexenv: Value::NIL,
             internal_interpreter_environment_symbol: core_eval_symbols
                 .internal_interpreter_environment_symbol,
+            load_read_stream_token: core_eval_symbols.load_read_stream_token,
             quit_flag_symbol: core_eval_symbols.quit_flag_symbol,
             inhibit_quit_symbol: core_eval_symbols.inhibit_quit_symbol,
             throw_on_input_symbol: core_eval_symbols.throw_on_input_symbol,
@@ -5583,6 +5603,7 @@ impl Context {
             lexenv,
             internal_interpreter_environment_symbol: core_eval_symbols
                 .internal_interpreter_environment_symbol,
+            load_read_stream_token: core_eval_symbols.load_read_stream_token,
             quit_flag_symbol: core_eval_symbols.quit_flag_symbol,
             inhibit_quit_symbol: core_eval_symbols.inhibit_quit_symbol,
             throw_on_input_symbol: core_eval_symbols.throw_on_input_symbol,

--- a/neovm-core/src/emacs_core/load.rs
+++ b/neovm-core/src/emacs_core/load.rs
@@ -1814,7 +1814,7 @@ fn streaming_readevalloop_lisp_source(
     eval.push_specpdl_root(eof_source);
     eval.specbind(
         intern("standard-input"),
-        Value::symbol(super::eval::LOAD_READ_STREAM_SYMBOL),
+        eval.load_read_stream_token.as_lisp_value(),
     );
     eval.load_read_cursors.push(super::eval::LoadReadCursor {
         source: content_value,
@@ -1885,10 +1885,7 @@ fn streaming_readevalloop_lisp_source(
             let (form, next_pos) = match read_hook {
                 Some(hook) => {
                     let hooked = eval
-                        .funcall_general(
-                            hook,
-                            vec![Value::symbol(super::eval::LOAD_READ_STREAM_SYMBOL)],
-                        )
+                        .funcall_general(hook, vec![eval.load_read_stream_token.as_lisp_value()])
                         .map_err(map_flow)?;
                     let advanced = eval
                         .load_read_cursors

--- a/neovm-core/src/emacs_core/lread.rs
+++ b/neovm-core/src/emacs_core/lread.rs
@@ -133,7 +133,7 @@ fn eval_forms_from_lisp_source_streaming(
     eval.push_specpdl_root(source_value);
     eval.specbind(
         intern("standard-input"),
-        Value::symbol(super::eval::LOAD_READ_STREAM_SYMBOL),
+        eval.load_read_stream_token.as_lisp_value(),
     );
     eval.load_read_cursors.push(super::eval::LoadReadCursor {
         source: source_value,

--- a/neovm-core/src/emacs_core/reader.rs
+++ b/neovm-core/src/emacs_core/reader.rs
@@ -2,7 +2,9 @@
 //! format-spec, and various interactive-input stubs.
 
 use super::error::{EvalResult, Flow, signal};
-use super::intern::{SymId, intern, resolve_sym};
+#[cfg(test)]
+use super::intern::resolve_sym;
+use super::intern::{SymId, intern};
 use super::minibuffer::{MinibufferEntryRejection, RecursiveMinibufferPolicy};
 use crate::emacs_core::error::LispCondition;
 use crate::emacs_core::error::{expect_args, expect_max_args, expect_min_args};
@@ -896,7 +898,7 @@ pub(crate) fn end_of_file_error_for_source(source: Option<Value>) -> Flow {
 
 /// Read the next top-level form from the active load-read cursor — the stream
 /// `standard-input` is bound to during a `load`/`eval-buffer` readevalloop
-/// (see [`crate::emacs_core::eval::LOAD_READ_STREAM_SYMBOL`]).  Advancing the
+/// (see [`crate::emacs_core::eval::LoadReadStreamToken`]).  Advancing the
 /// shared byte cursor makes the enclosing loop resume *after* this form,
 /// exactly like GNU's shared `readcharfun` (lread.c `readevalloop`): a file
 /// that calls `(read)` mid-load consumes its next top-level form.
@@ -1151,6 +1153,45 @@ pub fn builtin_read(ctx: &mut crate::emacs_core::eval::Context, args: Vec<Value>
     builtin_read_impl(ctx, args, false)
 }
 
+/// Closed dispatch plan for Lisp reader streams after nil has resolved through
+/// `standard-input`.  Keeping the opaque load token as its own variant makes
+/// that privileged route identity-only; an ordinary symbol can never reach it
+/// merely because its printed name happens to match.
+#[derive(Clone, Copy, Debug)]
+enum ResolvedReadStream {
+    Empty,
+    String(Value),
+    Marker(Value),
+    Buffer(crate::buffer::BufferId),
+    ActiveLoadCursor,
+    Minibuffer,
+    FunctionSymbol(Value),
+    Unsupported(Value),
+}
+
+impl ResolvedReadStream {
+    fn classify(stream: Value, load_token: crate::emacs_core::eval::LoadReadStreamToken) -> Self {
+        match stream.kind() {
+            ValueKind::Nil => Self::Empty,
+            ValueKind::T => Self::Minibuffer,
+            ValueKind::String => Self::String(stream),
+            ValueKind::Symbol(symbol) if load_token.identifies(symbol) => Self::ActiveLoadCursor,
+            ValueKind::Symbol(_) => Self::FunctionSymbol(stream),
+            ValueKind::Veclike(VecLikeType::Marker) => Self::Marker(stream),
+            ValueKind::Veclike(VecLikeType::Buffer) => {
+                Self::Buffer(stream.as_buffer_id().expect("buffer value kind"))
+            }
+            ValueKind::Fixnum(_)
+            | ValueKind::Cons
+            | ValueKind::Float
+            | ValueKind::Subr(_)
+            | ValueKind::Veclike(_)
+            | ValueKind::Unbound
+            | ValueKind::Unknown => Self::Unsupported(stream),
+        }
+    }
+}
+
 /// Shared implementation for `read` and `read-positioning-symbols`.
 /// When `locate_syms` is true, every interned symbol (except nil) is
 /// wrapped in a `symbol-with-pos` object carrying its source byte offset.
@@ -1170,17 +1211,16 @@ pub fn builtin_read_impl(
         args[0]
     };
 
-    if stream.is_nil() {
-        // In batch/non-interactive runs, stdin-backed read signals EOF.
-        return Err(signal(
-            LispCondition::EndOfFile,
-            vec![Value::string("End of file during parsing")],
-        ));
-    }
-
     let shorthands = current_read_symbol_shorthands(ctx);
-    match stream.kind() {
-        ValueKind::String => {
+    match ResolvedReadStream::classify(stream, ctx.load_read_stream_token) {
+        ResolvedReadStream::Empty => {
+            // In batch/non-interactive runs, stdin-backed read signals EOF.
+            Err(signal(
+                LispCondition::EndOfFile,
+                vec![Value::string("End of file during parsing")],
+            ))
+        }
+        ResolvedReadStream::String(stream) => {
             // Read from string
             let result = read_from_string_impl_inner(
                 &ctx.obarray,
@@ -1198,7 +1238,7 @@ pub fn builtin_read_impl(
                 _ => Ok(result),
             }
         }
-        ValueKind::Veclike(VecLikeType::Marker) => {
+        ResolvedReadStream::Marker(stream) => {
             let Some((Some(buf_id), Some(position), _)) =
                 super::marker::marker_logical_fields(&stream)
             else {
@@ -1257,8 +1297,7 @@ pub fn builtin_read_impl(
             ctx.obarray_mut().materialize_read_symbols(value);
             Ok(value)
         }
-        ValueKind::Veclike(VecLikeType::Buffer) => {
-            let buf_id = stream.as_buffer_id().unwrap();
+        ResolvedReadStream::Buffer(buf_id) => {
             let (maybe_value, new_pt) = {
                 let buf = ctx
                     .buffers
@@ -1292,16 +1331,11 @@ pub fn builtin_read_impl(
             ctx.obarray_mut().materialize_read_symbols(value);
             Ok(value)
         }
-        ValueKind::Symbol(id)
-            if resolve_sym(id) == crate::emacs_core::eval::LOAD_READ_STREAM_SYMBOL =>
-        {
-            read_from_active_load_cursor(ctx, locate_syms)
+        ResolvedReadStream::ActiveLoadCursor => read_from_active_load_cursor(ctx, locate_syms),
+        ResolvedReadStream::FunctionSymbol(stream) => {
+            Err(signal(LispCondition::VoidFunction, vec![stream]))
         }
-        ValueKind::Symbol(id) => Err(signal(
-            LispCondition::VoidFunction,
-            vec![Value::symbol(resolve_sym(id))],
-        )),
-        ValueKind::T => {
+        ResolvedReadStream::Minibuffer => {
             // GNU `Fread` (lread.c): a `t` stream -- including the batch default
             // `standard-input` = t reached by `(read)` with no argument -- maps
             // to `(read-minibuffer "Lisp expression: ")`: read one line (from the
@@ -1326,7 +1360,7 @@ pub fn builtin_read_impl(
                 _ => Ok(result),
             }
         }
-        _ => {
+        ResolvedReadStream::Unsupported(stream) => {
             // Unsupported stream source type for read-char function protocol.
             Err(signal(LispCondition::InvalidFunction, vec![stream]))
         }

--- a/neovm-oracle-tests/src/read/stream_and_standard_input_semantics.rs
+++ b/neovm-oracle-tests/src/read/stream_and_standard_input_semantics.rs
@@ -125,6 +125,26 @@ fn oracle_prop_read_end_of_file_boundaries() {
     assert_oracle_parity(form);
 }
 
+#[test]
+fn oracle_prop_internal_load_stream_name_is_not_forgeable() {
+    return_if_neovm_enable_oracle_proptest_not_set!();
+
+    // GNU removes its internal `get-file-char` symbol from the obarray and
+    // recognizes it by object identity.  Ordinary interned symbols bearing
+    // either GNU's printed name or neomacs's former sentinel name must remain
+    // ordinary function streams, not acquire access to loader state.
+    let form = r##"
+(mapcar
+ (lambda (stream)
+   (let ((standard-input stream))
+     (condition-case e
+         (list 'value (read))
+       (error (list 'error (car e) (cdr e))))))
+ '(internal--load-read-stream get-file-char))
+"##;
+    assert_oracle_parity(form);
+}
+
 // ---------------------------------------------------------------------------
 // read-from-string START/END and the returned index
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- make the internal load-reader stream an identity-only Lisp token instead of a forgeable interned sentinel
- preserve GNU Emacs `standard-input` semantics while loading and evaluating forms
- classify window presentation deltas with exhaustive Rust enums
- suppress transitions when window geometry changes, because retained pixels from different extents are incompatible
- add GNU oracle coverage for the load-stream identity contract and a real X11 pixel regression for resize ghosting

## Root cause

Issue #179 exposed that Neomacs represented its private load-reader stream with an ordinary interned symbol. User Lisp could forge that name, and reader dispatch could confuse it with the active load stream instead of following GNU Emacs' identity-only internal stream behavior.

The resize artifact had a separate presentation-layer cause: width or height changes requested a 200 ms crossfade from the previous frame. That retained old-size pixels and repeatedly restarted the blend during configure events, leaving stale content visible while resizing.

## Impact

`(read nil)` and nested reads during file loading now follow the active load stream without exposing a forgeable sentinel. GUI resizes present the new geometry directly; buffer switches, scrolling, and text-metric transitions keep their existing typed behavior.

## Validation

- GNU oracle parity: `oracle_prop_internal_load_stream_name_is_not_forgeable`
- display protocol: 630/630 tests passed
- focused transition tests: 4/4 passed
- real X11 resize regression: 664x646 to 1100x760, zero stale mode-line pixels after the matching new-size presentation
- GUI harness: 15/15 tests passed
- `cargo fmt --all -- --check`
- repository pre-push `cargo check`

Closes #179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved window transitions so resizing no longer triggers inappropriate animation effects.
  - Preserved smooth scrolling and crossfades for content and text changes.
  - Corrected stream handling during Lisp file loading and evaluation.
  - Ensured ordinary symbols used as input streams retain their expected behavior.

- **Tests**
  - Added coverage for window resizing, display artifacts, transition behavior, and input-stream compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->