### PR TITLE
build(windows): add portable release packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,28 +116,28 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
-            C:\gstreamer
-            C:\gstreamer-msi-cache
-          key: windows-gstreamer-msvc-x86_64-${{ env.GSTREAMER_VERSION }}-v1
+            ${{ github.workspace }}\PFiles64
+            ${{ github.workspace }}\gstreamer-msi-cache
+          key: windows-gstreamer-msvc-x86_64-${{ env.GSTREAMER_VERSION }}-v3
 
-      - name: Install GStreamer SDK
-        if: runner.os == 'Windows' && steps.cache-gstreamer.outputs.cache-hit != 'true'
-        shell: powershell
+      - name: Install and configure GStreamer SDK
+        if: runner.os == 'Windows'
+        shell: pwsh
         run: ./scripts/setup-windows-gstreamer.ps1 -Install
 
+      - name: Run Windows GStreamer setup contract
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./scripts/test-windows-gstreamer-setup.ps1
+
       - name: Save GStreamer SDK cache
-        if: runner.os == 'Windows' && steps.cache-gstreamer.outputs.cache-hit != 'true'
+        if: ${{ !cancelled() && runner.os == 'Windows' && steps.cache-gstreamer.outputs.cache-hit != 'true' && hashFiles('PFiles64/gstreamer/1.0/msvc_x86_64/bin/pkg-config.exe') != '' }}
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
-            C:\gstreamer
-            C:\gstreamer-msi-cache
+            ${{ github.workspace }}\PFiles64
+            ${{ github.workspace }}\gstreamer-msi-cache
           key: ${{ steps.cache-gstreamer.outputs.cache-primary-key }}
-
-      - name: Configure GStreamer SDK
-        if: runner.os == 'Windows'
-        shell: powershell
-        run: ./scripts/setup-windows-gstreamer.ps1
 
       - name: Set up Rust tooling
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
   build-windows-x86_64:
     name: build Windows x86_64
     runs-on: windows-latest
-    timeout-minutes: 180
+    timeout-minutes: 210
     env:
       CARGO_TERM_COLOR: always
       RUST_BACKTRACE: 1
@@ -238,27 +238,9 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
-            C:\gstreamer
-            C:\gstreamer-msi-cache
-          key: windows-gstreamer-msvc-x86_64-${{ env.GSTREAMER_VERSION }}-v1
-
-      - name: Install GStreamer SDK
-        if: steps.cache-gstreamer.outputs.cache-hit != 'true'
-        shell: powershell
-        run: ./scripts/setup-windows-gstreamer.ps1 -Install
-
-      - name: Save GStreamer SDK cache
-        if: steps.cache-gstreamer.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            C:\gstreamer
-            C:\gstreamer-msi-cache
-          key: ${{ steps.cache-gstreamer.outputs.cache-primary-key }}
-
-      - name: Configure GStreamer SDK
-        shell: powershell
-        run: ./scripts/setup-windows-gstreamer.ps1
+            ${{ github.workspace }}\PFiles64
+            ${{ github.workspace }}\gstreamer-msi-cache
+          key: windows-gstreamer-msvc-x86_64-${{ env.GSTREAMER_VERSION }}-v3
 
       - name: Set up Rust tooling
         uses: ./.github/actions/setup-rust
@@ -273,47 +255,26 @@ jobs:
         shell: powershell
         run: Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files (x86)\NSIS"
 
-      - name: Verify GStreamer pkg-config
-        shell: bash
-        run: source scripts/windows-gstreamer-env.sh --verify
-
-      - name: Build release binaries
-        shell: bash
-        timeout-minutes: 150
-        run: |
-          source scripts/windows-gstreamer-env.sh
-          # The pdump generation runs neomacs, whose startup expands `~`. The
-          # minimal CI build environment sets USERPROFILE/APPDATA but not HOME,
-          # so `~` would stay literal and `directory-files "~"` would fail. Give
-          # it HOME explicitly (a real Windows session always has one; GNU's
-          # w32.c init_environment likewise guarantees HOME is set).
-          export HOME="${USERPROFILE:-$GITHUB_WORKSPACE}"
-          cargo xtask fresh-build --release --features neomacs-layout-engine/freetype-bundled
-
       - name: Set version env (bash)
         shell: bash
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
-      - name: Install zip
-        run: choco install zip -y --no-progress
-
-      - name: Package zip (x86_64-pc-windows-msvc)
-        shell: bash
+      - name: Build and package zip (x86_64-pc-windows-msvc)
+        shell: pwsh
+        timeout-minutes: 160
         run: |
-          TARGET=x86_64-pc-windows-msvc
-          STAGING="neomacs-${VERSION}-${TARGET}"
-          mkdir -p "$STAGING"
-          cp target/release/neomacs.exe "$STAGING/"
-          cp target/release/neomacsclient.exe "$STAGING/"
-          cp target/release/neomacs.pdump "$STAGING/"
-          cp -r lisp "$STAGING/"
-          cp -r etc "$STAGING/"
-          cp COPYING "$STAGING/"
-          ./scripts/vendor-windows-gstreamer-runtime.sh \
-            --package-root "$STAGING" \
-            --bin-dir "$STAGING"
-          mkdir -p dist
-          zip -r "dist/${STAGING}.zip" "$STAGING"
+          # pdump startup expands "~"; hosted Windows jobs may not define HOME.
+          $env:HOME = if ($env:USERPROFILE) { $env:USERPROFILE } else { $env:GITHUB_WORKSPACE }
+          ./scripts/emacs-build.ps1 -Version $env:VERSION
+
+      - name: Save GStreamer SDK cache
+        if: ${{ !cancelled() && steps.cache-gstreamer.outputs.cache-hit != 'true' && hashFiles('PFiles64/gstreamer/1.0/msvc_x86_64/bin/pkg-config.exe') != '' }}
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ${{ github.workspace }}\PFiles64
+            ${{ github.workspace }}\gstreamer-msi-cache
+          key: ${{ steps.cache-gstreamer.outputs.cache-primary-key }}
 
       - name: Package .exe installer
         shell: bash

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -12,10 +12,12 @@ on:
       - scripts/package-windows-installer-upgrade-fixtures.sh
       - scripts/run-windows-installer-contract.ps1
       - scripts/setup-windows-gstreamer.ps1
+      - scripts/test-windows-gstreamer-setup.ps1
       - scripts/test-windows-installer.ps1
       - scripts/test-windows-installer-upgrade.ps1
       - scripts/vendor-windows-gstreamer-runtime.sh
       - scripts/windows-gstreamer-env.sh
+      - scripts/windows-msi-arguments.ps1
       - xtask/**
   pull_request:
     paths:
@@ -28,10 +30,12 @@ on:
       - scripts/package-windows-installer-upgrade-fixtures.sh
       - scripts/run-windows-installer-contract.ps1
       - scripts/setup-windows-gstreamer.ps1
+      - scripts/test-windows-gstreamer-setup.ps1
       - scripts/test-windows-installer.ps1
       - scripts/test-windows-installer-upgrade.ps1
       - scripts/vendor-windows-gstreamer-runtime.sh
       - scripts/windows-gstreamer-env.sh
+      - scripts/windows-msi-arguments.ps1
       - xtask/**
   workflow_dispatch:
 
@@ -59,27 +63,22 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
-            C:\gstreamer
-            C:\gstreamer-msi-cache
-          key: windows-gstreamer-msvc-x86_64-${{ env.GSTREAMER_VERSION }}-v1
+            ${{ github.workspace }}\PFiles64
+            ${{ github.workspace }}\gstreamer-msi-cache
+          key: windows-gstreamer-msvc-x86_64-${{ env.GSTREAMER_VERSION }}-v3
 
-      - name: Install GStreamer SDK
-        if: steps.cache-gstreamer.outputs.cache-hit != 'true'
-        shell: powershell
+      - name: Install and configure GStreamer SDK
+        shell: pwsh
         run: ./scripts/setup-windows-gstreamer.ps1 -Install
 
       - name: Save GStreamer SDK cache
-        if: steps.cache-gstreamer.outputs.cache-hit != 'true'
+        if: ${{ !cancelled() && steps.cache-gstreamer.outputs.cache-hit != 'true' && hashFiles('PFiles64/gstreamer/1.0/msvc_x86_64/bin/pkg-config.exe') != '' }}
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
-            C:\gstreamer
-            C:\gstreamer-msi-cache
+            ${{ github.workspace }}\PFiles64
+            ${{ github.workspace }}\gstreamer-msi-cache
           key: ${{ steps.cache-gstreamer.outputs.cache-primary-key }}
-
-      - name: Configure GStreamer SDK
-        shell: powershell
-        run: ./scripts/setup-windows-gstreamer.ps1
 
       - name: Set up Rust tooling
         uses: ./.github/actions/setup-rust

--- a/.gitignore
+++ b/.gitignore
@@ -436,3 +436,10 @@ result
 /drafts
 lisp/org/org-loaddefs.el
 neovm-oracle-tests/proptest-regressions/
+/PFiles64/
+/VC/
+/gstreamer-*.msi
+/gstreamer/
+/gstreamer-msi-cache/
+/gstreamer.tmp-*/
+/.superpowers/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,6 +276,10 @@ overflow-checks = false
 codegen-units = 16
 incremental = false
 
+[profile.dev-release]
+inherits = "dev"
+opt-level = 2
+
 # Optimized build driven by a PGO profile. Same codegen settings as release,
 # but cargo gives it its own target/release-pgo directory, so a PGO build never
 # replaces an ordinary release binary (or invalidates its pdump fingerprint).

--- a/neovm-core/src/emacs_core/process/sys/process_status.rs
+++ b/neovm-core/src/emacs_core/process/sys/process_status.rs
@@ -29,16 +29,42 @@ pub fn process_is_alive(pid: i64) -> bool {
     std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
 
-/// Non-Unix fallback.
-///
-/// Windows would probe this with `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
-/// ...)` (alive iff the handle opens, or the open fails with
-/// `ERROR_ACCESS_DENIED`); that native probe is left for a Windows build. The
-/// `/proc` heuristic is retained meanwhile (always false off Linux).
-#[cfg(not(unix))]
+#[cfg(windows)]
+pub fn process_is_alive(pid: i64) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, ERROR_ACCESS_DENIED, GetLastError};
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+
+    let Ok(pid) = u32::try_from(pid) else {
+        return false;
+    };
+    if pid == 0 {
+        return false;
+    }
+
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if process.is_null() {
+        return unsafe { GetLastError() } == ERROR_ACCESS_DENIED;
+    }
+    unsafe {
+        CloseHandle(process);
+    }
+    true
+}
+
+#[cfg(not(any(unix, windows)))]
 pub fn process_is_alive(pid: i64) -> bool {
     if pid <= 0 {
         return false;
     }
     std::fs::metadata(format!("/proc/{pid}")).is_ok()
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_process_is_alive() {
+        assert!(process_is_alive(i64::from(std::process::id())));
+    }
 }

--- a/scripts/emacs-build.ps1
+++ b/scripts/emacs-build.ps1
@@ -1,0 +1,662 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+  [switch]$SkipBuild,
+  [switch]$SkipPackage,
+  [string]$Version,
+  [string]$GStreamerRoot,
+  [string]$GStreamerRuntimeMsi,
+  [string[]]$DependencyRoot = @()
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+$targetTriple = 'x86_64-pc-windows-msvc'
+$runtimeExtractionRoot = Join-Path ([System.IO.Path]::GetTempPath()) "neomacs-gstreamer-runtime-$([guid]::NewGuid().ToString('N'))"
+
+function Get-CommandPath {
+  param([Parameter(Mandatory)][string]$Name)
+
+  $command = Get-Command -Name $Name -ErrorAction SilentlyContinue |
+    Where-Object CommandType -eq 'Application' |
+    Select-Object -First 1
+  if ($null -ne $command) {
+    return $command.Source
+  }
+  return $null
+}
+
+function Normalize-Version {
+  param([Parameter(Mandatory)][string]$Value)
+
+  $normalized = $Value.Trim()
+  if ($normalized.StartsWith('v', [System.StringComparison]::Ordinal)) {
+    $normalized = $normalized.Substring(1)
+  }
+  if ([string]::IsNullOrWhiteSpace($normalized)) {
+    throw 'version must not be empty'
+  }
+  if ($normalized -eq '.' -or $normalized -eq '..' -or $normalized.EndsWith('.')) {
+    throw "version is not safe for a directory name: $Value"
+  }
+  foreach ($invalidCharacter in [System.IO.Path]::GetInvalidFileNameChars()) {
+    if ($normalized.IndexOf($invalidCharacter) -ge 0) {
+      throw "version contains an invalid filename character: $Value"
+    }
+  }
+  return $normalized
+}
+
+function Get-GitCommit {
+  $gitPath = Get-CommandPath 'git.exe'
+  if ($null -eq $gitPath) {
+    $gitPath = Get-CommandPath 'git'
+  }
+  if ($null -eq $gitPath) {
+    return 'unknown'
+  }
+
+  $commitOutput = & $gitPath -C $repoRoot rev-parse --short=12 HEAD 2>$null
+  $commitExitCode = $LASTEXITCODE
+  if ($commitExitCode -eq 0) {
+    $commit = (@($commitOutput) -join '').Trim()
+    if ($commit) {
+      return $commit
+    }
+  }
+
+  return 'unknown'
+}
+
+function Get-Version {
+  $gitPath = Get-CommandPath 'git.exe'
+  if ($null -eq $gitPath) {
+    $gitPath = Get-CommandPath 'git'
+  }
+  if ($null -eq $gitPath) {
+    return '0.0.0-dev'
+  }
+
+  $tagOutput = & $gitPath -C $repoRoot describe --tags --abbrev=0 2>$null
+  $tagExitCode = $LASTEXITCODE
+  if ($tagExitCode -eq 0) {
+    $tag = (@($tagOutput) -join '').Trim()
+    if ($tag) {
+      return (Normalize-Version $tag)
+    }
+  }
+
+  $commit = Get-GitCommit
+  if ($commit -ne 'unknown') {
+    return (Normalize-Version $commit)
+  }
+
+  return '0.0.0-dev'
+}
+
+function Get-GitBashPath {
+  $candidates = @()
+  $gitPath = Get-CommandPath 'git.exe'
+  if ($null -eq $gitPath) {
+    $gitPath = Get-CommandPath 'git'
+  }
+  if ($null -ne $gitPath) {
+    $gitRoot = Split-Path -Parent (Split-Path -Parent $gitPath)
+    $candidates += Join-Path $gitRoot 'bin\bash.exe'
+    $candidates += Join-Path $gitRoot 'usr\bin\bash.exe'
+  }
+  foreach ($programFiles in @($env:ProgramFiles, ${env:ProgramFiles(x86)})) {
+    if ([string]::IsNullOrWhiteSpace($programFiles)) {
+      continue
+    }
+    $candidates += Join-Path $programFiles 'Git\bin\bash.exe'
+  }
+  foreach ($candidate in $candidates) {
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+      return (Resolve-Path -LiteralPath $candidate).Path
+    }
+  }
+  throw 'Git Bash (bash.exe) was not found with Git or under Program Files\Git\bin'
+}
+
+function Get-DumpbinPath {
+  $dumpbinPath = Get-CommandPath 'dumpbin.exe'
+  if ($null -ne $dumpbinPath) {
+    return $dumpbinPath
+  }
+
+  $vswherePath = Get-CommandPath 'vswhere.exe'
+  if ($null -eq $vswherePath) {
+    $vswhereCandidates = @()
+    foreach ($programFiles in @(${env:ProgramFiles(x86)}, $env:ProgramFiles)) {
+      if (-not [string]::IsNullOrWhiteSpace($programFiles)) {
+        $vswhereCandidates += Join-Path $programFiles 'Microsoft Visual Studio\Installer\vswhere.exe'
+      }
+    }
+    $vswherePath = $vswhereCandidates |
+      Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+      Select-Object -First 1
+  }
+  if ($null -eq $vswherePath) {
+    throw 'dumpbin.exe was not found on PATH and vswhere.exe is unavailable'
+  }
+
+  $installations = & $vswherePath `
+    -latest `
+    -products '*' `
+    -requires 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64' `
+    -property installationPath 2>$null
+  $vswhereExitCode = $LASTEXITCODE
+  if ($vswhereExitCode -ne 0) {
+    throw "vswhere.exe failed while locating an MSVC installation (exit code $vswhereExitCode)"
+  }
+
+  foreach ($installation in @($installations)) {
+    $installationPath = $installation.ToString().Trim()
+    if (-not $installationPath) {
+      continue
+    }
+
+    $dumpbin = Get-ChildItem -Path (Join-Path $installationPath 'VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe') `
+      -File `
+      -ErrorAction SilentlyContinue |
+      Sort-Object FullName -Descending |
+      Select-Object -First 1
+    if ($null -ne $dumpbin) {
+      return $dumpbin.FullName
+    }
+  }
+
+  throw 'dumpbin.exe was not found under an MSVC installation reported by vswhere.exe'
+}
+
+function Get-KnownDllNames {
+  $knownDlls = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+  )
+  $registryPaths = @(
+    'Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\KnownDLLs',
+    'Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\KnownDLLs32'
+  )
+
+  foreach ($registryPath in $registryPaths) {
+    if (-not (Test-Path -LiteralPath $registryPath)) {
+      continue
+    }
+    $properties = Get-ItemProperty -LiteralPath $registryPath
+    foreach ($property in $properties.PSObject.Properties) {
+      if ($property.Name -like 'PS*' -or $property.Value -isnot [string]) {
+        continue
+      }
+      [void]$knownDlls.Add([System.IO.Path]::GetFileName($property.Value))
+    }
+  }
+
+  return ,$knownDlls
+}
+
+function Test-IgnoredDependency {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter(Mandatory)][System.Collections.Generic.HashSet[string]]$KnownDlls,
+    [Parameter(Mandatory)][string]$SystemDirectory
+  )
+
+  if ($Name -match '^(api-ms-|ext-ms-)') {
+    return $true
+  }
+  if ($Name -match '^(VCRUNTIME|MSVCP|CONCRT).*\.dll$' -or $Name -ieq 'ucrtbase.dll') {
+    return $true
+  }
+  if ($KnownDlls.Contains($Name)) {
+    return $true
+  }
+  if (Test-Path -LiteralPath (Join-Path $SystemDirectory $Name) -PathType Leaf) {
+    return $true
+  }
+  return $false
+}
+
+function Get-DumpbinDependencies {
+  param([Parameter(Mandatory)][string]$FilePath)
+
+  $output = & $script:DumpbinPath /NOLOGO /DEPENDENTS $FilePath 2>$null
+  $exitCode = $LASTEXITCODE
+  if ($exitCode -ne 0) {
+    throw "dumpbin.exe failed for '$FilePath' (exit code $exitCode)"
+  }
+
+  $inDependencies = $false
+  $dependencies = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+  )
+  foreach ($line in @($output)) {
+    $text = $line.ToString()
+    if ($text -match 'Image has the following dependencies:') {
+      $inDependencies = $true
+      continue
+    }
+    if ($inDependencies -and $text -match 'Image has the following delay load dependencies:') {
+      break
+    }
+    if ($inDependencies -and $text -match '^\s+Summary\s*$') {
+      break
+    }
+    if ($inDependencies -and $text -match '^\s+([^\s]+\.dll)\s*$') {
+      [void]$dependencies.Add($Matches[1])
+    }
+  }
+
+  return ,$dependencies
+}
+
+function Find-Dependency {
+  param(
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter(Mandatory)][string[]]$SearchRoots
+  )
+
+  foreach ($root in $SearchRoots) {
+    if ([string]::IsNullOrWhiteSpace($root)) {
+      continue
+    }
+    $normalizedRoot = $root.Trim('"')
+    $candidate = Join-Path $normalizedRoot $Name
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+      return (Resolve-Path -LiteralPath $candidate).Path
+    }
+  }
+  return $null
+}
+
+function Register-StagedBinary {
+  param(
+    [Parameter(Mandatory)][hashtable]$StagedNamesByDirectory,
+    [Parameter(Mandatory)][string]$FilePath
+  )
+
+  $directory = [System.IO.Path]::GetDirectoryName($FilePath)
+  if (-not $StagedNamesByDirectory.ContainsKey($directory)) {
+    $StagedNamesByDirectory[$directory] = [System.Collections.Generic.HashSet[string]]::new(
+      [System.StringComparer]::OrdinalIgnoreCase
+    )
+  }
+  [void]$StagedNamesByDirectory[$directory].Add(
+    [System.IO.Path]::GetFileName($FilePath)
+  )
+}
+
+function Test-StagedDependency {
+  param(
+    [Parameter(Mandatory)][hashtable]$StagedNamesByDirectory,
+    [Parameter(Mandatory)][string]$ImporterPath,
+    [Parameter(Mandatory)][string]$Name,
+    [Parameter(Mandatory)][string]$BinDirectory
+  )
+
+  $importerDirectory = [System.IO.Path]::GetDirectoryName($ImporterPath)
+  if ($StagedNamesByDirectory.ContainsKey($importerDirectory) -and
+      $StagedNamesByDirectory[$importerDirectory].Contains($Name)) {
+    return $true
+  }
+  if ($StagedNamesByDirectory.ContainsKey($BinDirectory) -and
+      $StagedNamesByDirectory[$BinDirectory].Contains($Name)) {
+    return $true
+  }
+  return $false
+}
+
+function Test-GStreamerPkgConfig {
+  param(
+    [Parameter(Mandatory)][string]$PkgConfigPath
+  )
+
+  foreach ($package in @('glib-2.0', 'gstreamer-1.0', 'cairo', 'pango', 'pangocairo')) {
+    & $PkgConfigPath --exists $package 2>$null
+    $pkgConfigExitCode = $LASTEXITCODE
+    if ($pkgConfigExitCode -ne 0) {
+      throw "pkg-config could not find required package '$package' using '$PkgConfigPath' (exit code $pkgConfigExitCode); check PKG_CONFIG_PATH and PKG_CONFIG_LIBDIR"
+    }
+  }
+}
+
+try {
+  if ($SkipPackage -and $SkipBuild) {
+    Write-Output 'build and packaging skipped'
+    return
+  }
+
+  $setupParameters = @{}
+  if (-not [string]::IsNullOrWhiteSpace($GStreamerRoot)) {
+    $setupParameters.GStreamerRoot = $GStreamerRoot
+  }
+  if (-not $SkipBuild) {
+    $setupParameters.Install = $true
+  }
+  if ($PSBoundParameters.ContainsKey('GStreamerRuntimeMsi')) {
+    $setupParameters.GStreamerRuntimeMsi = $GStreamerRuntimeMsi
+  }
+  elseif (-not [string]::IsNullOrWhiteSpace($env:GSTREAMER_RUNTIME_MSI)) {
+    $setupParameters.GStreamerRuntimeMsi = $env:GSTREAMER_RUNTIME_MSI
+  }
+  & (Join-Path $PSScriptRoot 'setup-windows-gstreamer.ps1') @setupParameters
+
+  $developmentRoot = $null
+  if (-not $SkipBuild) {
+    $developmentRoot = $env:GSTREAMER_ROOT_X86_64
+    if ([string]::IsNullOrWhiteSpace($developmentRoot)) {
+      throw 'GSTREAMER_ROOT_X86_64 is not set'
+    }
+    if (-not (Test-Path -LiteralPath $developmentRoot -PathType Container)) {
+      throw "GSTREAMER_ROOT_X86_64 does not exist: $developmentRoot"
+    }
+    $pkgConfig = $env:PKG_CONFIG
+    if ([string]::IsNullOrWhiteSpace($pkgConfig)) {
+      throw 'PKG_CONFIG is not set after GStreamer setup'
+    }
+    if (-not (Test-Path -LiteralPath $pkgConfig -PathType Leaf)) {
+      throw "PKG_CONFIG does not exist: $pkgConfig"
+    }
+    Test-GStreamerPkgConfig -PkgConfigPath $pkgConfig
+  }
+
+  if (-not $SkipPackage) {
+    if ($PSBoundParameters.ContainsKey('Version')) {
+      $version = Normalize-Version $Version
+    }
+    else {
+      $version = Get-Version
+    }
+
+    $runtimeMsi = $env:GSTREAMER_RUNTIME_MSI
+    if ([string]::IsNullOrWhiteSpace($runtimeMsi)) {
+      throw 'GStreamer runtime MSI is not set; use -GStreamerRuntimeMsi or GSTREAMER_RUNTIME_MSI'
+    }
+    if (-not (Test-Path -LiteralPath $runtimeMsi -PathType Leaf)) {
+      throw "GStreamer runtime MSI does not exist: $runtimeMsi"
+    }
+
+    $gitBashPath = Get-GitBashPath
+    $script:DumpbinPath = Get-DumpbinPath
+  }
+
+  if (-not $SkipBuild) {
+    $buildGitBashDirectory = Split-Path -Parent (Get-GitBashPath)
+    $gitUsrBin = if ((Split-Path -Leaf (Split-Path -Parent $buildGitBashDirectory)) -ieq 'usr') {
+      $buildGitBashDirectory
+    } else {
+      Join-Path (Split-Path -Parent $buildGitBashDirectory) 'usr\bin'
+    }
+    $awkPath = Join-Path $gitUsrBin 'awk.exe'
+    if (-not (Test-Path -LiteralPath $awkPath -PathType Leaf)) {
+      throw "Git awk.exe does not exist: $awkPath"
+    }
+    $previousPath = $env:PATH
+    Push-Location $repoRoot
+    try {
+      $env:PATH = "$gitUsrBin;$env:PATH"
+      & cargo xtask fresh-build --release --features neomacs-layout-engine/freetype-bundled
+      $buildExitCode = $LASTEXITCODE
+      if ($buildExitCode -ne 0) {
+        throw "cargo xtask fresh-build failed (exit code $buildExitCode)"
+      }
+    }
+    finally {
+      $env:PATH = $previousPath
+      Pop-Location
+    }
+  }
+
+  if ($SkipPackage) {
+    Write-Output 'build completed; packaging skipped'
+    return
+  }
+
+  $packageName = "neomacs-$version-$targetTriple"
+  $distDirectory = Join-Path $repoRoot 'dist'
+  $archivePath = Join-Path $distDirectory "$packageName.zip"
+  $packageRoot = Join-Path $distDirectory $packageName
+  $binDirectory = Join-Path $packageRoot 'bin'
+
+  New-Item -ItemType Directory -Path $distDirectory -Force | Out-Null
+  if (Test-Path -LiteralPath $packageRoot) {
+    Remove-Item -LiteralPath $packageRoot -Recurse -Force
+  }
+
+  $releaseDirectory = Join-Path $repoRoot 'target\release'
+  $requiredArtifacts = @(
+    (Join-Path $releaseDirectory 'neomacs.exe'),
+    (Join-Path $releaseDirectory 'neomacsclient.exe'),
+    (Join-Path $releaseDirectory 'neomacs.pdump')
+  )
+  foreach ($artifact in $requiredArtifacts) {
+    if (-not (Test-Path -LiteralPath $artifact -PathType Leaf)) {
+      throw "missing required release artifact: $artifact"
+    }
+  }
+
+  New-Item -ItemType Directory -Path $binDirectory -Force | Out-Null
+  $neomacsShare = Join-Path $packageRoot 'share\neomacs'
+  New-Item -ItemType Directory -Path $neomacsShare -Force | Out-Null
+
+  foreach ($artifact in $requiredArtifacts) {
+    Copy-Item -LiteralPath $artifact -Destination $binDirectory
+  }
+
+  foreach ($directoryName in @('lisp', 'etc', 'leim')) {
+    $sourceDirectory = Join-Path $repoRoot $directoryName
+    if (-not (Test-Path -LiteralPath $sourceDirectory -PathType Container)) {
+      throw "missing required package directory: $sourceDirectory"
+    }
+    Copy-Item -LiteralPath $sourceDirectory `
+      -Destination (Join-Path $neomacsShare $directoryName) `
+      -Recurse
+  }
+
+  $infoDirectory = Join-Path $repoRoot 'info'
+  if (Test-Path -LiteralPath $infoDirectory -PathType Container) {
+    Copy-Item -LiteralPath $infoDirectory `
+      -Destination (Join-Path $neomacsShare 'info') `
+      -Recurse
+  }
+
+  foreach ($fileName in @('README.md', 'COPYING')) {
+    $sourceFile = Join-Path $repoRoot $fileName
+    if (-not (Test-Path -LiteralPath $sourceFile -PathType Leaf)) {
+      throw "missing required package file: $sourceFile"
+    }
+    Copy-Item -LiteralPath $sourceFile -Destination $packageRoot
+  }
+  [System.IO.File]::WriteAllText(
+    (Join-Path $packageRoot 'VERSION'),
+    ((@(
+      'name: neomacs'
+      "target: $targetTriple"
+      "git: $(Get-GitCommit)"
+      "built: $([System.DateTime]::UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", [System.Globalization.CultureInfo]::InvariantCulture))"
+    ) -join "`n") + "`n"),
+    [System.Text.UTF8Encoding]::new($false)
+  )
+
+  New-Item -ItemType Directory -Path $runtimeExtractionRoot -Force | Out-Null
+  $msiArguments = @(
+    '/a'
+    "`"$runtimeMsi`""
+    '/qn'
+    "TARGETDIR=`"$runtimeExtractionRoot`""
+  )
+  $msiexecProcess = Start-Process msiexec.exe -Wait -PassThru -ArgumentList $msiArguments
+  if ($msiexecProcess.ExitCode -ne 0) {
+    throw "msiexec.exe failed while extracting GStreamer runtime MSI (exit code $($msiexecProcess.ExitCode))"
+  }
+
+  $runtimeRoot = Join-Path $runtimeExtractionRoot 'PFiles64\gstreamer\1.0\msvc_x86_64'
+  if (-not (Test-Path -LiteralPath $runtimeRoot -PathType Container)) {
+    throw "extracted GStreamer runtime root does not exist: $runtimeRoot"
+  }
+  $runtimeBin = Join-Path $runtimeRoot 'bin'
+  if (-not (Test-Path -LiteralPath $runtimeBin -PathType Container)) {
+    throw "extracted GStreamer bin directory does not exist: $runtimeBin"
+  }
+  foreach ($runtimeDllName in @('glib-2.0-0.dll', 'gstreamer-1.0-0.dll')) {
+    $runtimeDllPath = Join-Path $runtimeBin $runtimeDllName
+    if (-not (Test-Path -LiteralPath $runtimeDllPath -PathType Leaf)) {
+      throw "required extracted GStreamer runtime DLL is missing: $runtimeDllPath"
+    }
+  }
+
+  $vendorScript = Join-Path $repoRoot 'scripts\vendor-windows-gstreamer-runtime.sh'
+  $hadDevelopmentRoot = Test-Path -LiteralPath 'Env:GSTREAMER_ROOT_X86_64'
+  $previousGStreamerRoot = $env:GSTREAMER_ROOT_X86_64
+  try {
+    $env:GSTREAMER_ROOT_X86_64 = $runtimeRoot
+    & $gitBashPath $vendorScript '--package-root' $packageRoot '--bin-dir' $binDirectory
+    $vendorExitCode = $LASTEXITCODE
+    if ($vendorExitCode -ne 0) {
+      throw "GStreamer runtime vendor script failed (exit code $vendorExitCode)"
+    }
+  }
+  finally {
+    if ($hadDevelopmentRoot) {
+      $env:GSTREAMER_ROOT_X86_64 = $previousGStreamerRoot
+    }
+    else {
+      Remove-Item Env:GSTREAMER_ROOT_X86_64 -ErrorAction SilentlyContinue
+    }
+  }
+
+  $pluginDirectory = Join-Path $packageRoot 'lib\gstreamer-1.0'
+  if (Test-Path -LiteralPath $pluginDirectory -PathType Container) {
+    Get-ChildItem -LiteralPath $pluginDirectory -Recurse -File |
+      Where-Object { $_.Extension -ieq '.a' -or $_.Extension -ieq '.lib' } |
+      Remove-Item -Force
+  }
+
+  $dependencyRoots = @((Join-Path $runtimeRoot 'bin'))
+  foreach ($root in @($DependencyRoot)) {
+    if (-not [string]::IsNullOrWhiteSpace($root)) {
+      $dependencyRoots += $root
+    }
+  }
+
+  $knownDlls = Get-KnownDllNames
+  $systemDirectory = [System.Environment]::SystemDirectory
+  $pendingFiles = [System.Collections.Generic.Queue[string]]::new()
+  $scannedFiles = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+  )
+  $stagedNamesByDirectory = @{}
+
+  # Optional plugin trees are outside the strict dependency closure by design.
+  foreach ($loaderRoot in @(
+    $binDirectory,
+    (Join-Path $packageRoot 'libexec')
+  )) {
+    if (-not (Test-Path -LiteralPath $loaderRoot -PathType Container)) {
+      continue
+    }
+    Get-ChildItem -LiteralPath $loaderRoot -Recurse -File |
+      Where-Object { $_.Extension -ieq '.exe' -or $_.Extension -ieq '.dll' } |
+      ForEach-Object {
+        Register-StagedBinary -StagedNamesByDirectory $stagedNamesByDirectory -FilePath $_.FullName
+        $pendingFiles.Enqueue($_.FullName)
+      }
+  }
+
+  while ($pendingFiles.Count -gt 0) {
+    $filePath = $pendingFiles.Dequeue()
+    if (-not $scannedFiles.Add($filePath)) {
+      continue
+    }
+
+    $importedDlls = Get-DumpbinDependencies $filePath
+    foreach ($dependencyName in $importedDlls) {
+      if (Test-IgnoredDependency `
+        -Name $dependencyName `
+        -KnownDlls $knownDlls `
+        -SystemDirectory $systemDirectory) {
+        continue
+      }
+
+      if (Test-StagedDependency `
+        -StagedNamesByDirectory $stagedNamesByDirectory `
+        -ImporterPath $filePath `
+        -Name $dependencyName `
+        -BinDirectory $binDirectory) {
+        continue
+      }
+
+      $dependencyPath = Find-Dependency -Name $dependencyName -SearchRoots $dependencyRoots
+      if ($null -eq $dependencyPath) {
+        throw "unresolved DLL '$dependencyName' imported by '$filePath'"
+      }
+
+      $destinationPath = Join-Path $binDirectory $dependencyName
+      if (-not (Test-Path -LiteralPath $destinationPath -PathType Leaf)) {
+        Copy-Item -LiteralPath $dependencyPath -Destination $destinationPath
+      }
+      Register-StagedBinary -StagedNamesByDirectory $stagedNamesByDirectory -FilePath $destinationPath
+      if ([System.IO.Path]::GetExtension($destinationPath) -ieq '.dll') {
+        $pendingFiles.Enqueue((Resolve-Path -LiteralPath $destinationPath).Path)
+      }
+    }
+  }
+
+  if (Test-Path -LiteralPath $archivePath) {
+    Remove-Item -LiteralPath $archivePath -Force
+  }
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  [System.IO.Compression.ZipFile]::CreateFromDirectory(
+    $packageRoot,
+    $archivePath,
+    [System.IO.Compression.CompressionLevel]::Optimal,
+    $true
+  )
+
+  $requiredEntries = @(
+    "$packageName/bin/neomacs.exe",
+    "$packageName/bin/neomacsclient.exe",
+    "$packageName/bin/neomacs.pdump"
+  )
+  $zip = [System.IO.Compression.ZipFile]::OpenRead($archivePath)
+  try {
+    $entryNames = [System.Collections.Generic.HashSet[string]]::new(
+      [System.StringComparer]::OrdinalIgnoreCase
+    )
+    foreach ($entry in $zip.Entries) {
+      [void]$entryNames.Add($entry.FullName.Replace('\', '/'))
+    }
+    foreach ($requiredEntry in $requiredEntries) {
+      if (-not $entryNames.Contains($requiredEntry)) {
+        throw "ZIP is missing required entry: $requiredEntry"
+      }
+    }
+    foreach ($directoryName in @('lisp', 'etc', 'leim')) {
+      $prefix = "$packageName/share/neomacs/$directoryName/"
+      if (-not ($entryNames | Where-Object { $_.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase) })) {
+        throw "ZIP is missing required directory contents: $prefix"
+      }
+    }
+    $sdkOnlyEntries = @($entryNames | Where-Object { $_ -match '(?i)\.(pdb|h|a|lib)$' })
+    if ($sdkOnlyEntries.Count -gt 0) {
+      throw "release ZIP contains $($sdkOnlyEntries.Count) SDK-only files: $($sdkOnlyEntries -join ', ')"
+    }
+  }
+  finally {
+    $zip.Dispose()
+  }
+
+  Write-Output "wrote $archivePath"
+}
+finally {
+  try {
+    if (Test-Path -LiteralPath $runtimeExtractionRoot) {
+      Remove-Item -LiteralPath $runtimeExtractionRoot -Recurse -Force -ErrorAction Stop
+    }
+  }
+  catch {
+    Write-Warning "failed to remove runtime MSI extraction directory '$runtimeExtractionRoot': $($_.Exception.Message)"
+  }
+}

--- a/scripts/setup-windows-gstreamer.ps1
+++ b/scripts/setup-windows-gstreamer.ps1
@@ -1,92 +1,177 @@
 param(
-  [switch]$Install
+  [switch]$Install,
+  [string]$GStreamerRoot,
+  [string]$GStreamerRuntimeMsi
 )
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
+$runtimeMsiExplicitlySupplied = $PSBoundParameters.ContainsKey('GStreamerRuntimeMsi')
 
-if ([string]::IsNullOrWhiteSpace($env:GSTREAMER_VERSION)) {
-  throw "GSTREAMER_VERSION is not set"
+function Resolve-SessionPath([string]$Path) {
+  return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path)
 }
 
-$installRoot = "C:\gstreamer"
-$msiCacheRoot = "C:\gstreamer-msi-cache"
-$baseUrl = "https://gstreamer.freedesktop.org/data/pkg/windows/$env:GSTREAMER_VERSION/msvc"
-$runtimeMsi = Join-Path $msiCacheRoot "gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
-$develMsi = Join-Path $msiCacheRoot "gstreamer-1.0-devel-msvc-x86_64-$env:GSTREAMER_VERSION.msi"
+function Normalize-RootPath([string]$Path) {
+  $resolved = Resolve-SessionPath $Path
+  $pathRoot = [System.IO.Path]::GetPathRoot($resolved)
+  if ([string]::IsNullOrEmpty($pathRoot) -or $resolved.Length -le $pathRoot.Length) {
+    return $pathRoot
+  }
+  return $resolved.TrimEnd([char[]]@('\', '/'))
+}
 
 function Download-IfMissing($uri, $path) {
-  if (Test-Path $path) {
+  if (Test-Path -LiteralPath $path -PathType Leaf) {
+    Write-Host "Reusing downloaded file: $path"
     return
   }
-  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $path) | Out-Null
-  Invoke-WebRequest -Uri $uri -OutFile $path
+  $parent = [System.IO.Path]::GetDirectoryName($path)
+  New-Item -ItemType Directory -Force -Path $parent | Out-Null
+  $partialPath = Join-Path $parent ".$([System.IO.Path]::GetFileName($path)).partial-$([guid]::NewGuid().ToString('N'))"
+  try {
+    Write-Host "Downloading $uri to $path"
+    Invoke-WebRequest -Uri $uri -OutFile $partialPath
+    if (-not (Test-Path -LiteralPath $partialPath -PathType Leaf)) {
+      throw "download did not produce a file: $uri"
+    }
+    [System.IO.File]::Move($partialPath, $path)
+  }
+  finally {
+    if (Test-Path -LiteralPath $partialPath) {
+      try {
+        Remove-Item -LiteralPath $partialPath -Force -ErrorAction Stop
+      }
+      catch {
+        Write-Warning "failed to remove partial download '$partialPath': $($_.Exception.Message)"
+      }
+    }
+  }
 }
 
-function Install-Msi($path) {
-  $process = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
-    "/i", $path, "/qn", "INSTALLLEVEL=1000", "INSTALLDIR=$installRoot"
+function Expand-MsiPayload($Msi, $TargetDirectory) {
+  $msiArguments = @(
+    '/a'
+    "`"$Msi`""
+    '/qn'
+    "TARGETDIR=`"$TargetDirectory`""
   )
+  $process = Start-Process msiexec.exe -Wait -PassThru -ArgumentList $msiArguments
   if ($process.ExitCode -ne 0) {
-    throw "msiexec failed with exit code $($process.ExitCode): $path"
+    throw "msiexec failed with exit code $($process.ExitCode): $Msi"
+  }
+}
+
+function Get-GStreamerRootMissingMarkers($Root) {
+  $requiredMarkers = @(
+    @{ RelativePath = 'bin\pkg-config.exe'; Type = 'Leaf' },
+    @{ RelativePath = 'bin\gstreamer-1.0-0.dll'; Type = 'Leaf' },
+    @{ RelativePath = 'include'; Type = 'Container' },
+    @{ RelativePath = 'lib\pkgconfig\glib-2.0.pc'; Type = 'Leaf' },
+    @{ RelativePath = 'lib\pkgconfig\gstreamer-1.0.pc'; Type = 'Leaf' }
+  )
+  foreach ($marker in $requiredMarkers) {
+    $path = Join-Path $Root $marker.RelativePath
+    if (-not (Test-Path -LiteralPath $path -PathType $marker.Type)) {
+      $marker.RelativePath
+    }
   }
 }
 
 function Export-CiEnv($name, $value) {
-  if ($env:GITHUB_ENV) {
-    Add-Content -Path $env:GITHUB_ENV -Value "$name=$value"
-  } else {
-    Set-Item -Path "Env:$name" -Value $value
+  Set-Item -LiteralPath "Env:$name" -Value $value
+  if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_ENV)) {
+    Add-Content -LiteralPath $env:GITHUB_ENV -Value "$name=$value"
   }
 }
 
 function Export-CiPath($value) {
-  if ($env:GITHUB_PATH) {
-    Add-Content -Path $env:GITHUB_PATH -Value $value
+  $env:PATH = "$value;$env:PATH"
+  if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_PATH)) {
+    Add-Content -LiteralPath $env:GITHUB_PATH -Value $value
+  }
+}
+
+function Invoke-GStreamerSetup {
+  $repoRoot = Resolve-SessionPath (Join-Path $PSScriptRoot '..')
+  $managedGStreamerSuffix = 'PFiles64\gstreamer\1.0\msvc_x86_64'
+  $usingDefaultGStreamerRoot = [string]::IsNullOrWhiteSpace($GStreamerRoot)
+  $version = if ([string]::IsNullOrWhiteSpace($env:GSTREAMER_VERSION)) {
+    '1.26.9'
   } else {
-    $env:PATH = "$value;$env:PATH"
+    $env:GSTREAMER_VERSION
   }
-}
-
-if ($Install) {
-  Download-IfMissing "$baseUrl/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.msi" $runtimeMsi
-  Download-IfMissing "$baseUrl/gstreamer-1.0-devel-msvc-x86_64-$env:GSTREAMER_VERSION.msi" $develMsi
-  Install-Msi $runtimeMsi
-  Install-Msi $develMsi
-}
-
-$searchRoots = @($installRoot, "${env:ProgramFiles}\gstreamer", "${env:ProgramFiles(x86)}\gstreamer") |
-  Where-Object { Test-Path $_ }
-$glibPc = $searchRoots |
-  ForEach-Object { Get-ChildItem -Path $_ -Filter glib-2.0.pc -Recurse -ErrorAction SilentlyContinue } |
-  Select-Object -First 1
-
-if (-not $glibPc) {
-  $searchRoots | ForEach-Object { Get-ChildItem -Path $_ -Depth 4 -ErrorAction SilentlyContinue }
-  throw "glib-2.0.pc not found; restore or install the GStreamer devel MSI first"
-}
-
-$pkgConfigDir = Split-Path -Parent $glibPc.FullName
-$libDir = Split-Path -Parent $pkgConfigDir
-$gstRoot = Split-Path -Parent $libDir
-$pkgConfig = "$gstRoot\bin\pkg-config.exe"
-
-if (-not (Test-Path $pkgConfig)) {
-  choco install pkgconfiglite -y
-  $pkgConfig = (Get-Command pkg-config.exe -All |
-    Where-Object { $_.Source -notmatch "\\Git\\" } |
-    Select-Object -First 1 -ExpandProperty Source)
-  if (-not $pkgConfig) {
-    throw "pkg-config.exe not found after installing pkgconfiglite"
+  if ($usingDefaultGStreamerRoot) {
+    $GStreamerRoot = Join-Path $repoRoot $managedGStreamerSuffix
   }
+  $GStreamerRoot = Normalize-RootPath $GStreamerRoot
+  $msiCacheRoot = if ($usingDefaultGStreamerRoot) {
+    Join-Path $repoRoot 'gstreamer-msi-cache'
+  } else {
+    "$GStreamerRoot-msi-cache"
+  }
+  $extractionTarget = $null
+  if ($GStreamerRoot.EndsWith($managedGStreamerSuffix, [System.StringComparison]::OrdinalIgnoreCase)) {
+    $extractionTarget = $GStreamerRoot.Substring(0, $GStreamerRoot.Length - $managedGStreamerSuffix.Length)
+    if ([string]::IsNullOrWhiteSpace($extractionTarget)) {
+      $extractionTarget = [System.IO.Path]::GetPathRoot($GStreamerRoot)
+    } else {
+      $extractionTarget = $extractionTarget.TrimEnd([char[]]@('\', '/'))
+    }
+  }
+  $baseUrl = "https://gstreamer.freedesktop.org/data/pkg/windows/$version/msvc"
+  if ($runtimeMsiExplicitlySupplied) {
+    if ([string]::IsNullOrWhiteSpace($GStreamerRuntimeMsi)) {
+      throw 'explicit GStreamer runtime MSI path must not be empty'
+    }
+    $runtimeMsi = Resolve-SessionPath $GStreamerRuntimeMsi
+    if (-not (Test-Path -LiteralPath $runtimeMsi -PathType Leaf)) {
+      throw "explicit GStreamer runtime MSI does not exist: '$GStreamerRuntimeMsi'"
+    }
+  } else {
+    $runtimeMsi = Resolve-SessionPath (Join-Path $msiCacheRoot "gstreamer-1.0-msvc-x86_64-$version.msi")
+  }
+  $develMsi = Resolve-SessionPath (Join-Path $msiCacheRoot "gstreamer-1.0-devel-msvc-x86_64-$version.msi")
+
+  Write-Host "Selected GStreamer root: $GStreamerRoot"
+
+  $missingMarkers = @(Get-GStreamerRootMissingMarkers $GStreamerRoot)
+  $sdkValid = $missingMarkers.Count -eq 0
+  if ($Install) {
+    if ($sdkValid) {
+      Write-Host "Reusing valid GStreamer SDK root: $GStreamerRoot"
+    } elseif ($null -eq $extractionTarget) {
+      if (Test-Path -LiteralPath $GStreamerRoot) {
+        throw "GStreamer SDK root exists but is invalid: '$GStreamerRoot'. Missing required paths: $($missingMarkers -join ', '). Manually remove or rename this directory, then rerun with -Install; setup will not delete it automatically."
+      }
+      throw "GStreamer SDK root '$GStreamerRoot' is missing and cannot be installed directly. A missing root must end with '$managedGStreamerSuffix'."
+    } else {
+      Download-IfMissing "$baseUrl/gstreamer-1.0-msvc-x86_64-$version.msi" $runtimeMsi
+      Download-IfMissing "$baseUrl/gstreamer-1.0-devel-msvc-x86_64-$version.msi" $develMsi
+      Expand-MsiPayload $runtimeMsi $extractionTarget
+      Expand-MsiPayload $develMsi $extractionTarget
+      $missingMarkers = @(Get-GStreamerRootMissingMarkers $GStreamerRoot)
+      if ($missingMarkers.Count -ne 0) {
+        throw "GStreamer SDK payload is missing required paths: $($missingMarkers -join ', ')"
+      }
+      $sdkValid = $true
+    }
+  }
+
+  Download-IfMissing "$baseUrl/gstreamer-1.0-msvc-x86_64-$version.msi" $runtimeMsi
+
+  if (-not $sdkValid) {
+    Write-Warning "GStreamer SDK root '$GStreamerRoot' is not valid; missing required paths: $($missingMarkers -join ', '). Continuing with runtime MSI only. Provide a valid SDK root or manually remove or rename this directory and rerun with -Install to install the SDK."
+  } else {
+    $pkgConfig = Join-Path $GStreamerRoot 'bin\pkg-config.exe'
+    Export-CiPath (Join-Path $GStreamerRoot 'bin')
+    Export-CiEnv 'GSTREAMER_ROOT_X86_64' $GStreamerRoot
+    Export-CiEnv 'PKG_CONFIG' $pkgConfig
+    Export-CiEnv 'PKG_CONFIG_PATH' (Join-Path $GStreamerRoot 'lib\pkgconfig')
+    Export-CiEnv 'PKG_CONFIG_LIBDIR' (Join-Path $GStreamerRoot 'lib\pkgconfig')
+  }
+  Export-CiEnv 'GSTREAMER_RUNTIME_MSI' $runtimeMsi
 }
 
-if (-not (Test-Path $runtimeMsi)) {
-  Download-IfMissing "$baseUrl/gstreamer-1.0-msvc-x86_64-$env:GSTREAMER_VERSION.msi" $runtimeMsi
+if ($MyInvocation.InvocationName -ne '.') {
+  Invoke-GStreamerSetup
 }
-
-Export-CiPath (Split-Path -Parent $pkgConfig)
-Export-CiPath "$gstRoot\bin"
-Export-CiEnv "GSTREAMER_ROOT_X86_64" "$gstRoot\"
-Export-CiEnv "PKG_CONFIG" $pkgConfig
-Export-CiEnv "PKG_CONFIG_PATH" "$gstRoot\lib\pkgconfig"
-Export-CiEnv "GSTREAMER_RUNTIME_MSI" $runtimeMsi

--- a/scripts/test-windows-gstreamer-setup.ps1
+++ b/scripts/test-windows-gstreamer-setup.ps1
@@ -1,0 +1,197 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$setup = Join-Path $PSScriptRoot 'setup-windows-gstreamer.ps1'
+$build = Join-Path $PSScriptRoot 'emacs-build.ps1'
+
+$root = Join-Path ([System.IO.Path]::GetTempPath()) `
+  "neomacs-gst-test-$([guid]::NewGuid().ToString('N'))"
+$repoTarget = Join-Path $root 'repo'
+$sdkRoot = Join-Path $repoTarget 'PFiles64\gstreamer\1.0\msvc_x86_64'
+$runtimeMsi = Join-Path $root 'runtime.msi'
+$develMsi = Join-Path "$sdkRoot-msi-cache" `
+  'gstreamer-1.0-devel-msvc-x86_64-1.26.9.msi'
+$originalEnvironment = @{}
+Get-ChildItem Env: | ForEach-Object { $originalEnvironment[$_.Name] = $_.Value }
+$previousStartProcess = Get-Item Function:\Start-Process -ErrorAction SilentlyContinue
+
+try {
+  New-Item -ItemType Directory -Force -Path `
+    $repoTarget,
+    (Split-Path -Parent $develMsi),
+    (Join-Path $root 'github'),
+    (Join-Path $sdkRoot 'bin') | Out-Null
+  New-Item -ItemType File -Path $runtimeMsi, $develMsi, `
+    (Join-Path $root 'github\env'), (Join-Path $root 'github\path'), `
+    (Join-Path $sdkRoot 'bin\partial-marker') | Out-Null
+  $env:GSTREAMER_VERSION = '1.26.9'
+  $env:GITHUB_ENV = Join-Path $root 'github\env'
+  $env:GITHUB_PATH = Join-Path $root 'github\path'
+
+  $runtimePayload = Join-Path $root 'runtime-payload'
+  $develPayload = Join-Path $root 'devel-payload'
+  New-Item -ItemType Directory -Force -Path `
+    (Join-Path $runtimePayload 'bin'),
+    (Join-Path $runtimePayload 'include'),
+    (Join-Path $runtimePayload 'lib\pkgconfig'),
+    (Join-Path $develPayload 'bin'),
+    (Join-Path $develPayload 'include'),
+    (Join-Path $develPayload 'lib\pkgconfig') | Out-Null
+  New-Item -ItemType File -Path `
+    (Join-Path $runtimePayload 'bin\gstreamer-1.0-0.dll'),
+    (Join-Path $runtimePayload 'include\runtime.h'),
+    (Join-Path $runtimePayload 'lib\pkgconfig\glib-2.0.pc'),
+    (Join-Path $develPayload 'bin\pkg-config.exe'),
+    (Join-Path $develPayload 'include\devel.h'),
+    (Join-Path $develPayload 'lib\pkgconfig\gstreamer-1.0.pc') | Out-Null
+
+  $global:payloadTrees = @($runtimePayload, $develPayload)
+  $global:payloadIndex = 0
+  $global:msiTargets = @()
+  $global:expectedMsiTarget = $repoTarget
+  function global:Start-Process {
+    param(
+      [string]$FilePath,
+      [switch]$Wait,
+      [switch]$PassThru,
+      [object[]]$ArgumentList
+    )
+    if ($FilePath -ne 'msiexec.exe') {
+      throw "unexpected process: $FilePath"
+    }
+    if ($ArgumentList.Count -ne 4 -or
+        $ArgumentList[0] -cne '/a' -or
+        $ArgumentList[2] -cne '/qn' -or
+        -not ([string]$ArgumentList[1]).StartsWith('"') -or
+        -not ([string]$ArgumentList[1]).EndsWith('"')) {
+      throw "unexpected msiexec arguments: $($ArgumentList -join ', ')"
+    }
+    $targetArgument = [string]$ArgumentList[3]
+    if ($targetArgument -cne "TARGETDIR=`"$global:expectedMsiTarget`"") {
+      throw "unexpected MSI TARGETDIR argument: $targetArgument"
+    }
+    $target = ([string]$targetArgument).Substring(10).Trim('"')
+    $global:msiTargets += $target
+    $payload = Join-Path $target 'PFiles64\gstreamer\1.0\msvc_x86_64'
+    New-Item -ItemType Directory -Force -Path $payload | Out-Null
+    Copy-Item -Path (Join-Path $global:payloadTrees[$global:payloadIndex] '*') `
+      -Destination $payload -Recurse -Force
+    $global:payloadIndex++
+    [pscustomobject]@{ ExitCode = 0 }
+  }
+
+  & $setup -Install -GStreamerRoot $sdkRoot -GStreamerRuntimeMsi $runtimeMsi | Out-Null
+
+  if ($global:payloadIndex -ne 2 -or $global:msiTargets.Count -ne 2) {
+    throw 'setup did not administratively extract both MSIs'
+  }
+  if ($global:msiTargets[0] -cne $repoTarget -or $global:msiTargets[0] -cne $global:msiTargets[1]) {
+    throw 'runtime and development MSIs did not share the repository TARGETDIR'
+  }
+  foreach ($marker in @(
+      'bin\pkg-config.exe',
+      'bin\gstreamer-1.0-0.dll',
+      'include',
+      'lib\pkgconfig\glib-2.0.pc',
+      'lib\pkgconfig\gstreamer-1.0.pc')) {
+    $type = if ($marker -eq 'include') { 'Container' } else { 'Leaf' }
+    if (-not (Test-Path -LiteralPath (Join-Path $sdkRoot $marker) -PathType $type)) {
+      throw "final SDK is missing required marker: $marker"
+    }
+  }
+  foreach ($nested in @('bin\bin', 'lib\lib')) {
+    if (Test-Path -LiteralPath (Join-Path $sdkRoot $nested)) {
+      throw "final SDK contains duplicate nested directory: $nested"
+    }
+  }
+  if ($env:GSTREAMER_ROOT_X86_64 -cne $sdkRoot) {
+    throw 'GSTREAMER_ROOT_X86_64 was not exported as the exact SDK root'
+  }
+
+  $badRoot = Join-Path $root 'custom-sdk'
+  $badError = $null
+  try {
+    & $setup -Install -GStreamerRoot $badRoot -GStreamerRuntimeMsi $runtimeMsi
+  } catch {
+    $badError = $_.Exception.Message
+  }
+  if ($badError -notmatch 'PFiles64.*msvc_x86_64') {
+    throw 'missing custom root did not explain the required managed layout'
+  }
+
+  $buildOutput = @(& $build -SkipBuild -SkipPackage)
+  if ($buildOutput -notcontains 'build and packaging skipped') {
+    throw 'combined emacs-build skip flags were not a no-op'
+  }
+
+  $buildHarness = Join-Path $root 'build-harness'
+  $buildHarnessScripts = Join-Path $buildHarness 'scripts'
+  $buildHarnessTools = Join-Path $buildHarness 'tools'
+  $buildHarnessGStreamer = Join-Path $buildHarness 'gstreamer'
+  $buildHarnessGit = Join-Path $buildHarness 'Git'
+  $buildHarnessGitCmd = Join-Path $buildHarnessGit 'cmd'
+  $buildHarnessGitBin = Join-Path $buildHarnessGit 'bin'
+  $buildHarnessGitUsrBin = Join-Path $buildHarnessGit 'usr\bin'
+  New-Item -ItemType Directory -Force -Path `
+    $buildHarnessScripts,
+    $buildHarnessTools,
+    $buildHarnessGStreamer,
+    $buildHarnessGitCmd,
+    $buildHarnessGitBin,
+    $buildHarnessGitUsrBin | Out-Null
+  New-Item -ItemType File -Force -Path `
+    (Join-Path $buildHarnessGitCmd 'git.exe'),
+    (Join-Path $buildHarnessGitBin 'bash.exe'),
+    (Join-Path $buildHarnessGitUsrBin 'awk.exe') | Out-Null
+  Copy-Item -LiteralPath $build -Destination $buildHarnessScripts
+  @'
+param(
+  [switch]$Install,
+  [string]$GStreamerRoot,
+  [string]$GStreamerRuntimeMsi
+)
+$env:GSTREAMER_ROOT_X86_64 = $env:NEOMACS_TEST_GSTREAMER_ROOT
+$env:PKG_CONFIG = $env:NEOMACS_TEST_PKG_CONFIG
+$env:PKG_CONFIG_PATH = $env:NEOMACS_TEST_GSTREAMER_ROOT
+$env:PKG_CONFIG_LIBDIR = $env:NEOMACS_TEST_GSTREAMER_ROOT
+'@ | Set-Content -LiteralPath (Join-Path $buildHarnessScripts 'setup-windows-gstreamer.ps1')
+  @'
+@exit /b 0
+'@ | Set-Content -LiteralPath (Join-Path $buildHarnessTools 'pkg-config.cmd')
+  @'
+@where awk.exe >nul 2>&1 || exit /b 42
+@exit /b 0
+'@ | Set-Content -LiteralPath (Join-Path $buildHarnessTools 'cargo.cmd')
+
+  $env:NEOMACS_TEST_GSTREAMER_ROOT = $buildHarnessGStreamer
+  $env:NEOMACS_TEST_PKG_CONFIG = Join-Path $buildHarnessTools 'pkg-config.cmd'
+  $env:PATH = "$buildHarnessGitCmd;$buildHarnessTools;$env:PATH"
+  $buildHarnessOutput = @(
+    & pwsh -NoProfile -File (Join-Path $buildHarnessScripts 'emacs-build.ps1') `
+      -SkipPackage 2>&1
+  )
+  if ($LASTEXITCODE -ne 0) {
+    throw "PowerShell build did not expose Git awk.exe to xtask: $($buildHarnessOutput -join "`n")"
+  }
+
+  Write-Output 'windows GStreamer setup contract passed'
+}
+finally {
+  $currentNames = @(Get-ChildItem Env: | Select-Object -ExpandProperty Name)
+  foreach ($name in $currentNames | Where-Object { -not $originalEnvironment.ContainsKey($_) }) {
+    Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+  }
+  foreach ($entry in $originalEnvironment.GetEnumerator()) {
+    Set-Item -LiteralPath "Env:$($entry.Key)" -Value $entry.Value
+  }
+  if ($null -eq $previousStartProcess) {
+    Remove-Item Function:\Start-Process -ErrorAction SilentlyContinue
+  } else {
+    Set-Item Function:\Start-Process -Value $previousStartProcess.Definition
+  }
+  Remove-Variable payloadTrees, payloadIndex, msiTargets, expectedMsiTarget `
+    -Scope Global -ErrorAction SilentlyContinue
+  Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -363,27 +363,18 @@ impl FreshBuildOptions {
                 return Err(
                     "fresh-build must be used with --release or --profile NAME.\n\n\
                  fresh-build builds the runnable GNU-shaped runtime pipeline \
-                 (cargo build, temacs bootstrap, byte-compilation, pdump) and is an \
-                 optimized-build operation. Re-run with:\n    cargo xtask fresh-build --release\n\
-                 or, for a symbol-preserving profiling build that leaves target/release \
-                 alone:\n    cargo xtask fresh-build --profile profiling"
+                 (cargo build, temacs bootstrap, byte-compilation, pdump). Re-run with:\n\
+                     cargo xtask fresh-build --release\n\
+                 or choose any explicit Cargo profile, for example:\n\
+                     cargo xtask fresh-build --profile dev"
                         .to_string()
                         .into(),
                 );
             }
         };
-        // The pipeline byte-compiles the whole Lisp tree with the binary it
-        // just built; an unoptimized profile makes that take hours, which is
-        // what the original --release requirement existed to prevent.
-        if !profile.is_optimized() {
-            return Err(format!(
-                "fresh-build cannot use the `{}` profile: the pipeline \
-                 byte-compiles the Lisp tree with the binary it builds, so it \
-                 needs an optimized profile (`release`, or `profiling` which \
-                 inherits it).",
-                profile.as_name()
-            )
-            .into());
+
+        if matches!(profile, BuildProfile::Dev | BuildProfile::DevRelease) {
+            no_byte_compile = true;
         }
 
         let bin_dir = bin_dir.unwrap_or_else(|| default_bin_dir(&repo_root, &profile));
@@ -452,9 +443,8 @@ enum BuildProfile {
     ReleasePgoProfiling,
     /// The instrumented pass that PRODUCES a profile. Never a PGO consumer.
     ReleasePgoGen,
-    /// Unoptimized; rejected, since the pipeline byte-compiles the Lisp tree
-    /// with the binary it just built.
     Dev,
+    DevRelease,
     Debug,
     Test,
     #[strum(disabled)]
@@ -482,11 +472,6 @@ impl BuildProfile {
     /// string inequality, so the recursion is impossible rather than guarded.
     fn consumes_pgo(&self) -> bool {
         matches!(self, Self::ReleasePgo | Self::ReleasePgoProfiling)
-    }
-
-    /// Optimized enough to byte-compile the Lisp tree with.
-    fn is_optimized(&self) -> bool {
-        !matches!(self, Self::Dev | Self::Debug | Self::Test)
     }
 
     /// Directory name cargo writes this profile's artifacts into.
@@ -805,6 +790,20 @@ fn run_fresh_build_inner(
         &loaddefs_args,
         &envs,
     )?;
+
+    if !options.dry_run {
+        let mut generated_loaddefs = generated_secondary_loaddefs_files(&paths.lisp_root)?;
+        generated_loaddefs.extend([
+            loaddefs_el.clone(),
+            theme_loaddefs_el.clone(),
+            paths.lisp_root.join("emacs-lisp/cl-loaddefs.el"),
+        ]);
+        for path in generated_loaddefs {
+            if path.is_file() {
+                normalize_lisp_line_endings(&path)?;
+            }
+        }
+    }
 
     print_synthetic_step(&format!(
         "generate {} from {}",
@@ -4084,6 +4083,14 @@ fn write_ldefs_boot(loaddefs_el: &Path, ldefs_boot: &Path) -> Result<()> {
     Ok(())
 }
 
+fn normalize_lisp_line_endings(path: &Path) -> Result<()> {
+    let contents = fs::read_to_string(path)?;
+    if contents.contains("\r\n") {
+        fs::write(path, contents.replace("\r\n", "\n"))?;
+    }
+    Ok(())
+}
+
 const LOADDEFS_END_BOUNDARY: &str = "\n\x0c\n;;; End of scraped data";
 // GNU Emacs 31.0.90's `loaddefs-generate` prints the autoload docstring on its
 // own line (verified against the system emacs-31.0.90 binary), not the older
@@ -4161,7 +4168,8 @@ Usage: cargo xtask [fresh-build] (--release | --profile NAME) [--bin-dir DIR] [-
        cargo xtask perf profile SCENARIO [--profiler perf] [--editor PATH] [--iterations N]
 
 --release (or --profile NAME) is required: fresh-build produces the runnable runtime
-binary by byte-compiling the Lisp tree with it, so it needs an optimized profile.
+pipeline. Any explicit Cargo profile is accepted. Dev skips Lisp
+byte-compilation for a faster inner loop.
 
 Build the GNU-shaped Neomacs runtime pipeline:
   1. cargo build --verbose -p neomacs [--features wpe-webkit on Linux] [--release]
@@ -4175,6 +4183,8 @@ Build the GNU-shaped Neomacs runtime pipeline:
   9. bootstrap-neomacs byte-compiles the GNU src/lisp.mk preloaded Lisp set
  10. neomacs-temacs --temacs=pdump
  11. neomacs byte-compiles the GNU compile-main Lisp set into .elc files
+
+ For dev builds, stages 5, 9, and 11 are skipped.
 
 Options:
   --bin-dir DIR       Directory containing neomacs and generated role copies
@@ -4207,8 +4217,9 @@ Options:
   --profile NAME      Build with cargo profile NAME, using target/<dir> for it.
                       `profiling` inherits release but keeps debug symbols, and
                       lives in target/profiling -- so it does NOT disturb an
-                      existing target/release build or its pdump. Unoptimized
-                      profiles (dev/debug/test) are rejected.
+                      existing target/release build or its pdump. Any explicit
+                      profile is accepted; dev skips Lisp byte-compilation for
+                      a faster inner loop.
   --dry-run           Print planned commands without running them
   --native-comp       Include native-comp-only COMPILE_FIRST entries
   --no-native-comp    Exclude native-comp-only COMPILE_FIRST entries

--- a/xtask/src/main_test.rs
+++ b/xtask/src/main_test.rs
@@ -760,6 +760,30 @@ fn parse_release_uses_release_bin_dir() {
 }
 
 #[test]
+fn parse_dev_skips_byte_compile_by_default() {
+    let options = parse_options(&["--profile", "dev"]);
+    assert_eq!(options.profile, BuildProfile::Dev);
+    assert_eq!(options.bin_dir, PathBuf::from("/repo/target/debug"));
+    assert!(options.no_byte_compile);
+}
+
+#[test]
+fn parse_dev_release_skips_byte_compile_by_default() {
+    let options = parse_options(&["--profile", "dev-release"]);
+    assert_eq!(options.profile, BuildProfile::DevRelease);
+    assert_eq!(options.bin_dir, PathBuf::from("/repo/target/dev-release"));
+    assert!(options.no_byte_compile);
+}
+
+#[test]
+fn parse_dev_preserves_no_byte_compile_flag() {
+    let options = parse_options(&["--profile", "dev", "--no-byte-compile"]);
+    assert_eq!(options.profile, BuildProfile::Dev);
+    assert_eq!(options.bin_dir, PathBuf::from("/repo/target/debug"));
+    assert!(options.no_byte_compile);
+}
+
+#[test]
 fn explicit_bin_dir_overrides_release_default() {
     let options = parse_options(&["--release", "--bin-dir", "out/neomacs-bin"]);
     assert_eq!(options.profile, BuildProfile::Release);
@@ -1554,6 +1578,17 @@ fn validate_primary_loaddefs_rejects_crlf_output_as_a_gnu_mismatch() {
         err.to_string().contains("missing GNU end boundary"),
         "CRLF output must remain a surfaced GNU mismatch: {err}"
     );
+}
+
+#[test]
+fn normalize_lisp_line_endings_rewrites_crlf() {
+    let tempdir = tempdir();
+    let path = tempdir.join("loaddefs.el");
+    fs::write(&path, b"first\r\nsecond\r\n").unwrap();
+
+    normalize_lisp_line_endings(&path).unwrap();
+
+    assert_eq!(fs::read(&path).unwrap(), b"first\nsecond\n");
 }
 
 #[test]


### PR DESCRIPTION
## Issue

Windows builds currently require several manual, environment-specific steps: configuring the GStreamer development SDK, generating the Lisp runtime, and assembling the DLL/plugin layout needed beside `neomacs.exe`. Raw Cargo output is not portable, and the CI, release, and installer workflows duplicate parts of this setup. This makes local reproduction and release packaging fragile, especially when runtime-only and development GStreamer files are mixed.

## Solution

- Add `scripts/emacs-build.ps1` as the single Windows build/package entry point, with independent build and package switches.
- Separate the build-time GStreamer SDK from the runtime MSI used for packaging.
- Vendor the required GStreamer runtime layout and discover the executable DLL closure with MSVC tooling.
- Harden `setup-windows-gstreamer.ps1` and add a self-contained setup contract test.
- Reuse the same setup and packaging flow from CI, release, and installer workflows.
- Keep installation user-scoped and preserve native Windows process-liveness behavior needed by the packaged runtime.

## Verification

- Windows installer-focused xtask tests pass (6 tests).
- `scripts/test-windows-gstreamer-setup.ps1` passes with both managed and custom SDK roots.
- A packaged `dev-release` build starts in batch and GUI modes with the runtime DLLs placed beside the executable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a streamlined Windows build and packaging process that produces validated ZIP archives with required runtime dependencies.
  - Added configurable Windows GStreamer setup with reusable local SDK resources and improved environment configuration.
  - Added Windows process detection support.
  - Added development build profiles that skip Lisp byte-compilation for faster iteration.

- **Bug Fixes**
  - Improved Windows build reliability, dependency handling, caching, and generated-file consistency.

- **Tests**
  - Added coverage for Windows GStreamer setup, packaging, process detection, development builds, and line-ending normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->