### PR TITLE
Fix mode-line face realization

### DIFF
--- a/neomacs-display-protocol/src/face.rs
+++ b/neomacs-display-protocol/src/face.rs
@@ -266,39 +266,6 @@ impl BasicFaceId {
         self.into()
     }
 
-    /// Return the GNU Lisp face realized into this cache slot.
-    ///
-    /// Cache-role names and Lisp face names are deliberately distinct for the
-    /// active mode/header slots: GNU's `MODE_LINE_FACE_ID` realizes
-    /// `mode-line`, while only the inactive slot realizes
-    /// `mode-line-inactive` (likewise for `header-line`).  Keep this mapping
-    /// exhaustive so adding a cache role cannot silently select a made-up Lisp
-    /// face name.
-    pub const fn lisp_face_name(self) -> &'static str {
-        match self {
-            Self::Default => "default",
-            Self::ModeLineActive => "mode-line",
-            Self::ModeLineInactive => "mode-line-inactive",
-            Self::ToolBar => "tool-bar",
-            Self::Fringe => "fringe",
-            Self::HeaderLineActive => "header-line",
-            Self::HeaderLineInactive => "header-line-inactive",
-            Self::ScrollBar => "scroll-bar",
-            Self::Border => "border",
-            Self::Cursor => "cursor",
-            Self::Mouse => "mouse",
-            Self::Menu => "menu",
-            Self::VerticalBorder => "vertical-border",
-            Self::WindowDivider => "window-divider",
-            Self::WindowDividerFirstPixel => "window-divider-first-pixel",
-            Self::WindowDividerLastPixel => "window-divider-last-pixel",
-            Self::InternalBorder => "internal-border",
-            Self::ChildFrameBorder => "child-frame-border",
-            Self::TabBar => "tab-bar",
-            Self::TabLine => "tab-line",
-        }
-    }
-
     /// Return GNU's fixed `enum face_id` value.
     pub fn gnu_code(self) -> u32 {
         self.into()

--- a/neomacs-display-protocol/src/face_test.rs
+++ b/neomacs-display-protocol/src/face_test.rs
@@ -60,25 +60,6 @@ fn basic_face_ids_preserve_gnu_slots_and_names() {
 }
 
 #[test]
-fn basic_face_cache_roles_map_to_gnu_lisp_faces() {
-    assert_eq!(BasicFaceId::ModeLineActive.lisp_face_name(), "mode-line");
-    assert_eq!(
-        BasicFaceId::ModeLineInactive.lisp_face_name(),
-        "mode-line-inactive"
-    );
-    assert_eq!(
-        BasicFaceId::HeaderLineActive.lisp_face_name(),
-        "header-line"
-    );
-    assert_eq!(
-        BasicFaceId::HeaderLineInactive.lisp_face_name(),
-        "header-line-inactive"
-    );
-    assert_eq!(BasicFaceId::TabBar.lisp_face_name(), "tab-bar");
-    assert_eq!(BasicFaceId::TabLine.lisp_face_name(), "tab-line");
-}
-
-#[test]
 fn underline_style_codes_match_gnu_face_underline_type() {
     let styles = [
         (UnderlineStyle::None, 0),

--- a/neomacs-layout-engine/src/engine_test.rs
+++ b/neomacs-layout-engine/src/engine_test.rs
@@ -38,7 +38,7 @@ use neomacs_display_protocol::cursor::CursorBarWidth;
 use neomacs_display_protocol::frame_chrome::{FrameChromeContent, FrameChromeKind};
 use neomacs_display_protocol::frame_glyphs::{CursorKind, DisplaySlotId, FrameGlyph, GlyphRowRole};
 use neomacs_display_protocol::glyph_matrix::{
-    Glyph, GlyphArea, GlyphProvenance, GlyphRow, GlyphStringBufferRange, GlyphType,
+    Glyph, GlyphArea, GlyphProvenance, GlyphRow, GlyphStringBufferRange, GlyphType, MatrixRow,
     NO_BUFFER_POSITION_CHARPOS,
 };
 use neomacs_display_protocol::types::FaceId;
@@ -26478,6 +26478,262 @@ fn p52_selected_window_change_re_evaluates_both_windows_mode_lines() {
         2,
         "a selected-window change must re-evaluate BOTH windows' mode lines \
          (the active/inactive face flips on both)"
+    );
+}
+
+/// GNU realizes the selected window's mode-line cache slot from
+/// `mode-line-active`, not from its `mode-line` parent
+/// (`realize_basic_faces`, xfaces.c; `display_mode_lines`, xdisp.c).  This is
+/// observable even when both rows carry the right numeric basic-face ids: the
+/// selected row must receive the active face's explicit decoration and font
+/// overrides before its height is measured.
+#[test]
+fn selected_mode_line_realizes_active_face_and_matches_inactive_metrics() {
+    use neomacs_display_protocol::face::FaceAttributes;
+    use neovm_core::face::{Color, Face, FaceHeight};
+
+    let (mut eval, frame_id, buf_id, selected) = incr_editing_frame("body\n", 800, 240);
+    {
+        let buffer = eval.buffer_manager_mut().get_mut(buf_id).expect("buffer");
+        buffer.set_buffer_local("mode-line-format", Value::string("ML"));
+    }
+
+    // Deliberately make the parent visibly and metrically incompatible with
+    // both leaf faces.  This is the minimal version of the user's theme:
+    // selecting the parent leaks an overline and shrinks only the active row.
+    {
+        let table = eval.face_table_mut();
+
+        let mut parent = Face::new("mode-line");
+        parent.foreground = Some(Color::rgb(0xff, 0x00, 0x00));
+        parent.height = Some(FaceHeight::Absolute(80));
+        parent.overline = Some(true);
+        table.define("mode-line", parent);
+
+        let mut active = Face::new("mode-line-active");
+        active.inherit = Some(Value::symbol("mode-line"));
+        active.foreground = Some(Color::rgb(0xff, 0xff, 0xff));
+        active.height = Some(FaceHeight::Absolute(140));
+        active.overline = Some(false);
+        table.define("mode-line-active", active);
+
+        let mut inactive = Face::new("mode-line-inactive");
+        inactive.inherit = Some(Value::symbol("mode-line"));
+        inactive.foreground = Some(Color::rgb(0x80, 0x80, 0x80));
+        inactive.height = Some(FaceHeight::Absolute(140));
+        inactive.overline = Some(false);
+        table.define("mode-line-inactive", inactive);
+    }
+
+    let inactive = eval
+        .frame_manager_mut()
+        .split_window(
+            frame_id,
+            selected,
+            neovm_core::window::SplitDirection::Horizontal,
+            buf_id,
+            None,
+            neovm_core::window::SplitPlacement::AfterTarget,
+        )
+        .expect("split window");
+    {
+        let frames = eval.frame_manager_mut();
+        frames
+            .get_mut(frame_id)
+            .expect("frame")
+            .set_window_system(Some(Value::symbol("neo")));
+        for window_id in [selected, inactive] {
+            frames.set_window_parameter(
+                window_id,
+                Value::symbol("mode-line-format"),
+                Value::string("ML"),
+            );
+        }
+    }
+
+    let mut engine = LayoutEngine::new();
+    engine.layout_frame_rust(&mut eval, frame_id);
+    let state = engine
+        .last_frame_display_state
+        .as_ref()
+        .expect("frame display state");
+
+    let mode_line = |window_id: neovm_core::window::WindowId| {
+        let entry = state
+            .window_matrices
+            .iter()
+            .find(|entry| entry.window_id.get() == window_id.0 as i64)
+            .unwrap_or_else(|| panic!("window {window_id:?} matrix"));
+        entry
+            .matrix
+            .rows
+            .iter()
+            .find(|row| row.enabled && row.role == GlyphRowRole::ModeLine)
+            .unwrap_or_else(|| {
+                panic!(
+                    "window {window_id:?} mode-line row; selected={} rows={:?}",
+                    entry.selected,
+                    entry
+                        .matrix
+                        .rows
+                        .iter()
+                        .map(|row| (row.enabled, row.role, row.height_px))
+                        .collect::<Vec<_>>()
+                )
+            })
+    };
+    let active_row = mode_line(selected);
+    let inactive_row = mode_line(inactive);
+    let active_glyph = active_row.glyphs[GlyphArea::Text.index()]
+        .iter()
+        .find(|glyph| matches!(glyph.glyph_type, GlyphType::Char { ch: 'M' }))
+        .expect("active mode-line text glyph");
+    let active_face = state
+        .faces
+        .get(&active_glyph.face_id)
+        .expect("published active mode-line face");
+
+    assert_eq!(
+        active_face.lisp_name.as_deref(),
+        Some("mode-line-active"),
+        "the selected row must realize GNU's mode-line-active face"
+    );
+    assert!(
+        !active_face.attributes.contains(FaceAttributes::OVERLINE),
+        "mode-line-active's explicit nil must suppress its parent's overline"
+    );
+    assert_eq!(
+        active_row.height_px, inactive_row.height_px,
+        "equal active/inactive face heights must produce equal mode-line rows"
+    );
+}
+
+/// GNU `lookup_named_face` starts an inherited basic face from the frame's
+/// unremapped default face (xfaces.c), so buffer-local `default` scaling affects
+/// body text but not a mode line that has no direct remapping.  Treemacs relies
+/// on exactly this separation: `treemacs-text-scale` remaps only `default`.
+#[test]
+fn buffer_default_text_scale_does_not_shrink_inactive_mode_line() {
+    use neovm_core::face::{Face, FaceHeight};
+
+    let (mut eval, frame_id, main_buffer, selected) = incr_editing_frame("main body\n", 800, 240);
+    realize_test_gui_frame(&mut eval, frame_id);
+    let side_buffer = eval
+        .buffer_manager_mut()
+        .create_buffer("*treemacs-like-scaled-buffer*");
+    {
+        let buffer = eval
+            .buffer_manager_mut()
+            .get_mut(main_buffer)
+            .expect("main buffer");
+        buffer.set_buffer_local("mode-line-format", Value::string("MAIN"));
+    }
+    {
+        let buffer = eval
+            .buffer_manager_mut()
+            .get_mut(side_buffer)
+            .expect("scaled side buffer");
+        buffer.insert("scaled body\n");
+        buffer.set_buffer_local("mode-line-format", Value::string("TREEMACS"));
+        buffer.set_buffer_local(
+            "face-remapping-alist",
+            Value::list(vec![Value::list(vec![
+                Value::symbol("default"),
+                Value::list(vec![Value::keyword("height"), Value::make_float(0.7)]),
+                Value::symbol("default"),
+            ])]),
+        );
+    }
+    {
+        let table = eval.face_table_mut();
+
+        let mut default = Face::new("default");
+        default.height = Some(FaceHeight::Absolute(140));
+        table.define("default", default);
+
+        let mut mode_line = Face::new("mode-line");
+        mode_line.height = Some(FaceHeight::Relative(1.0));
+        table.define("mode-line", mode_line);
+
+        let mut active = Face::new("mode-line-active");
+        active.inherit = Some(Value::symbol("mode-line"));
+        table.define("mode-line-active", active);
+
+        let mut inactive = Face::new("mode-line-inactive");
+        inactive.inherit = Some(Value::symbol("mode-line"));
+        table.define("mode-line-inactive", inactive);
+    }
+
+    let side = eval
+        .frame_manager_mut()
+        .split_window(
+            frame_id,
+            selected,
+            neovm_core::window::SplitDirection::Horizontal,
+            side_buffer,
+            None,
+            neovm_core::window::SplitPlacement::AfterTarget,
+        )
+        .expect("split window");
+    {
+        let frames = eval.frame_manager_mut();
+        frames
+            .get_mut(frame_id)
+            .expect("frame")
+            .set_window_system(Some(Value::symbol("neo")));
+        for (window_id, label) in [(selected, "MAIN"), (side, "TREEMACS")] {
+            frames.set_window_parameter(
+                window_id,
+                Value::symbol("mode-line-format"),
+                Value::string(label),
+            );
+        }
+    }
+
+    let mut engine = LayoutEngine::new();
+    engine.layout_frame_rust(&mut eval, frame_id);
+    let state = engine
+        .last_frame_display_state
+        .as_ref()
+        .expect("frame display state");
+    let window_rows = |window_id: neovm_core::window::WindowId| {
+        state
+            .window_matrices
+            .iter()
+            .find(|entry| entry.window_id.get() == window_id.0 as i64)
+            .unwrap_or_else(|| panic!("window {window_id:?} matrix"))
+            .matrix
+            .rows
+            .iter()
+            .filter(|row| row.enabled)
+            .collect::<Vec<_>>()
+    };
+    let main_rows = window_rows(selected);
+    let side_rows = window_rows(side);
+    fn row_for_role<'a>(rows: &'a [&MatrixRow], role: GlyphRowRole) -> &'a MatrixRow {
+        rows.iter()
+            .copied()
+            .find(|row| row.role == role)
+            .unwrap_or_else(|| panic!("{role:?} row in {rows:?}"))
+    }
+    fn body_text_row<'a>(rows: &'a [&MatrixRow]) -> &'a MatrixRow {
+        rows.iter()
+            .copied()
+            .find(|row| row.role == GlyphRowRole::Text && row.displays_text)
+            .unwrap_or_else(|| panic!("body text row in {rows:?}"))
+    }
+    let main_body = body_text_row(&main_rows);
+    let side_body = body_text_row(&side_rows);
+    let main_mode_line = row_for_role(&main_rows, GlyphRowRole::ModeLine);
+    let side_mode_line = row_for_role(&side_rows, GlyphRowRole::ModeLine);
+
+    assert!(
+        side_body.height_px < main_body.height_px,
+        "precondition: the side buffer's default remap must shrink its body text; main={main_body:?} side={side_body:?}"
+    );
+    assert_eq!(
+        side_mode_line.height_px, main_mode_line.height_px,
+        "a default-only buffer remap must not scale the inactive mode line"
     );
 }
 

--- a/neomacs-layout-engine/src/neovm_bridge.rs
+++ b/neomacs-layout-engine/src/neovm_bridge.rs
@@ -3622,15 +3622,17 @@ pub struct FaceResolver {
     font_sizing: FontSizing,
 }
 
-/// GNU basic-face lookup has two identity outcomes.  A canonical lookup keeps
-/// the fixed `enum face_id` slot; a window-named lookup may incorporate
-/// `face-remapping-alist` and therefore needs a content-addressed dynamic slot.
-/// Keeping that distinction typed prevents a remapped face from accidentally
-/// retaining the canonical basic-face id.
+/// GNU basic-face lookup has two realization outcomes.  A canonical lookup
+/// keeps the fixed `enum face_id` slot.  A window-named lookup starts from the
+/// frame's unremapped default, then may incorporate direct or inherited entries
+/// from `face-remapping-alist`, so it needs a content-addressed dynamic slot.
+/// Keeping the base in the variant name prevents window chrome from
+/// accidentally inheriting a buffer-local `default` remap (such as Treemacs'
+/// text scale).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum BufferBasicFaceLookup {
     Canonical(BasicFaceId),
-    WindowNamed(BasicFaceId),
+    WindowNamedOverFrameDefault(BasicFaceId),
 }
 
 impl FaceResolver {
@@ -4155,7 +4157,7 @@ impl FaceResolver {
             return BufferBasicFaceLookup::Canonical(face_id);
         }
 
-        let face_name = face_id.lisp_face_name();
+        let face_name = face_id.name();
         let has_direct_mapping = Self::buffer_face_remapping_specs(buffer, face_name).is_some();
         let inherits = self
             .face_table
@@ -4169,7 +4171,7 @@ impl FaceResolver {
         if !has_direct_mapping && !inherits {
             BufferBasicFaceLookup::Canonical(face_id)
         } else {
-            BufferBasicFaceLookup::WindowNamed(face_id)
+            BufferBasicFaceLookup::WindowNamedOverFrameDefault(face_id)
         }
     }
 
@@ -4500,35 +4502,40 @@ impl FaceResolver {
                 let buffer = buffer.expect("buffer-remapped basic face policy requires a buffer");
                 match self.buffer_basic_face_lookup(buffer, face_id) {
                     BufferBasicFaceLookup::Canonical(face_id) => {
-                        let mut resolved = self.resolve_named_face(face_id.lisp_face_name());
-                        // Active mode/header slots intentionally realize Lisp
-                        // faces whose names differ from their cache-role name
-                        // (`mode-line`, not `mode-line-active`).  The enum is
-                        // the authoritative identity at this boundary.
+                        let mut resolved = self.resolve_named_face(face_id.name());
+                        // GNU realizes every basic cache slot from the named
+                        // face represented by that typed role.  Re-stamp the
+                        // fixed cache id after realization so name and slot
+                        // cannot drift apart at this boundary.
                         resolved.face_id = u32::from(face_id);
                         resolved
                     }
-                    BufferBasicFaceLookup::WindowNamed(face_id) => {
-                        let base = self.resolve_buffer_default_face(buffer);
+                    BufferBasicFaceLookup::WindowNamedOverFrameDefault(face_id) => {
+                        // GNU `lookup_named_face` initializes ATTRS from the
+                        // frame's canonical DEFAULT_FACE_ID before merging the
+                        // named face and its buffer-local remappings.  Starting
+                        // here from `resolve_buffer_default_face` would
+                        // pre-apply a default-only text scale to basic window
+                        // chrome before the named face is merged.
+                        let base = self.default_face.clone();
                         let mut resolved = self
                             .resolve_buffer_face_value_over(
                                 buffer,
                                 &base,
-                                &Value::symbol(face_id.lisp_face_name()),
+                                &Value::symbol(face_id.name()),
                             )
                             .unwrap_or(base);
                         // Zero is the bridge's "allocate from the frame face
                         // arena" marker.  The typed lookup above ensures only
-                        // the WindowNamed branch can erase a canonical id.
+                        // the WindowNamedOverFrameDefault branch can erase a
+                        // canonical id.
                         resolved.face_id = 0;
-                        resolved.lisp_name = Some(face_id.lisp_face_name().to_string());
+                        resolved.lisp_name = Some(face_id.name().to_string());
                         resolved
                     }
                 }
             }
-            BaseFacePolicy::FrameBasicFace(face_id) => {
-                self.resolve_named_face(face_id.lisp_face_name())
-            }
+            BaseFacePolicy::FrameBasicFace(face_id) => self.resolve_named_face(face_id.name()),
         }
     }
 
@@ -4552,9 +4559,7 @@ impl FaceResolver {
     ) -> ResolvedFace {
         match origin.default_base_face_policy() {
             BaseFacePolicy::DefaultFace => self.default_face.clone(),
-            BaseFacePolicy::FrameBasicFace(face_id) => {
-                self.resolve_named_face(face_id.lisp_face_name())
-            }
+            BaseFacePolicy::FrameBasicFace(face_id) => self.resolve_named_face(face_id.name()),
             BaseFacePolicy::BufferRemappedBasicFace(_) => {
                 panic!("display origin {origin:?} requires a buffer for basic-face remapping")
             }


### PR DESCRIPTION
## What changed

- use the canonical `BasicFaceId::name()` mapping for active and inactive window chrome
- realize buffer-sensitive basic faces over the frame default, while preserving direct and inherited face remaps
- encode that distinction as `WindowNamedOverFrameDefault`
- add renderer-level regressions for active-face decorations and Treemacs-style buffer-local text scaling

## Why

Selected mode lines were sometimes realized as the `mode-line` parent instead of `mode-line-active`, which leaked parent decorations and metrics. Separately, a buffer-local `default` scale—such as `treemacs-text-scale`—was incorrectly used as the base for inactive mode-line realization, shrinking window chrome along with buffer text.

GNU Emacs realizes each typed basic face from its canonical name and starts window-named realization from the frame's unremapped default. This change follows that boundary while retaining legitimate named face remappings.

## Impact

- active mode lines honor `mode-line-active` attributes, including explicit decoration suppression
- Treemacs and similarly scaled buffers keep normal-sized mode-line text
- body text remains buffer-locally scaled

## Validation

- test-first renderer-level regressions
- GNU Emacs 31 private-X11 oracle: main and Treemacs-like mode lines both 23 px
- rebuilt Neomacs private-X11 verification: both mode lines 23 px
- `cargo nextest run -p neomacs-display-protocol -p neomacs-layout-engine`: 2,605 passed, 3 skipped
- `cargo fmt --all -- --check`
- `git diff --check`
