### PR TITLE
fix(load): preserve init-file identity and raw symbol errors

### DIFF
--- a/neovm-core/src/emacs_core/intern.rs
+++ b/neovm-core/src/emacs_core/intern.rs
@@ -38,7 +38,19 @@ impl std::fmt::Debug for SymId {
         // read could deadlock. `try_read` degrades to the id on contention.
         match global_symbol_registry().try_read() {
             Some(registry) => match registry.slot(*self) {
-                Some(slot) => write!(f, "SymId({} {})", self.0, registry.names.resolve(slot.name)),
+                Some(slot) => {
+                    let name = registry.names.resolve_lisp_string(slot.name);
+                    match name.as_utf8_str() {
+                        Some(name) => write!(f, "SymId({} {name})", self.0),
+                        None => write!(
+                            f,
+                            "SymId({} <{} raw byte{}>)",
+                            self.0,
+                            name.as_bytes().len(),
+                            if name.as_bytes().len() == 1 { "" } else { "s" }
+                        ),
+                    }
+                }
                 None => write!(f, "SymId({})", self.0),
             },
             None => write!(f, "SymId({})", self.0),

--- a/neovm-core/src/emacs_core/intern_test.rs
+++ b/neovm-core/src/emacs_core/intern_test.rs
@@ -657,3 +657,16 @@ fn sym_id_debug_resolves_the_symbol_name() {
         "got {embedded}"
     );
 }
+
+#[test]
+fn sym_id_debug_handles_raw_unibyte_symbol_names() {
+    crate::test_utils::init_test_tracing();
+    let id = intern_lisp_string(&unibyte_name(&[0xff]));
+    let rendered = format!("{id:?}");
+
+    assert!(
+        rendered == format!("SymId({})", id.0)
+            || rendered == format!("SymId({} <1 raw byte>)", id.0),
+        "got {rendered}"
+    );
+}

--- a/neovm-core/src/emacs_core/load.rs
+++ b/neovm-core/src/emacs_core/load.rs
@@ -2,7 +2,7 @@
 
 use super::builtins::collections::builtin_make_hash_table;
 use super::error::{EvalError, Flow, map_flow, signal};
-use super::intern::{intern, resolve_sym};
+use super::intern::{SymId, intern, resolve_sym};
 use super::keymap::is_list_keymap;
 use super::value::{Value, ValueKind, VecLikeType, list_to_vec};
 use super::value_reader::ReadSymbolShorthands;
@@ -234,9 +234,14 @@ pub(crate) fn decode_emacs_utf8(bytes: &[u8]) -> String {
 }
 
 /// Format a Value for human-readable error messages, resolving SymIds and heap-backed values.
+fn format_symbol_name_for_error(symbol: SymId) -> String {
+    let name = super::intern::resolve_sym_lisp_string(symbol);
+    crate::emacs_core::emacs_char::emacs_bytes_to_lossy_string(name.as_bytes(), name.is_multibyte())
+}
+
 fn format_value_for_error(v: &Value) -> String {
     match v.kind() {
-        ValueKind::Symbol(sid) => super::intern::resolve_sym(sid).to_string(),
+        ValueKind::Symbol(sid) => format_symbol_name_for_error(sid),
         ValueKind::String => format!("\"{}\"", load_string_text(v).expect("checked string")),
         ValueKind::Fixnum(n) => format!("{}", n),
         ValueKind::Nil => "nil".to_string(),
@@ -270,7 +275,7 @@ fn format_eval_error_in_state(eval: &super::eval::Context, err: &EvalError) -> S
             } else {
                 crate::emacs_core::error::print_value_in_state(eval, &Value::list(data.clone()))
             };
-            format!("({} {})", resolve_sym(*symbol), payload)
+            format!("({} {})", format_symbol_name_for_error(*symbol), payload)
         }
         EvalError::UncaughtThrow { tag, value } => format!(
             "(throw {} {})",
@@ -305,7 +310,7 @@ fn format_load_form_error(err: &EvalError) -> String {
                 let data_strs: Vec<String> = data.iter().map(format_value_for_error).collect();
                 format!("({})", data_strs.join(" "))
             };
-            format!("({} {})", resolve_sym(*symbol), payload)
+            format!("({} {})", format_symbol_name_for_error(*symbol), payload)
         }
         other => format!("{other:?}"),
     }
@@ -2160,6 +2165,16 @@ pub(crate) fn load_file_with_requested_and_found_options(
             ))],
             raw_data: None,
         });
+    }
+
+    let user_init_file = intern("user-init-file");
+    if eval
+        .visible_runtime_variable_value_by_id(user_init_file)
+        .map_err(map_flow)?
+        == Some(Value::T)
+    {
+        eval.try_set_runtime_binding_by_id(user_init_file, Value::heap_string(found.clone()))
+            .map_err(map_flow)?;
     }
 
     // GNU Emacs only signals `Recursive load` once the same found filename is

--- a/neovm-core/src/emacs_core/load_test.rs
+++ b/neovm-core/src/emacs_core/load_test.rs
@@ -40,6 +40,46 @@ fn load_name_equal_matches_lisp_equal_without_tagged_heap_allocation() {
     );
 }
 
+#[test]
+fn load_error_formatting_handles_raw_unibyte_symbol_names() {
+    crate::test_utils::init_test_tracing();
+    let name = crate::heap_types::LispString::from_unibyte(vec![0xff]);
+    let symbol = crate::emacs_core::intern::intern_lisp_string(&name);
+
+    assert_eq!(
+        format_value_for_error(&Value::from_sym_id(symbol)),
+        "\u{fffd}"
+    );
+}
+
+#[test]
+fn load_error_formatting_preserves_unibyte_symbol_encoding() {
+    crate::test_utils::init_test_tracing();
+    let name = crate::heap_types::LispString::from_unibyte(vec![0xc3, 0xa9]);
+    let symbol = crate::emacs_core::intern::intern_lisp_string(&name);
+
+    assert_eq!(
+        format_value_for_error(&Value::from_sym_id(symbol)),
+        "\u{fffd}\u{fffd}"
+    );
+}
+
+#[test]
+fn load_error_formatting_handles_raw_unibyte_signal_names() {
+    crate::test_utils::init_test_tracing();
+    let eval = Context::new();
+    let name = crate::heap_types::LispString::from_unibyte(vec![0xff]);
+    let symbol = crate::emacs_core::intern::intern_lisp_string(&name);
+    let error = EvalError::Signal {
+        symbol,
+        data: Vec::new(),
+        raw_data: None,
+    };
+
+    assert_eq!(format_load_form_error(&error), "(\u{fffd} nil)");
+    assert_eq!(format_eval_error_in_state(&eval, &error), "(\u{fffd} nil)");
+}
+
 fn isolated_runtime_bootstrap_eval() -> Context {
     let dump_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../target/test-cache/neovm-advice-stack-minibuffer-partial.pdump");
@@ -80,7 +120,7 @@ fn bootstrap_load_path_entries_use_gnu_windows_file_name_syntax() {
     let entries = bootstrap_load_path_entries(&lisp_dir);
     let first = entries
         .first()
-        .and_then(Value::as_lisp_string)
+        .and_then(|value| value.as_lisp_string())
         .map(|ls| crate::emacs_core::emacs_char::to_utf8_lossy(ls.as_bytes()))
         .expect("load-path should include lisp root");
     assert!(
@@ -9705,6 +9745,36 @@ fn nested_load_exact_gc_preserves_reader_load_file_name() {
     );
 
     let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn load_replaces_t_user_init_file_with_found_filename() {
+    crate::test_utils::init_test_tracing();
+    let temp = tempdir().expect("tempdir");
+    let file = temp.path().join("init.el");
+    fs::write(&file, "(setq vm-user-init-file-seen user-init-file)\n").expect("write fixture");
+
+    let mut eval = super::super::eval::Context::new();
+    eval.set_variable("user-init-file", Value::T);
+
+    let loaded = load_file(&mut eval, &file).expect("load fixture");
+    assert_eq!(loaded, Value::T);
+
+    let expected = crate::emacs_core::fileio::host_path_to_lisp_file_name_string(&file);
+    assert_eq!(
+        eval.obarray()
+            .symbol_value("vm-user-init-file-seen")
+            .and_then(|value| value.as_utf8_str()),
+        Some(expected.as_str()),
+        "the init file must see its resolved filename while loading",
+    );
+    assert_eq!(
+        eval.obarray()
+            .symbol_value("user-init-file")
+            .and_then(|value| value.as_utf8_str()),
+        Some(expected.as_str()),
+        "the resolved filename must persist after loading",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Issue

GNU startup temporarily sets `user-init-file` to `t` and relies on `load` to replace it with the filename that was actually found. Neomacs leaves the value as `t`, so startup or a later `eval-buffer` can pass a boolean to path functions and signal errors such as `(wrong-type-argument stringp t)`.

Load-error reporting also assumes symbol names are valid UTF-8. A raw or unibyte symbol in the original Lisp error can therefore trigger a Rust panic while formatting the diagnostic, hiding the real failure and potentially aborting while processing a panic.

## Solution

- When the visible `user-init-file` value is exactly `t`, replace it with the resolved `found` filename before evaluating the loaded forms and retain it after load completion.
- Preserve GNU load identity semantics by using `found`, rather than the requested or canonical host path.
- Format raw and unibyte symbol names without requiring valid UTF-8, so the original Lisp error remains reportable.
- Add regressions for the startup handshake and raw-symbol diagnostics.

This fixes the demonstrated GNU compatibility errors and the secondary diagnostic panic; it does not claim that the historical native abort had only this one cause.

## Verification

- `load_replaces_t_user_init_file_with_found_filename` passes.
- `sym_id_debug_handles_raw_unibyte_symbol_names` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of symbol names containing non-UTF-8 byte data without causing errors.
  * Load and evaluator error messages now render symbol and signal names more accurately.
  * Loading an init file now records the resolved filename when the setting is enabled.
  * Improved handling of init-file paths on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->