### PR TITLE
fix(display): honor pixel-size row offsets

### DIFF
--- a/neovm-core/src/emacs_core/builtins/symbols.rs
+++ b/neovm-core/src/emacs_core/builtins/symbols.rs
@@ -2197,6 +2197,51 @@ fn vertical_motion_screen_width(eval: &mut super::eval::Context, window: Option<
         .max(1)
 }
 
+pub(crate) fn screen_line_offset_target(
+    eval: &mut super::eval::Context,
+    window: Value,
+    buffer_id: crate::buffer::BufferId,
+    pos: EmacsBytePos,
+    lines: i64,
+) -> Result<EmacsBytePos, Flow> {
+    let screen_width = vertical_motion_screen_width(eval, Some(window));
+    let truncate_lines =
+        super::window_cmds::window_truncates_lines_for_motion(eval, Some(window), buffer_id);
+    let mut target = current_screen_line_start_with_truncation(
+        eval,
+        buffer_id,
+        pos,
+        screen_width,
+        truncate_lines,
+    )?
+    .unwrap_or(pos);
+
+    if lines < 0 {
+        return previous_screen_line_target(
+            eval,
+            buffer_id,
+            target,
+            screen_width,
+            truncate_lines,
+            lines.unsigned_abs() as usize,
+        )
+        .map(|(target, _)| target);
+    }
+
+    for _ in 0..lines {
+        let Some(step) =
+            next_visible_line_start(eval, buffer_id, target, screen_width, truncate_lines)?
+        else {
+            break;
+        };
+        target = step.next;
+        if !step.counts_line {
+            break;
+        }
+    }
+    Ok(target)
+}
+
 fn line_start_at_or_before(buf: &crate::buffer::buffer::Buffer, pos: EmacsBytePos) -> EmacsBytePos {
     let accessible = buf.accessible_emacs_byte_region();
     let begv = accessible.start();

--- a/neovm-core/src/emacs_core/xdisp.rs
+++ b/neovm-core/src/emacs_core/xdisp.rs
@@ -3399,27 +3399,35 @@ fn window_text_pixel_size_from_pos(
     buffers: &crate::buffer::BufferManager,
     buf: &Buffer,
     from: Option<&Value>,
-) -> Result<EmacsBytePos, Flow> {
+) -> Result<(EmacsBytePos, Option<i64>), Flow> {
     let beg = buf.point_min_lisp_char_pos();
     let end = buf.point_max_lisp_char_pos();
     let beg_byte = buf.lisp_pos_to_emacs_byte_pos(beg);
     let end_byte = buf.lisp_pos_to_emacs_byte_pos(end);
 
     match from {
-        None => Ok(beg_byte),
-        Some(value) if value.is_nil() => Ok(beg_byte),
-        Some(value) if value.is_t() => Ok(first_non_empty_line_start_in_region(
-            buf,
-            EmacsByteRange::new(beg_byte, end_byte),
+        None => Ok((beg_byte, None)),
+        Some(value) if value.is_nil() => Ok((beg_byte, None)),
+        Some(value) if value.is_t() => Ok((
+            first_non_empty_line_start_in_region(buf, EmacsByteRange::new(beg_byte, end_byte)),
+            None,
         )),
         Some(value) if value.is_cons() => {
             let pos = integer_or_marker_value_in_buffers(buffers, value.cons_car())?;
-            expect_fixnum_arg("integerp", &value.cons_cdr())?;
-            Ok(buffer_lisp_pos_to_emacs_byte_pos_clipped(buf, pos, beg))
+            let y_offset = value.cons_cdr();
+            expect_fixnum_arg("integerp", &y_offset)?;
+            let y_offset = y_offset.as_fixnum().expect("validated fixnum");
+            Ok((
+                buffer_lisp_pos_to_emacs_byte_pos_clipped(buf, pos, beg),
+                (y_offset != 0).then_some(y_offset),
+            ))
         }
         Some(value) => {
             let pos = integer_or_marker_value_in_buffers(buffers, *value)?;
-            Ok(buffer_lisp_pos_to_emacs_byte_pos_clipped(buf, pos, beg))
+            Ok((
+                buffer_lisp_pos_to_emacs_byte_pos_clipped(buf, pos, beg),
+                None,
+            ))
         }
     }
 }
@@ -3532,14 +3540,49 @@ pub(crate) fn builtin_window_text_pixel_size_ctx(
         return Ok(Value::cons(Value::fixnum(0), Value::fixnum(0)));
     };
 
-    let buf = eval.buffers.get(buf_id);
-    let Some(buf) = buf else {
-        return Ok(Value::cons(Value::fixnum(0), Value::fixnum(0)));
+    let (initial_from_pos, y_offset, max_offset_rows) = {
+        let Some(buf) = eval.buffers.get(buf_id) else {
+            return Ok(Value::cons(Value::fixnum(0), Value::fixnum(0)));
+        };
+        let (from_pos, y_offset) =
+            window_text_pixel_size_from_pos(&eval.buffers, buf, args.get(1))?;
+        let accessible = buf.accessible_emacs_byte_region();
+        (
+            from_pos,
+            y_offset,
+            accessible
+                .end()
+                .get()
+                .saturating_sub(accessible.start().get())
+                .saturating_add(1),
+        )
     };
 
     // Determine FROM/TO range.
-    let from_pos = window_text_pixel_size_from_pos(&eval.buffers, buf, args.get(1))?;
-    let to_pos = window_text_pixel_size_to_pos(&eval.buffers, buf, args.get(2), from_pos)?;
+    let from_pos = if let Some(y_offset) = y_offset {
+        let rows = (((y_offset.unsigned_abs() as f64) / f64::from(char_h.max(1.0))).ceil()
+            as usize)
+            .min(max_offset_rows);
+        let lines = i64::try_from(rows).unwrap_or(i64::MAX) * y_offset.signum();
+        super::builtins::symbols::screen_line_offset_target(
+            eval,
+            Value::make_window(wid.0 as u64),
+            buf_id,
+            initial_from_pos,
+            lines,
+        )?
+    } else {
+        initial_from_pos
+    };
+    let (to_pos, reported_start) = {
+        let Some(buf) = eval.buffers.get(buf_id) else {
+            return Ok(Value::cons(Value::fixnum(0), Value::fixnum(0)));
+        };
+        (
+            window_text_pixel_size_to_pos(&eval.buffers, buf, args.get(2), from_pos)?,
+            y_offset.map(|_| Value::fixnum(buf.emacs_byte_pos_to_lisp_char_pos(from_pos).as_i64())),
+        )
+    };
     // GNU's TO=t means measure through the line ending the last non-empty line,
     // not through trailing blank lines.
     let apply_trim = args
@@ -3576,7 +3619,15 @@ pub(crate) fn builtin_window_text_pixel_size_ctx(
     };
     let height = ((text_metrics.lines as f32 + mode_line_rows) * char_h).ceil() as i64;
 
-    Ok(Value::cons(Value::fixnum(width), Value::fixnum(height)))
+    if let Some(reported_start) = reported_start {
+        Ok(Value::list(vec![
+            Value::fixnum(width),
+            Value::fixnum(height),
+            reported_start,
+        ]))
+    } else {
+        Ok(Value::cons(Value::fixnum(width), Value::fixnum(height)))
+    }
 }
 
 fn resolve_live_window_for_text_pixel_size(

--- a/neovm-core/src/emacs_core/xdisp_test.rs
+++ b/neovm-core/src/emacs_core/xdisp_test.rs
@@ -2136,6 +2136,109 @@ fn test_window_text_pixel_size_plain_text_unchanged_by_fix() {
     assert_eq!(result.cons_cdr(), Value::fixnum(2));
 }
 
+#[test]
+fn window_text_pixel_size_cons_from_reports_offset_start() {
+    crate::test_utils::init_test_tracing();
+    let (mut eval, selected_window) = pixel_size_tty_context();
+    let buf_id = eval.buffers.current_buffer().expect("current buffer").id;
+    eval.buffers
+        .get_mut(buf_id)
+        .expect("buffer")
+        .insert("a\nb\nc\nd\ne\n");
+
+    let result = builtin_window_text_pixel_size_ctx(
+        &mut eval,
+        vec![
+            Value::make_window(selected_window as u64),
+            Value::cons(Value::fixnum(11), Value::fixnum(-3)),
+            Value::fixnum(11),
+            Value::NIL,
+            Value::NIL,
+        ],
+    )
+    .expect("window-text-pixel-size");
+
+    assert_eq!(
+        result,
+        Value::list(vec![Value::fixnum(1), Value::fixnum(3), Value::fixnum(5),])
+    );
+}
+
+#[test]
+fn window_text_pixel_size_zero_cons_offset_preserves_pair_shape() {
+    crate::test_utils::init_test_tracing();
+    let (mut eval, selected_window) = pixel_size_tty_context();
+    let buf_id = eval.buffers.current_buffer().expect("current buffer").id;
+    eval.buffers
+        .get_mut(buf_id)
+        .expect("buffer")
+        .insert("a\nb\n");
+
+    let result = builtin_window_text_pixel_size_ctx(
+        &mut eval,
+        vec![
+            Value::make_window(selected_window as u64),
+            Value::cons(Value::fixnum(5), Value::fixnum(0)),
+            Value::fixnum(5),
+        ],
+    )
+    .expect("window-text-pixel-size");
+
+    assert_eq!(result, Value::cons(Value::fixnum(0), Value::fixnum(0)));
+}
+
+#[test]
+fn window_text_pixel_size_positive_cons_offset_moves_forward() {
+    crate::test_utils::init_test_tracing();
+    let (mut eval, selected_window) = pixel_size_tty_context();
+    let buf_id = eval.buffers.current_buffer().expect("current buffer").id;
+    eval.buffers
+        .get_mut(buf_id)
+        .expect("buffer")
+        .insert("a\nb\nc\nd\ne\n");
+
+    let result = builtin_window_text_pixel_size_ctx(
+        &mut eval,
+        vec![
+            Value::make_window(selected_window as u64),
+            Value::cons(Value::fixnum(1), Value::fixnum(3)),
+            Value::fixnum(11),
+        ],
+    )
+    .expect("window-text-pixel-size");
+
+    assert_eq!(
+        result,
+        Value::list(vec![Value::fixnum(1), Value::fixnum(2), Value::fixnum(7),])
+    );
+}
+
+#[test]
+fn window_text_pixel_size_cons_offset_counts_wrapped_rows() {
+    crate::test_utils::init_test_tracing();
+    let (mut eval, selected_window) = pixel_size_tty_context();
+    let buf_id = eval.buffers.current_buffer().expect("current buffer").id;
+    eval.buffers
+        .get_mut(buf_id)
+        .expect("buffer")
+        .insert(&format!("{}\nb\nc\n", "a".repeat(400)));
+
+    let result = builtin_window_text_pixel_size_ctx(
+        &mut eval,
+        vec![
+            Value::make_window(selected_window as u64),
+            Value::cons(Value::fixnum(406), Value::fixnum(-3)),
+            Value::fixnum(406),
+        ],
+    )
+    .expect("window-text-pixel-size");
+
+    assert_eq!(
+        result,
+        Value::list(vec![Value::fixnum(2), Value::fixnum(3), Value::fixnum(399),])
+    );
+}
+
 /// GNU's display iterator resolves every `face' property run while measuring
 /// text for `window-text-pixel-size'.  A missing named face is therefore a
 /// log-only diagnostic even when no redisplay callback is installed (the path


### PR DESCRIPTION
## Issue

`window-text-pixel-size` does not support GNU Emacs's `(POSITION . Y-OFFSET)` input and result shape. Ghostel expects this form and otherwise hits redisplay errors such as `(wrong-type-argument listp (0 . 0))`; the failure is reproducible on Linux as well as Windows.

## Solution

- Parse `(POSITION . Y-OFFSET)` and preserve the existing pair result for a zero offset.
- Convert nonzero pixel offsets into movement across displayed screen rows, including wrapped rows.
- Return `(WIDTH HEIGHT START-POSITION)` when offset reporting is requested.
- Add regressions for negative, zero, positive, and wrapped-row offsets.

## Verification

- `cargo test -p neovm-core --lib window_text_pixel_size_ -- --nocapture` passes (21 tests).
- `cargo fmt --all -- --check` passes.
- `cargo build -p neomacs` passes on Windows.

Split from #273 at the maintainer's request.