### PR TITLE
fix(display): honor display-table glyph faces

### DIFF
--- a/neomacs-layout-engine/src/buffer_source/face_resolution.rs
+++ b/neomacs-layout-engine/src/buffer_source/face_resolution.rs
@@ -320,6 +320,24 @@ impl BufferSourceItemLayoutResolutionContext<'_> {
         item.face =
             RenderFaceRef::FaceId(render_face_ref_id(item.face, active_face_state.face_id()));
 
+        let display_table_face_name = match &item.kind {
+            DisplayItemKind::SourceMappedText(text) => text.face_name().map(str::to_owned),
+            _ => None,
+        };
+        let active_face_state = if let Some(face_name) = display_table_face_name.as_deref() {
+            self.merge_display_table_active_face(
+                source_render,
+                face_ids,
+                row_geometry,
+                active_face_state,
+                item,
+                face_name,
+            )
+            .unwrap_or_else(|| active_face_state.clone())
+        } else {
+            active_face_state.clone()
+        };
+
         // GNU `merge_escape_glyph_face` (xdisp.c:8372-8389): a control char shown
         // as `^A` paints in the `escape-glyph` face merged over the surrounding
         // base face. Realize that merged face here, install it, and use it as the
@@ -331,7 +349,7 @@ impl BufferSourceItemLayoutResolutionContext<'_> {
                 source_render,
                 face_ids,
                 row_geometry,
-                active_face_state,
+                &active_face_state,
                 item,
                 "escape-glyph",
             )
@@ -355,7 +373,7 @@ impl BufferSourceItemLayoutResolutionContext<'_> {
                 source_render,
                 face_ids,
                 row_geometry,
-                active_face_state,
+                &active_face_state,
                 item,
                 face_name,
             )
@@ -398,13 +416,27 @@ impl BufferSourceItemLayoutResolutionContext<'_> {
         resolved_active_face
     }
 
-    /// Realize a face = the surrounding base (active) face merged with the named
-    /// face (GNU `merge_faces (w, <face>, 0, base_face_id)`), install it under a
-    /// fresh id, set the item to that face, and return it as the active-face
-    /// state. Returns `None` when the merge changes nothing (no themed
-    /// foreground), so plain terminals keep the surrounding face exactly like
-    /// GNU's no-op merge. Shared by the escape-glyph (control char) and
-    /// nobreak-space/nobreak-hyphen (nbsp/hyphen) hooks.
+    /// Realize a display-table face merged over the active face, retaining all
+    /// named-face attributes. Returns `None` when the full merge is unchanged.
+    fn merge_display_table_active_face(
+        &self,
+        source_render: &mut TextRowSourceRenderState<'_>,
+        face_ids: &mut FrameFaceAttempt,
+        row_geometry: &mut DisplayRowGeometryState,
+        active_face_state: &DisplayRowActiveFaceState,
+        item: &mut DisplayItem,
+        face_name: &str,
+    ) -> Option<DisplayRowActiveFaceState> {
+        let base = active_face_state.resolved_face();
+        let merged = source_render.merge_named_face_over(base, face_name);
+        if merged == *base {
+            return None;
+        }
+        Some(self.install_merged_active_face(source_render, face_ids, row_geometry, item, merged))
+    }
+
+    /// Realize the legacy escape/nobreak face merge. Its foreground-only
+    /// no-op rule is intentional and keeps those paths unchanged.
     fn merge_named_active_face(
         &self,
         source_render: &mut TextRowSourceRenderState<'_>,
@@ -419,6 +451,17 @@ impl BufferSourceItemLayoutResolutionContext<'_> {
         if merged.fg == base.fg && merged.use_default_foreground == base.use_default_foreground {
             return None;
         }
+        Some(self.install_merged_active_face(source_render, face_ids, row_geometry, item, merged))
+    }
+
+    fn install_merged_active_face(
+        &self,
+        source_render: &mut TextRowSourceRenderState<'_>,
+        face_ids: &mut FrameFaceAttempt,
+        row_geometry: &mut DisplayRowGeometryState,
+        item: &mut DisplayItem,
+        merged: ResolvedFace,
+    ) -> DisplayRowActiveFaceState {
         let face_id = stable_face_id_for_resolved(face_ids, &merged);
         item.face = RenderFaceRef::FaceId(face_id);
         let resolved_active_face = source_render.resolve_and_install_measured_face(
@@ -430,7 +473,7 @@ impl BufferSourceItemLayoutResolutionContext<'_> {
         );
         let metrics = resolved_active_face.metrics();
         row_geometry.include_row_extents(metrics.row_height(), metrics.ascent());
-        Some(resolved_active_face)
+        resolved_active_face
     }
 }
 

--- a/neomacs-layout-engine/src/buffer_source/text_source.rs
+++ b/neomacs-layout-engine/src/buffer_source/text_source.rs
@@ -670,7 +670,7 @@ impl<'a, B: LayoutBufferView + ?Sized> BufferTextSourceCursor<'a, B> {
             // A char that the active display table remaps to a glyph vector must
             // break the plain text run so it is emitted as its own item (GNU
             // `DISP_CHAR_VECTOR` is consulted per character in the producer).
-            if self.display_table_glyphs(ch).is_some() {
+            if crate::neovm_bridge::buffer_display_table_glyph_vector_p(self.buffer, ch) {
                 break;
             }
             end = end.add_len(CharLen::new(1));
@@ -679,10 +679,13 @@ impl<'a, B: LayoutBufferView + ?Sized> BufferTextSourceCursor<'a, B> {
     }
 
     /// Resolve the active display table's glyph vector for `ch`, returning the
-    /// decoded glyph characters to display in place of `ch` (GNU
+    /// decoded glyph characters and any homogeneous face to display in place of `ch` (GNU
     /// `DISP_CHAR_VECTOR`).  `None` is the hot path (no table / no entry / not a
     /// vector) and leaves `ch` to render literally.
-    fn display_table_glyphs(&self, ch: char) -> Option<String> {
+    fn display_table_glyphs(
+        &self,
+        ch: char,
+    ) -> Option<crate::neovm_bridge::BufferDisplayTableGlyphs> {
         crate::neovm_bridge::buffer_display_table_glyphs(self.buffer, ch)
     }
 
@@ -752,6 +755,7 @@ impl<'a, B: LayoutBufferView + ?Sized> BufferTextSourceCursor<'a, B> {
         // decoded glyph is appended as a real glyph (a `?\t` glyph re-expands
         // through the ordinary tab path), keeping the row non-blank.
         if let Some(glyphs) = self.display_table_glyphs(ch) {
+            let crate::neovm_bridge::BufferDisplayTableGlyphs { text, face_name } = glyphs;
             self.char_pos = start.add_len(CharLen::new(1));
             // GNU iterates a display-table entry element-by-element and decides
             // end-of-line on the DISPLAYED char: `ITERATOR_AT_END_OF_LINE_P`
@@ -764,13 +768,15 @@ impl<'a, B: LayoutBufferView + ?Sized> BufferTextSourceCursor<'a, B> {
             // the next row resumes on the following char. An entry WITHOUT a
             // trailing `\n` (e.g. `[$]`) keeps the plain no-break replacement,
             // matching GNU (the newline's break is fully replaced -> lines join).
-            if ch == '\n' && glyphs.ends_with('\n') {
-                let prefix = glyphs[..glyphs.len() - '\n'.len_utf8()].to_string();
+            if ch == '\n' && text.ends_with('\n') {
+                let prefix = text[..text.len() - '\n'.len_utf8()].to_string();
                 return Some(
                     DisplayItem::new(
                         self.span(start, self.char_pos),
                         face,
-                        DisplayItemKind::SourceMappedText(DisplaySourceMappedText::new(prefix)),
+                        DisplayItemKind::SourceMappedText(
+                            DisplaySourceMappedText::new(prefix).with_face_name(face_name),
+                        ),
                     )
                     .with_layout(layout)
                     .with_break_after_row(),
@@ -780,7 +786,9 @@ impl<'a, B: LayoutBufferView + ?Sized> BufferTextSourceCursor<'a, B> {
                 DisplayItem::new(
                     self.span(start, self.char_pos),
                     face,
-                    DisplayItemKind::SourceMappedText(DisplaySourceMappedText::new(glyphs)),
+                    DisplayItemKind::SourceMappedText(
+                        DisplaySourceMappedText::new(text).with_face_name(face_name),
+                    ),
                 )
                 .with_layout(layout),
             );

--- a/neomacs-layout-engine/src/display_item.rs
+++ b/neomacs-layout-engine/src/display_item.rs
@@ -719,6 +719,10 @@ pub(crate) struct DisplaySourceMappedText {
     /// `None` retains the covered-start rule used by escape/composition
     /// expansions.
     pub(crate) glyph_string_start: Option<DisplaySourcePosition>,
+    /// Optional homogeneous named face carried by a display-table glyph
+    /// vector. Mixed or zero faces leave this unset and inherit the active
+    /// buffer face.
+    pub(crate) face_name: Option<Box<str>>,
 }
 
 impl DisplaySourceMappedText {
@@ -726,6 +730,7 @@ impl DisplaySourceMappedText {
         Self {
             text: text.into(),
             glyph_string_start: None,
+            face_name: None,
         }
     }
 
@@ -740,7 +745,17 @@ impl DisplaySourceMappedText {
         Self {
             text: text.into(),
             glyph_string_start: Some(glyph_string_start),
+            face_name: None,
         }
+    }
+
+    pub(crate) fn with_face_name(mut self, face_name: Option<String>) -> Self {
+        self.face_name = face_name.map(Into::into);
+        self
+    }
+
+    pub(crate) fn face_name(&self) -> Option<&str> {
+        self.face_name.as_deref()
     }
 
     /// Keep the displayed text and its glyph-coordinate origin transactional
@@ -756,6 +771,7 @@ impl DisplaySourceMappedText {
             glyph_string_start: self
                 .glyph_string_start
                 .map(|start| start.advanced_by(emitted_chars, split_byte)),
+            face_name: self.face_name,
         })
     }
 }

--- a/neomacs-layout-engine/src/display_item_test.rs
+++ b/neomacs-layout-engine/src/display_item_test.rs
@@ -176,6 +176,17 @@ fn display_item_source_trait_exposes_items() {
 }
 
 #[test]
+fn display_source_mapped_text_remainder_preserves_face_name() {
+    let remainder = DisplaySourceMappedText::new("abc")
+        .with_face_name(Some("bold".to_owned()))
+        .into_remainder_after(1)
+        .expect("one-character remainder");
+
+    assert_eq!(remainder.text.as_ref(), "bc");
+    assert_eq!(remainder.face_name(), Some("bold"));
+}
+
+#[test]
 fn glyphless_method_routes_cf_format_control_to_zero_width() {
     let m = |c: char| glyphless_method_for_char(c, GlyphlessJoinerPolicy::ClassifyAsGlyphless);
     // GNU `format-control` group (Cf, except SHY): the interlinear annotation

--- a/neomacs-layout-engine/src/engine_test.rs
+++ b/neomacs-layout-engine/src/engine_test.rs
@@ -4952,6 +4952,212 @@ fn layout_frame_rust_display_table_maps_char_to_glyph_vector() {
 }
 
 #[test]
+fn layout_frame_rust_display_table_newline_glyph_uses_face_and_breaks_row() {
+    let mut eval = Context::new();
+    let buf_id = eval
+        .buffer_manager()
+        .current_buffer()
+        .expect("current buffer")
+        .id();
+    {
+        let buffer = eval.buffer_manager_mut().get_mut(buf_id).expect("buffer");
+        buffer.insert("a\nb");
+    }
+    let frame_id =
+        eval.frame_manager_mut()
+            .create_frame("display-table-newline-face", 360, 180, buf_id);
+    assert!(eval.frame_manager_mut().select_frame(frame_id));
+    let face_setup = eval.eval_str_each(
+        "(internal-set-lisp-face-attribute \
+          'whitespace-newline :foreground \"#555555\" (selected-frame))",
+    );
+    assert!(
+        face_setup.iter().all(Result::is_ok),
+        "display-table face setup must succeed, got {face_setup:?}"
+    );
+    let face_id = eval
+        .eval_str("(get 'whitespace-newline 'face)")
+        .expect("face-id")
+        .as_fixnum()
+        .expect("numeric Lisp face id");
+    {
+        let table = Value::make_char_table(Value::symbol("display-table"), Value::NIL, 6);
+        let glyphs = Value::vector(vec![
+            Value::cons(Value::fixnum('↪' as i64), Value::fixnum(face_id)),
+            Value::fixnum('\n' as i64),
+        ]);
+        neovm_core::emacs_core::chartable::ct_set_single(&table, '\n' as i64, glyphs);
+        eval.buffer_manager_mut()
+            .get_mut(buf_id)
+            .expect("buffer")
+            .set_buffer_local("buffer-display-table", table);
+    }
+
+    let selected_window = eval
+        .frame_manager()
+        .get(frame_id)
+        .expect("frame")
+        .selected_window;
+    let mut engine = LayoutEngine::new();
+    engine.layout_frame_rust(&mut eval, frame_id);
+
+    let state = engine
+        .last_frame_display_state
+        .as_ref()
+        .expect("display state");
+    let entry = state
+        .window_matrices
+        .iter()
+        .find(|entry| entry.window_id.get() == selected_window.0 as i64)
+        .expect("selected window matrix");
+    let text_rows: Vec<_> = entry
+        .matrix
+        .rows
+        .iter()
+        .filter(|row| row.enabled && row.role == GlyphRowRole::Text && row.displays_text)
+        .collect();
+    assert!(
+        text_rows.len() >= 2,
+        "display newline must break into two rows"
+    );
+
+    let first_row_glyphs = &text_rows[0].glyphs[GlyphArea::Text.index()];
+    let arrow = first_row_glyphs
+        .iter()
+        .find(|glyph| matches!(glyph.glyph_type, GlyphType::Char { ch: '↪' }))
+        .expect("visible display-table arrow");
+    let arrow_face = state.faces.get(&arrow.face_id).expect("arrow face");
+    let base = first_row_glyphs
+        .iter()
+        .find(|glyph| matches!(glyph.glyph_type, GlyphType::Char { ch: 'a' }))
+        .expect("surrounding base glyph");
+    let base_face = state.faces.get(&base.face_id).expect("base face");
+    assert_ne!(
+        arrow.face_id, base.face_id,
+        "display-table arrow must use a distinct resolved face"
+    );
+    assert_eq!(
+        arrow_face.foreground,
+        neomacs_display_protocol::types::Color::from_pixel(0x00555555),
+        "display-table arrow must use whitespace-newline foreground"
+    );
+    assert_ne!(
+        arrow_face.foreground, base_face.foreground,
+        "display-table arrow foreground must differ from surrounding text"
+    );
+    assert!(
+        text_rows[1].glyphs[GlyphArea::Text.index()]
+            .iter()
+            .any(|glyph| matches!(glyph.glyph_type, GlyphType::Char { ch: 'b' })),
+        "the trailing newline glyph must still break the row"
+    );
+}
+
+#[test]
+fn layout_frame_rust_display_table_face_preserves_attributes_and_height() {
+    use neomacs_display_protocol::face::FaceAttributes;
+    use neomacs_display_protocol::types::Color;
+
+    let mut eval = Context::new();
+    let buf_id = eval
+        .buffer_manager()
+        .current_buffer()
+        .expect("current buffer")
+        .id();
+    {
+        let buffer = eval.buffer_manager_mut().get_mut(buf_id).expect("buffer");
+        buffer.insert("axb\n");
+    }
+    let frame_id =
+        eval.frame_manager_mut()
+            .create_frame("display-table-full-face", 360, 180, buf_id);
+    assert!(eval.frame_manager_mut().select_frame(frame_id));
+    let face_setup = eval.eval_str_each(
+        "(internal-set-lisp-face-attribute \
+          '__display-table-face :background \"#112233\" (selected-frame))\
+         (internal-set-lisp-face-attribute \
+          '__display-table-face :underline t (selected-frame))\
+         (internal-set-lisp-face-attribute \
+          '__display-table-face :weight 'bold (selected-frame))",
+    );
+    assert!(
+        face_setup.iter().all(Result::is_ok),
+        "display-table face setup must succeed, got {face_setup:?}"
+    );
+    let face_id = eval
+        .eval_str("(get '__display-table-face 'face)")
+        .expect("face-id")
+        .as_fixnum()
+        .expect("numeric Lisp face id");
+    {
+        let table = Value::make_char_table(Value::symbol("display-table"), Value::NIL, 6);
+        neovm_core::emacs_core::chartable::ct_set_single(
+            &table,
+            'x' as i64,
+            Value::vector(vec![Value::cons(
+                Value::fixnum('<' as i64),
+                Value::fixnum(face_id),
+            )]),
+        );
+        let buffer = eval.buffer_manager_mut().get_mut(buf_id).expect("buffer");
+        buffer.set_buffer_local("buffer-display-table", table);
+        buffer.put_text_property(
+            1,
+            2,
+            Value::symbol("display"),
+            Value::list(vec![Value::keyword(":height"), Value::fixnum(2)]),
+        );
+    }
+
+    let selected_window = eval
+        .frame_manager()
+        .get(frame_id)
+        .expect("frame")
+        .selected_window;
+    let mut engine = LayoutEngine::new();
+    engine.layout_frame_rust(&mut eval, frame_id);
+
+    let state = engine
+        .last_frame_display_state
+        .as_ref()
+        .expect("display state");
+    let entry = state
+        .window_matrices
+        .iter()
+        .find(|entry| entry.window_id.get() == selected_window.0 as i64)
+        .expect("selected window matrix");
+    let row = entry
+        .matrix
+        .rows
+        .iter()
+        .find(|row| row.enabled && row.role == GlyphRowRole::Text && row.displays_text)
+        .expect("text row");
+    let text_glyphs = &row.glyphs[GlyphArea::Text.index()];
+    let mapped = text_glyphs
+        .iter()
+        .find(|glyph| matches!(glyph.glyph_type, GlyphType::Char { ch: '<' }))
+        .expect("mapped glyph");
+    let base = text_glyphs
+        .iter()
+        .find(|glyph| matches!(glyph.glyph_type, GlyphType::Char { ch: 'a' }))
+        .expect("base glyph");
+    let mapped_face = state.faces.get(&mapped.face_id).expect("mapped face");
+    let base_face = state.faces.get(&base.face_id).expect("base face");
+
+    assert_eq!(mapped_face.background, Color::from_pixel(0x00112233));
+    assert_eq!(
+        mapped_face.foreground, base_face.foreground,
+        "the explicit display-table face leaves the base foreground unchanged"
+    );
+    assert_eq!(mapped_face.font_weight, 700);
+    assert!(mapped_face.attributes.contains(FaceAttributes::UNDERLINE));
+    assert!(
+        mapped_face.font_size > base_face.font_size,
+        "height modifier must apply after the display-table face merge"
+    );
+}
+
+#[test]
 fn layout_frame_rust_display_table_replaces_newline_without_row_break() {
     let text = "a\nb\n";
     let setup = |buffer: &mut neovm_core::buffer::Buffer, _id: BufferId, _t: &str| {

--- a/neomacs-layout-engine/src/neovm_bridge.rs
+++ b/neomacs-layout-engine/src/neovm_bridge.rs
@@ -1115,21 +1115,30 @@ fn buffer_fill_column_indicator(buffer: &Buffer, obarray: &Obarray) -> Option<(i
 /// table's extra slots (`DISP_INVIS_VECTOR`, `disptab.h:35` -> `extras[4]`).
 const DISP_INVIS_VECTOR_SLOT: usize = 4;
 
-/// Decode a display-table glyph code to its character.
-///
+/// The decoded text and optional homogeneous nonzero Lisp face carried by a
+/// display-table glyph vector.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct BufferDisplayTableGlyphs {
+    pub(crate) text: String,
+    pub(crate) face_name: Option<String>,
+}
+
 /// `make-glyph-code` (`disp-table.el`) encodes a glyph as either a bare
 /// character fixnum, a fixnum packing the face id above the low 22 char bits,
-/// or a `(char . face-id)` cons when the face id needs more than 6 bits.  Here
-/// we only need the character; the face is currently rendered with the active
-/// (preceding text) face, matching GNU's common `setup_for_ellipsis` path
-/// where the glyph carries the default face.
-fn glyph_code_char(glyph: Value) -> Option<char> {
-    let code = if glyph.is_cons() {
-        glyph.cons_car().as_fixnum()?
+/// or a `(char . face-id)` cons when the face id needs more than 6 bits.
+fn glyph_code_parts(glyph: Value) -> Option<(char, Option<i64>)> {
+    let (code, face_id) = if glyph.is_cons() {
+        (glyph.cons_car().as_fixnum()?, glyph.cons_cdr().as_fixnum())
     } else {
-        glyph.as_fixnum()?
+        let code = glyph.as_fixnum()?;
+        (code, Some(code >> 22))
     };
-    char::from_u32((code as u64 & 0x3F_FFFF) as u32)
+    let ch = char::from_u32((code as u64 & 0x3F_FFFF) as u32)?;
+    Some((ch, face_id.filter(|face_id| *face_id > 0)))
+}
+
+fn glyph_code_char(glyph: Value) -> Option<char> {
+    glyph_code_parts(glyph).map(|(ch, _)| ch)
 }
 
 /// The active display table for a buffer: `buffer-display-table`, else
@@ -1147,6 +1156,21 @@ fn active_buffer_display_table<B: LayoutBufferView + ?Sized>(buffer: &B) -> Opti
 /// remap arbitrary chars, so such buffers stay on the buffer pipeline.
 pub(crate) fn buffer_has_active_display_table<B: LayoutBufferView + ?Sized>(buffer: &B) -> bool {
     active_buffer_display_table(buffer).is_some()
+}
+
+/// Whether the active display table maps `ch` to a glyph vector. This keeps
+/// text-run scanning on the cheap presence path; decoding is deferred until
+/// the mapped item is emitted.
+pub(crate) fn buffer_display_table_glyph_vector_p<B: LayoutBufferView + ?Sized>(
+    buffer: &B,
+    ch: char,
+) -> bool {
+    let Some(table) = active_buffer_display_table(buffer) else {
+        return false;
+    };
+    neovm_core::emacs_core::chartable::ct_ref(&table, ch as i64)
+        .as_vector_data()
+        .is_some()
 }
 
 /// Resolve the ellipsis string GNU renders for invisible/selective-display
@@ -1173,34 +1197,49 @@ pub(crate) fn buffer_invisible_ellipsis_text<B: LayoutBufferView>(buffer: &B) ->
 }
 
 /// Resolve the per-character display-vector for `ch` from the active display
-/// table, returning the decoded glyph characters to render in place of `ch`.
+/// table, returning the decoded glyph characters and an optional homogeneous
+/// face name to render in place of `ch`.
 ///
 /// Mirrors GNU `get_next_display_element` (`xdisp.c:8463`): `dv =
 /// DISP_CHAR_VECTOR(it->dp, c)`; when `dv` is a non-empty vector the character
 /// is displayed as the sequence of glyph codes in the vector (each decoded by
 /// `GLYPH_CODE_CHAR = code & MAX_CHAR`), all sharing the original char's buffer
-/// position.  We return the decoded glyph string so the caller can emit it as a
-/// single `SourceMappedText` item over the one source char (the whole vector is
-/// one display item, consumed once — matching GNU's `dpvec_char_len`-once
-/// advance), and so a `?\t` glyph inside the vector re-expands through the
-/// normal tab path.
+/// position.  We return the decoded glyph string and face hint so the caller
+/// can emit it as a single `SourceMappedText` item over the one source char
+/// (the whole vector is one display item, consumed once — matching GNU's
+/// `dpvec_char_len`-once advance), and so a `?\t` glyph inside the vector
+/// re-expands through the normal tab path.
 ///
 /// Returns `None` (the hot path) when there is no active display table, no
 /// entry for `ch`, or the entry is not a vector — leaving `ch` to render
 /// literally.  An EMPTY vector means "display nothing"; we return `Some("")`
 /// so the char is replaced by no glyphs (GNU skips it entirely).
 ///
-/// Per-glyph faces (`GLYPH_CODE_FACE = code >> 22`) are not yet honored here:
-/// the whole mapped vector inherits the source char's active face, which is
-/// correct for the common `make-glyph-code` form with no face (face id 0).
 pub(crate) fn buffer_display_table_glyphs<B: LayoutBufferView + ?Sized>(
     buffer: &B,
     ch: char,
-) -> Option<String> {
+) -> Option<BufferDisplayTableGlyphs> {
     let table = active_buffer_display_table(buffer)?;
     let entry = neovm_core::emacs_core::chartable::ct_ref(&table, ch as i64);
     let glyphs = entry.as_vector_data()?;
-    Some(glyphs.iter().filter_map(|g| glyph_code_char(*g)).collect())
+    let decoded: Vec<_> = glyphs
+        .iter()
+        .filter_map(|glyph| glyph_code_parts(*glyph))
+        .collect();
+    let text = decoded.iter().map(|(ch, _)| *ch).collect();
+    let visible = decoded
+        .last()
+        .is_some_and(|(last, _)| *last == '\n' && ch == '\n')
+        .then(|| &decoded[..decoded.len() - 1])
+        .unwrap_or(&decoded);
+    let face_id = visible
+        .first()
+        .and_then(|(_, face_id)| *face_id)
+        .filter(|face_id| visible.iter().all(|(_, other)| *other == Some(*face_id)));
+    Some(BufferDisplayTableGlyphs {
+        text,
+        face_name: face_id.and_then(neovm_core::emacs_core::xfaces::face_name_for_id),
+    })
 }
 
 pub(crate) fn buffer_selective_display<B: LayoutBufferView>(buffer: &B) -> i32 {

--- a/neomacs-layout-engine/src/neovm_bridge_test.rs
+++ b/neomacs-layout-engine/src/neovm_bridge_test.rs
@@ -1815,17 +1815,142 @@ fn buffer_display_table_glyphs_decodes_per_char_vector() {
 
     let buf = evaluator.buffer_manager().get(buf_id).unwrap();
     assert_eq!(
-        buffer_display_table_glyphs(buf, '\t').as_deref(),
-        Some(">\t"),
+        buffer_display_table_glyphs(buf, '\t').map(|glyphs| glyphs.text),
+        Some(">\t".to_string()),
         "tab maps to '>' then a literal tab glyph"
     );
-    assert_eq!(buffer_display_table_glyphs(buf, 'x').as_deref(), Some("A"));
+    assert_eq!(
+        buffer_display_table_glyphs(buf, 'x').map(|glyphs| glyphs.text),
+        Some("A".to_string())
+    );
     // Empty vector -> Some("") (display nothing), distinct from None (no entry).
-    assert_eq!(buffer_display_table_glyphs(buf, 'q').as_deref(), Some(""));
+    assert_eq!(
+        buffer_display_table_glyphs(buf, 'q').map(|glyphs| glyphs.text),
+        Some(String::new())
+    );
     // A plain-character entry is NOT a glyph vector -> None (render literally).
     assert_eq!(buffer_display_table_glyphs(buf, 'n'), None);
     // An unmapped char -> None (the hot path).
     assert_eq!(buffer_display_table_glyphs(buf, 'z'), None);
+}
+
+#[test]
+fn buffer_display_table_glyphs_reports_homogeneous_visible_face() {
+    let mut evaluator = neovm_core::emacs_core::Context::new();
+    let buf_id = evaluator
+        .buffer_manager_mut()
+        .create_buffer("*disp-char-face*");
+    let face_id = evaluator
+        .eval_str("(get 'bold 'face)")
+        .expect("bold face id")
+        .as_fixnum()
+        .expect("numeric face id");
+    let table = Value::make_char_table(Value::symbol("display-table"), Value::NIL, 6);
+    neovm_core::emacs_core::chartable::ct_set_single(
+        &table,
+        '\n' as i64,
+        Value::vector(vec![
+            Value::cons(Value::fixnum('↪' as i64), Value::fixnum(face_id)),
+            Value::cons(Value::fixnum('\n' as i64), Value::fixnum(face_id + 1)),
+        ]),
+    );
+    neovm_core::emacs_core::chartable::ct_set_single(
+        &table,
+        'm' as i64,
+        Value::vector(vec![
+            Value::cons(Value::fixnum('a' as i64), Value::fixnum(face_id)),
+            Value::cons(Value::fixnum('b' as i64), Value::fixnum(face_id + 1)),
+        ]),
+    );
+    neovm_core::emacs_core::chartable::ct_set_single(
+        &table,
+        'z' as i64,
+        Value::vector(vec![
+            Value::cons(Value::fixnum('a' as i64), Value::fixnum(0)),
+            Value::cons(Value::fixnum('b' as i64), Value::fixnum(0)),
+        ]),
+    );
+    neovm_core::emacs_core::chartable::ct_set_single(
+        &table,
+        'p' as i64,
+        Value::vector(vec![Value::fixnum(('P' as i64) | (face_id << 22))]),
+    );
+    neovm_core::emacs_core::chartable::ct_set_single(
+        &table,
+        'n' as i64,
+        Value::vector(vec![Value::fixnum(('N' as i64) | (-1i64 << 22))]),
+    );
+    if let Some(buf) = evaluator.buffer_manager_mut().get_mut(buf_id) {
+        set_buffer_text(buf, "\n");
+        buf.set_buffer_local("buffer-display-table", table);
+    }
+
+    let buf = evaluator.buffer_manager().get(buf_id).unwrap();
+    let decoded = buffer_display_table_glyphs(buf, '\n').expect("display-table vector");
+    assert_eq!(decoded.text, "↪\n");
+    assert_eq!(
+        decoded.face_name.as_deref(),
+        Some("bold"),
+        "a trailing newline with another face is excluded from the visible-face comparison"
+    );
+    assert_eq!(
+        buffer_display_table_glyphs(buf, 'm')
+            .expect("mixed display-table vector")
+            .face_name,
+        None,
+        "mixed visible faces must not select a face"
+    );
+    assert_eq!(
+        buffer_display_table_glyphs(buf, 'z')
+            .expect("zero-face display-table vector")
+            .face_name,
+        None,
+        "zero face ids must not select a face"
+    );
+    assert_eq!(
+        buffer_display_table_glyphs(buf, 'p')
+            .expect("packed-face display-table vector")
+            .face_name
+            .as_deref(),
+        Some("bold"),
+        "packed positive face ids must resolve to their face name"
+    );
+    assert_eq!(
+        buffer_display_table_glyphs(buf, 'n')
+            .expect("negative-face display-table vector")
+            .face_name,
+        None,
+        "negative packed face ids must not select a face"
+    );
+}
+
+#[test]
+fn glyph_code_face_encoding_accepts_positive_and_rejects_nonpositive_ids() {
+    let positive = ('A' as i64) | (7i64 << 22);
+    assert_eq!(
+        glyph_code_parts(Value::fixnum(positive)),
+        Some(('A', Some(7)))
+    );
+
+    let negative = ('A' as i64) | (-1i64 << 22);
+    assert_eq!(
+        glyph_code_parts(Value::fixnum(negative)),
+        Some(('A', None)),
+        "packed face ids use signed arithmetic shift and reject negative ids"
+    );
+    let zero = 'A' as i64;
+    assert_eq!(
+        glyph_code_parts(Value::fixnum(zero)),
+        Some(('A', None)),
+        "packed zero face id is not a named face"
+    );
+
+    let negative_cons = Value::cons(Value::fixnum('A' as i64), Value::fixnum(-1));
+    assert_eq!(
+        glyph_code_parts(negative_cons),
+        Some(('A', None)),
+        "cons face ids reject negative ids"
+    );
 }
 
 #[test]

--- a/neovm-core/src/emacs_core/xfaces/mod.rs
+++ b/neovm-core/src/emacs_core/xfaces/mod.rs
@@ -981,6 +981,10 @@ thread_local! {
     /// (with a per-comparison `face_id_for_name`) each time dominated the face
     /// path in the startup profile.
     static FACE_NAME_LIST_CACHE: RefCell<Option<(u64, Rc<[String]>)>> = const { RefCell::new(None) };
+    /// Cached reverse face-id lookup, valid while `FACE_SET_GENERATION` is
+    /// unchanged.
+    static FACE_NAME_BY_ID_CACHE: RefCell<Option<(u64, HashMap<i64, String>)>> =
+        const { RefCell::new(None) };
 }
 
 /// Invalidate the cached face-name list after the defined-face set changes.
@@ -1086,6 +1090,32 @@ pub(crate) fn face_id_for_name(name: &str) -> Option<i64> {
         ensure_dynamic_face_id(name);
     }
     dynamic_face_id(name)
+}
+
+/// Resolve a numeric Lisp face id back to its face name.
+pub fn face_name_for_id(id: i64) -> Option<String> {
+    let generation = FACE_SET_GENERATION.with(|generation| generation.get());
+    if let Some(result) = FACE_NAME_BY_ID_CACHE.with(|cache| {
+        cache
+            .borrow()
+            .as_ref()
+            .filter(|(cached_generation, _)| *cached_generation == generation)
+            .map(|(_, names)| names.get(&id).cloned())
+    }) {
+        return result;
+    }
+
+    let mut names_by_id = HashMap::default();
+    for name in all_defined_face_names_sorted_by_id_desc().iter() {
+        if let Some(face_id) = face_id_for_name(name) {
+            names_by_id.entry(face_id).or_insert_with(|| name.clone());
+        }
+    }
+    let result = names_by_id.get(&id).cloned();
+    FACE_NAME_BY_ID_CACHE.with(|cache| {
+        *cache.borrow_mut() = Some((generation, names_by_id));
+    });
+    result
 }
 
 pub(crate) fn all_defined_face_names_sorted_by_id_desc() -> Rc<[String]> {

--- a/neovm-core/src/emacs_core/xfaces/xfaces_test.rs
+++ b/neovm-core/src/emacs_core/xfaces/xfaces_test.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+#[test]
+fn face_name_for_id_round_trips_known_face_ids() {
+    crate::test_utils::init_test_tracing();
+    let face_id = face_id_for_name("bold").expect("bootstrap face id");
+    assert_eq!(face_name_for_id(face_id).as_deref(), Some("bold"));
+    assert_eq!(face_name_for_id(-1), None);
+    assert_eq!(face_name_for_id(-1), None);
+}
+
 // --- FaceColorResolver::realize (spec -> realized color bridge) ---
 
 #[test]


### PR DESCRIPTION
## Issue

Display-table glyph vectors can encode a face with `make-glyph-code`, but Neomacs decodes only the replacement character and discards the embedded face. This makes `whitespace-mode` newline markers render as solid surrounding text instead of using the subdued, partially transparent `whitespace-newline` face.

## Solution

- Preserve a display-table glyph-vector face when all visible glyphs share the same nonzero face.
- Resolve glyph face IDs through a generation-keyed reverse cache, including negative caching for unknown IDs.
- Merge the explicit glyph face with the active face so background, underline, weight, height, and other attributes remain intact.
- Preserve face metadata across clipped display-item remainders and avoid duplicate decoding while probing text runs.
- Add regressions for homogeneous, mixed, zero, unresolved, trailing-newline, clipping, and full face-attribute behavior.

## Verification

- `cargo fmt --all -- --check` passes.
- `cargo check -p neomacs-layout-engine` passes.
- `cargo test -p neovm-core --lib face_name_for_id` passes.
- Focused display-table layout tests pass (15 tests).
- A fresh Windows `dev-release` build completes successfully in `target/dev-release`.

Now it can display partial transparent face
<img width="189" height="99" alt="image" src="https://github.com/user-attachments/assets/efa62a46-7a6b-4a48-854d-a8d7c5725afa" />
