### PR TITLE
fix(backtrace): quit from recursive edits

### DIFF
--- a/neovm-core/src/emacs_core/eval.rs
+++ b/neovm-core/src/emacs_core/eval.rs
@@ -7005,21 +7005,24 @@ impl Context {
         }
     }
 
-    /// Inner command loop with top-level catch.
+    /// Inner command loop; only the outermost loop catches `top-level`.
     ///
     /// Mirrors GNU Emacs `command_loop()` (keyboard.c:1104).
-    /// Wraps command_loop_2 in a catch for 'top-level.
+    /// The outermost invocation wraps command_loop_2 in a catch for
+    /// 'top-level.
     #[tracing::instrument(skip_all)]
     fn command_loop_inner(&mut self) -> EvalResult {
         let outermost_command_loop =
             self.command_loop.recursive_depth == 1 && self.minibuffers.depth() == 0;
         loop {
-            // Catch 'top-level throws (from (top-level) function).
-            let top_level_tag = Value::symbol("top-level");
-            self.push_condition_frame(ConditionFrame::Catch {
-                tag: top_level_tag,
-                resume: ResumeTarget::CommandLoopTopLevel,
-            });
+            if outermost_command_loop {
+                // Catch 'top-level throws (from (top-level) function).
+                let top_level_tag = Value::symbol("top-level");
+                self.push_condition_frame(ConditionFrame::Catch {
+                    tag: top_level_tag,
+                    resume: ResumeTarget::CommandLoopTopLevel,
+                });
+            }
 
             // GNU keyboard.c command_loop():
             //   internal_catch (Qtop_level, top_level_1, Qnil);
@@ -7049,11 +7052,15 @@ impl Context {
                 self.command_loop_2(CommandLoopEntry::RecursiveEdit)
             };
 
-            self.pop_condition_frame();
+            if outermost_command_loop {
+                self.pop_condition_frame();
+            }
 
             match result {
                 // top-level throw → restart the loop
-                Err(Flow::Throw(ref thrown)) if thrown.tag.is_symbol_named("top-level") => {
+                Err(Flow::Throw(ref thrown))
+                    if outermost_command_loop && thrown.tag.is_symbol_named("top-level") =>
+                {
                     tracing::debug!("command_loop_inner: top-level throw, restarting loop");
                     continue;
                 }

--- a/neovm-core/src/emacs_core/eval_test.rs
+++ b/neovm-core/src/emacs_core/eval_test.rs
@@ -2301,6 +2301,64 @@ fn recursive_edit_runs_top_level_before_outer_command_loop_reads_input() {
 }
 
 #[test]
+fn nested_recursive_edit_propagates_top_level_and_runs_unwind_cleanup() {
+    crate::test_utils::init_test_tracing();
+    let mut ev = Context::new();
+    let scratch = ev.buffers.create_buffer("*nested-recursive-edit*");
+    ev.buffers.set_current(scratch);
+    let frame = ev.frames.create_frame("F1", 80, 24, scratch);
+    assert!(ev.frames.select_frame(frame), "test needs a selected frame");
+    let global_map = crate::emacs_core::keymap::make_sparse_list_keymap();
+    install_global_map_for_test(&mut ev, global_map);
+    let (tx, rx) = crossbeam_channel::unbounded();
+    drop(tx);
+
+    ev.input_rx = Some(rx);
+    ev.command_loop.running = true;
+    // Simulate an already-active outer command loop. The recursive-edit
+    // below must not catch the top-level throw meant to unwind it.
+    ev.command_loop.recursive_depth = 1;
+    ev.eval_str(
+        r#"(progn
+             (setq neo-recursive-edit-cleanup nil)
+             (fset 'neo-throw-top-level
+                   (lambda () (interactive) (top-level)))
+             (fset 'command-execute
+                   (lambda (cmd &optional _record _keys _special)
+                     (funcall cmd))))"#,
+    )
+    .expect("install nested recursive-edit test command");
+    crate::emacs_core::keymap::list_keymap_define_seq(
+        global_map,
+        &[Value::fixnum('q' as i64)],
+        Value::symbol("neo-throw-top-level"),
+    )
+    .expect("define top-level test command");
+    ev.command_loop
+        .keyboard
+        .kboard
+        .unread_events
+        .push_back(Value::fixnum('q' as i64));
+
+    let result = ev.eval_str(
+        "(unwind-protect
+             (recursive-edit)
+           (setq neo-recursive-edit-cleanup t))",
+    );
+
+    assert!(matches!(
+        result,
+        Err(crate::emacs_core::error::EvalError::UncaughtThrow { tag, .. })
+            if tag == Value::symbol("top-level")
+    ));
+    assert_eq!(
+        ev.eval_symbol("neo-recursive-edit-cleanup")
+            .expect("read recursive-edit cleanup marker"),
+        Value::T
+    );
+}
+
+#[test]
 fn command_loop_runs_initial_post_command_hook_before_first_command() {
     crate::test_utils::init_test_tracing();
     let mut ev = Context::new();


### PR DESCRIPTION
## Issue

Backtrace buffers enter a recursive edit. Invoking `top-level` to quit them is currently caught by every nested command loop, so the recursive edit restarts instead of unwinding. This leaves the backtrace buffer effectively unquittable and prevents surrounding cleanup from running.

## Solution

- Catch `top-level` only in the outermost command loop.
- Let nested recursive edits propagate `top-level` so their unwind cleanup runs.
- Add a regression covering nested recursive-edit propagation and cleanup.

## Verification

- `git diff --check upstream/main...HEAD` passes.
- The regression is included in `neovm-core/src/emacs_core/eval_test.rs`.
- Windows `neovm-core` test compilation is currently blocked on unmodified `upstream/main` by the separate Unix-signal issue addressed in #276.