### PR TITLE
fix(windows): gate Unix signal handlers

### DIFF
--- a/neovm-core/src/emacs_core/os_signal.rs
+++ b/neovm-core/src/emacs_core/os_signal.rs
@@ -134,7 +134,9 @@
 //! shape this port already uses for the Lisp profiler's watchdog flag.
 
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering};
+#[cfg(unix)]
+use std::sync::atomic::AtomicI32;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 /// One of the OS signals this port installs a disposition for.
 ///
@@ -146,12 +148,14 @@ use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering};
 /// SIGWINCH, SIGINT, SIGHUP and SIGPIPE are all still in the hole ledger
 /// 180 §9.6 opened.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(usize)]
+#[cfg_attr(unix, repr(usize))]
 pub(crate) enum HandledSignal {
     /// `add_user_signal (SIGUSR1, "sigusr1")`.
+    #[cfg(unix)]
     Sigusr1 = 0,
     /// `add_user_signal (SIGUSR2, "sigusr2")`.  This is `debug-on-event`'s
     /// default value (src/keyboard.c:14358-14367).
+    #[cfg(unix)]
     Sigusr2,
     /// `catch_child_signal` (src/process.c:8645-8660), which installs
     /// `deliver_child_signal` -> `handle_child_signal`.
@@ -163,27 +167,38 @@ pub(crate) enum HandledSignal {
     /// entire body is one `emacs_write` to a self-pipe (:7616-7650).  The walk
     /// that decides `changed` is what cannot go in a handler here, so it runs
     /// at the safe point instead (ledger 193).
+    #[cfg(unix)]
     Sigchld,
 }
 
 impl HandledSignal {
     /// Derived from the last discriminant, so a variant missing from
     /// [`Self::ALL`] is a compile error rather than a silent omission.
+    #[cfg(unix)]
     pub(crate) const COUNT: usize = Self::Sigchld as usize + 1;
+    #[cfg(not(unix))]
+    pub(crate) const COUNT: usize = 0;
 
+    #[cfg(unix)]
     pub(crate) const ALL: [Self; Self::COUNT] = [Self::Sigusr1, Self::Sigusr2, Self::Sigchld];
+    #[cfg(not(unix))]
+    pub(crate) const ALL: [Self; Self::COUNT] = [];
 
     /// The OS signal number.
     pub(crate) const fn number(self) -> libc::c_int {
+        #[cfg(unix)]
         match self {
             Self::Sigusr1 => libc::SIGUSR1,
             Self::Sigusr2 => libc::SIGUSR2,
             Self::Sigchld => libc::SIGCHLD,
         }
+        #[cfg(not(unix))]
+        match self {}
     }
 
     /// `file:line` of the install in the GNU tree.
     pub(crate) const fn gnu(self) -> &'static str {
+        #[cfg(unix)]
         match self {
             Self::Sigusr1 => "src/sysdep.c, init_signals: add_user_signal (SIGUSR1, \"sigusr1\")",
             Self::Sigusr2 => "src/sysdep.c, init_signals: add_user_signal (SIGUSR2, \"sigusr2\")",
@@ -191,10 +206,13 @@ impl HandledSignal {
                 "src/process.c:8650, catch_child_signal: sigaction (SIGCHLD, &action, &old_action)"
             }
         }
+        #[cfg(not(unix))]
+        match self {}
     }
 
     /// What the Lisp thread does with a delivery -- **data only**.
     pub(crate) const fn disposition(self) -> InstalledDisposition {
+        #[cfg(unix)]
         match self {
             Self::Sigusr1 => InstalledDisposition::UserSignal {
                 lisp_name: "sigusr1",
@@ -204,12 +222,15 @@ impl HandledSignal {
             },
             Self::Sigchld => InstalledDisposition::ChildStatus,
         }
+        #[cfg(not(unix))]
+        match self {}
     }
 
     /// The inverse of [`Self::number`], used by the handler.
     ///
     /// `const fn` over the closed enum rather than a table lookup, so it needs
     /// no static storage and cannot fault.
+    #[cfg(unix)]
     const fn from_raw(sig: libc::c_int) -> Option<Self> {
         if sig == libc::SIGUSR1 {
             Some(Self::Sigusr1)
@@ -318,6 +339,7 @@ static PENDING_ANY: AtomicBool = AtomicBool::new(false);
 
 /// The write end of GNU's self-pipe (`child_signal_write_fd`,
 /// src/process.c:7595).  `-1` until [`install`] creates it.
+#[cfg(unix)]
 static SELF_PIPE_WRITE_FD: AtomicI32 = AtomicI32::new(-1);
 
 /// GNU's `lib_child_handler` (src/process.c:7657), the SIGCHLD handler that
@@ -367,8 +389,10 @@ fn chain_to_previous_sigchld_handler(sig: libc::c_int) {
 /// It is `!Send` and `!Sync` (the `PhantomData<*const ()>`), has no public
 /// constructor, and **no method takes or returns a Lisp `Value`** -- which is
 /// the type-level statement that a handler cannot reach the interpreter.
+#[cfg(unix)]
 struct AsyncSignalScope(std::marker::PhantomData<*const ()>);
 
+#[cfg(unix)]
 impl AsyncSignalScope {
     /// GNU's `p->npending++` (src/keyboard.c:8511) and its
     /// `pending_signals = true` (:8431).
@@ -407,6 +431,7 @@ impl AsyncSignalScope {
 ///
 /// There is exactly one of these in the crate and it is total over
 /// [`HandledSignal`], so a new signal adds no code that runs here.
+#[cfg(unix)]
 extern "C" fn deliver_user_signal(sig: libc::c_int) {
     // GNU preserves errno around the handler ("Races can occur even in
     // single-threaded hosts", src/sysdep.c:1734-1735).
@@ -460,6 +485,7 @@ pub(crate) fn install() -> &'static InstallReport {
     INSTALL.get_or_init(install_once)
 }
 
+#[cfg(unix)]
 fn install_once() -> InstallReport {
     let self_pipe_read_fd = create_self_pipe();
 
@@ -564,6 +590,16 @@ fn install_once() -> InstallReport {
     report
 }
 
+#[cfg(not(unix))]
+fn install_once() -> InstallReport {
+    InstallReport {
+        previous: [],
+        installed: [],
+        self_pipe_read_fd: -1,
+    }
+}
+
+#[cfg(unix)]
 fn classify_previous(old: &libc::sigaction) -> PreviousDisposition {
     match old.sa_sigaction {
         // The seed survived: `sigaction` reported success without writing the
@@ -579,6 +615,7 @@ fn classify_previous(old: &libc::sigaction) -> PreviousDisposition {
 /// GNU's `child_signal_init` (src/process.c:7580-7597): a nonblocking,
 /// close-on-exec pipe whose read end the wait registers and whose write end
 /// the handler pokes.
+#[cfg(unix)]
 fn create_self_pipe() -> libc::c_int {
     let mut fds: [libc::c_int; 2] = [-1, -1];
     // SAFETY: `pipe2` writes exactly two ints through the array.

--- a/neovm-core/src/emacs_core/os_signal_test.rs
+++ b/neovm-core/src/emacs_core/os_signal_test.rs
@@ -23,6 +23,9 @@
 //!   SIGUSR1    rc=0, nothing armed            rc=138, killed
 //! ```
 
+#[cfg(windows)]
+use super::{self as os_signal, HandledSignal};
+#[cfg(unix)]
 use super::{
     self as os_signal, HandledSignal, InstalledDisposition, PreviousDisposition, UserSignalAction,
 };
@@ -33,6 +36,7 @@ use super::{
 /// the one GNU answers: `deliver_process_signal` (src/sysdep.c:1729-1751)
 /// exists precisely because "POSIX says any thread can receive a signal that
 /// is associated with a process".
+#[cfg(unix)]
 fn kill_self(sig: libc::c_int) {
     // SAFETY: `kill` with the caller's own pid and a valid signal number.
     let rc = unsafe { libc::kill(libc::getpid(), sig) };
@@ -55,6 +59,7 @@ fn kill_self(sig: libc::c_int) {
 /// the case `deliver_process_signal` (src/sysdep.c:1729-1751) exists for in
 /// GNU and that this port handles by making the handler correct on any thread.
 /// `raise`/`pthread_kill` would take the wait away and the question with it.
+#[cfg(unix)]
 fn kill_self_and_wait(signal: HandledSignal) {
     let before = os_signal::pending_count(signal);
     kill_self(signal.number());
@@ -68,6 +73,7 @@ fn kill_self_and_wait(signal: HandledSignal) {
 /// process is TERMINATED by the signal and nextest reports it killed rather
 /// than failed.  It survives only because [`os_signal::install`] ran.
 #[test]
+#[cfg(unix)]
 fn a_user_signal_does_not_terminate_this_process_like_gnu() {
     let report = os_signal::install();
     assert!(
@@ -102,6 +108,7 @@ fn a_user_signal_does_not_terminate_this_process_like_gnu() {
 /// `#if !defined HAVE_ANDROID`, because `android_select` uses them -- does not
 /// apply here.
 #[test]
+#[cfg(unix)]
 fn the_two_user_signals_were_unclaimed_before_this_port_installed_them() {
     let report = os_signal::install();
     for signal in HandledSignal::ALL {
@@ -121,6 +128,7 @@ fn the_two_user_signals_were_unclaimed_before_this_port_installed_them() {
 /// last discriminant, so a variant that is not listed is a compile error, and
 /// an emptied table fails here rather than passing over nothing.
 #[test]
+#[cfg(unix)]
 fn every_handled_signal_carries_its_gnu_citation_and_disposition() {
     assert_eq!(
         HandledSignal::COUNT,
@@ -178,6 +186,7 @@ fn every_handled_signal_carries_its_gnu_citation_and_disposition() {
 /// (src/keyboard.c:8487-8508).  Here that comparison runs on the Lisp thread
 /// at the safe point, because BOTH arms touch Lisp state.
 #[test]
+#[cfg(unix)]
 fn debug_on_event_selects_the_debugger_arm_by_name_like_gnu() {
     // `debug-on-event' defaults to `sigusr2' (src/keyboard.c:14358-14367).
     assert_eq!(
@@ -223,6 +232,7 @@ fn debug_on_event_selects_the_debugger_arm_by_name_like_gnu() {
 /// `:984`, `:6340`, `:6359`, and `sys::poll_child_status`), three of them
 /// through `std::process::Child`.
 #[test]
+#[cfg(unix)]
 fn a_second_reaper_takes_the_exit_status_the_owner_would_have_reported() {
     let mut child = std::process::Command::new("/bin/sh")
         .arg("-c")
@@ -270,6 +280,7 @@ fn a_second_reaper_takes_the_exit_status_the_owner_would_have_reported() {
 /// noticed through `epoll_wait`'s EINTR (which signal(7) says is never
 /// restarted) rather than through a readable fd.
 #[test]
+#[cfg(unix)]
 fn the_handler_has_gnus_self_pipe_and_it_carries_a_byte() {
     let report = os_signal::install();
     let read_fd = report
@@ -308,6 +319,7 @@ fn the_handler_has_gnus_self_pipe_and_it_carries_a_byte() {
 /// be an atomic -- and an atomic that fell back to a lock would put a lock in
 /// signal context, which is exactly the state this module exists to exclude.
 #[test]
+#[cfg(unix)]
 fn the_pending_counters_are_lock_free() {
     // `Atomic*::is_lock_free` is still unstable, and `target_has_atomic` is
     // the stable spelling of the same fact: rustc sets it only for widths the
@@ -324,7 +336,6 @@ fn the_pending_counters_are_lock_free() {
          would take a lock in signal context"
     );
 }
-
 /// The trigger's ENGAGEMENT counter, and the previous disposition it replaced.
 ///
 /// Ledger P5.2's skip was 100% green and fired ZERO times, so a mechanism that
@@ -401,4 +412,17 @@ fn sigchld_was_unclaimed_before_this_port_installed_it() {
          lib_child_handler (src/process.c:7657, 8656-8659) and this port's \
          chain would have to be exercised rather than merely present"
     );
+}
+
+/// Windows has no POSIX SIGUSR dispositions, so this module must expose no
+/// signal entries and must not create an install-time wake mechanism.
+#[cfg(windows)]
+#[test]
+fn windows_does_not_advertise_or_install_user_signals() {
+    assert!(HandledSignal::ALL.is_empty());
+
+    let report = os_signal::install();
+    assert_eq!(report.installed_count(), 0);
+    assert_eq!(report.self_pipe_read_fd(), None);
+    assert!(!os_signal::pending());
 }

--- a/neovm-core/src/emacs_core/post_image_init_test.rs
+++ b/neovm-core/src/emacs_core/post_image_init_test.rs
@@ -148,11 +148,19 @@ fn post_image_init_screened_sites_carry_their_evidence() {
                     "{} claims no Lisp-visible state without evidence",
                     site.site().c_name
                 );
-                assert!(
-                    !installs.is_empty(),
-                    "{} claims to install dispositions but names none",
-                    site.site().c_name
-                );
+                if cfg!(unix) {
+                    assert!(
+                        !installs.is_empty(),
+                        "{} claims to install dispositions but names none",
+                        site.site().c_name
+                    );
+                } else {
+                    assert!(
+                        installs.is_empty(),
+                        "{} has no supported signal dispositions on this platform",
+                        site.site().c_name
+                    );
+                }
                 os_dispositions += 1;
             }
             Establishes::Facts { constants, derived } => {


### PR DESCRIPTION
## Issue

The Unix signal implementation references `SIGUSR1`, `SIGUSR2`, `sigaction`, and Unix errno APIs on Windows, which breaks Windows compilation.

## Solution

- Gate Unix-only signal constants, handlers, and registration behind `cfg(unix)`.
- Provide Windows-compatible no-op signal setup and empty signal capability behavior.
- Gate signal tests and post-image initialization assertions by platform.

## Verification

- `cargo test -p neovm-core --lib os_signal -- --nocapture` passes.
- `cargo check -p neovm-core` passes.
- `cargo check -p neomacs --no-default-features --features neo-term --bin neomacs` passes.
- `cargo fmt --all -- --check` passes.
- `git diff --check upstream/main...HEAD` passes.