### PR TITLE
render: optimize rendering for CPU adapters

### DIFF
--- a/neomacs-display-runtime/src/render_thread/asset_commands.rs
+++ b/neomacs-display-runtime/src/render_thread/asset_commands.rs
@@ -524,22 +524,28 @@ impl RenderApp {
                     renderer.free_surface(id);
                 }
             }
-            AssetCommand::FrameShaderSet { composed } => {
-                if let Some(ref mut renderer) = self.renderer {
-                    match composed {
-                        Some((source, language, uniforms)) => {
-                            if let Err(err) = renderer.set_frame_post(language, &source, &uniforms)
-                            {
-                                tracing::warn!("frame shader install failed: {err}");
-                            }
+            AssetCommand::FrameShaderSet { composed } => match composed {
+                Some((_source, _language, _uniforms)) if self.cpu_adapter => {
+                    tracing::warn!("Ignoring frame shader installation on CPU adapter");
+                }
+                Some((source, language, uniforms)) => {
+                    if let Some(renderer) = self.renderer.as_mut() {
+                        if let Err(err) = renderer.set_frame_post(language, &source, &uniforms) {
+                            tracing::warn!("frame shader install failed: {err}");
                         }
-                        None => renderer.clear_frame_post(),
                     }
                 }
-            }
+                None => {
+                    if let Some(renderer) = self.renderer.as_mut() {
+                        renderer.clear_frame_post();
+                    }
+                }
+            },
             AssetCommand::FrameShaderSetUniform { name, value } => {
-                if let Some(ref mut renderer) = self.renderer {
-                    renderer.set_frame_post_uniform(&name, value);
+                if !self.cpu_adapter {
+                    if let Some(ref mut renderer) = self.renderer {
+                        renderer.set_frame_post_uniform(&name, value);
+                    }
                 }
             }
         }

--- a/neomacs-display-runtime/src/render_thread/bootstrap.rs
+++ b/neomacs-display-runtime/src/render_thread/bootstrap.rs
@@ -53,11 +53,13 @@ impl RenderApp {
             };
 
         let adapter_info = adapter.get_info();
+        let cpu_adapter = super::state::is_cpu_adapter(adapter_info.device_type);
         tracing::info!(
-            "wgpu adapter: {} (vendor={:04x}, device={:04x}, backend={:?})",
+            "wgpu adapter: {} (vendor={:04x}, device={:04x}, type={:?}, backend={:?})",
             adapter_info.name,
             adapter_info.vendor,
             adapter_info.device,
+            adapter_info.device_type,
             adapter_info.backend
         );
 
@@ -185,6 +187,7 @@ impl RenderApp {
             device: device.clone(),
             queue: queue.clone(),
         });
+        self.cpu_adapter = cpu_adapter;
         let mut renderer = renderer;
         if let Some(max_bytes) = super::state::media_budget_env_limit() {
             renderer.set_media_budget_limit(max_bytes);
@@ -205,21 +208,12 @@ impl RenderApp {
                 },
             });
 
-        {
-            let primary = self.frame_windows.primary_window_mut().unwrap();
-            primary
-                .render
-                .populate_glyph_atlas(&device, pending_scale_factor);
-            primary
-                .render
-                .cursor
-                .apply_config(self.cursor_defaults.config_snapshot());
-            primary
-                .render
-                .compositor
-                .transitions
-                .apply_policy(self.transition_policy);
-        }
+        self.frame_windows
+            .primary_window_mut()
+            .unwrap()
+            .render
+            .populate_glyph_atlas(&device, pending_scale_factor);
+        self.apply_requested_visual_config();
 
         let pending_frame_chrome = self
             .frame_windows

--- a/neomacs-display-runtime/src/render_thread/lifecycle.rs
+++ b/neomacs-display-runtime/src/render_thread/lifecycle.rs
@@ -519,10 +519,15 @@ impl RenderApp {
             // contribute to the aggregate rate because the cycle cannot change
             // their pixels. Color remains a function of elapsed presentation
             // time, not the number of ticks.
+            let cycle_frame = if self.cpu_adapter {
+                None
+            } else {
+                window_state.render.compositor.current_frame.as_ref()
+            };
             let cycle_action = Self::reconcile_cursor_color_cycle_demand(
                 &mut self.frame_coordinator,
                 id,
-                window_state.render.compositor.current_frame.as_ref(),
+                cycle_frame,
                 &self.effects,
                 max_rate,
                 window_state.render.cursor.blink_on,

--- a/neomacs-display-runtime/src/render_thread/render_pass.rs
+++ b/neomacs-display-runtime/src/render_thread/render_pass.rs
@@ -477,6 +477,7 @@ impl RenderApp {
         extra_line_spacing: f32,
         extra_letter_spacing: f32,
         cursor_only_hint: bool,
+        cpu_adapter: bool,
         device_lost: &mut super::device_loss::DeviceLossDetector,
     ) -> Result<RenderedFrameSurface, FrameRenderFailure> {
         Self::render_frame_window_contents_to_acquired_surface(
@@ -490,6 +491,7 @@ impl RenderApp {
             extra_letter_spacing,
             None,
             cursor_only_hint,
+            cpu_adapter,
             device_lost,
         )
     }
@@ -506,6 +508,7 @@ impl RenderApp {
         extra_letter_spacing: f32,
         output: Option<wgpu::SurfaceTexture>,
         cursor_only_hint: bool,
+        cpu_adapter: bool,
         device_lost: &mut super::device_loss::DeviceLossDetector,
     ) -> Result<RenderedFrameSurface, FrameRenderFailure> {
         let render = &mut window_state.render;
@@ -533,8 +536,11 @@ impl RenderApp {
         // cursor. The frame's stored cursor geometry is no longer mutated here,
         // so the materialized frame stays a pure function of the layout snapshot.
 
-        let need_offscreen =
-            render.compositor.transitions.policy.needs_offscreen() || frame_has_theme_transition;
+        let need_offscreen = super::state::needs_offscreen_render(
+            render.compositor.transitions.policy,
+            frame_has_theme_transition,
+            cpu_adapter,
+        );
 
         let output = if let Some(output) = output {
             output
@@ -592,6 +598,11 @@ impl RenderApp {
         let mut frame = render
             .take_current_frame_for_render()
             .ok_or(FrameRenderFailure::AwaitingContent)?;
+        if cpu_adapter {
+            frame.transition_hints.clear();
+            frame.effect_hints.clear();
+            frame.cursor_effects_by_window.clear();
+        }
         render.begin_presentable_render();
         if extra_line_spacing != 0.0 || extra_letter_spacing != 0.0 {
             Self::apply_extra_spacing(
@@ -1464,6 +1475,7 @@ impl RenderApp {
             self.extra_line_spacing,
             self.extra_letter_spacing,
             cursor_only_hint,
+            self.cpu_adapter,
             &mut self.device_lost,
         );
         let (output, frame) = match rendered {

--- a/neomacs-display-runtime/src/render_thread/state.rs
+++ b/neomacs-display-runtime/src/render_thread/state.rs
@@ -10,8 +10,9 @@ pub use crate::thread_comm::MonitorInfo;
 use crate::thread_comm::RenderComms;
 pub(super) use neomacs_display_protocol::PointerAppearancePhase;
 use neomacs_display_protocol::{
-    EffectsConfig, FrameGlyphBuffer, FrameRect, InteractionId, PointerAppearanceId,
-    PointerAppearanceSelection, PresentationId, ToolBarImageSource, TransitionPolicy,
+    EffectOperation, EffectValue, EffectsConfig, FrameGlyphBuffer, FrameRect, InteractionId,
+    PointerAppearanceId, PointerAppearanceSelection, PresentationId, ToolBarImageSource,
+    TransitionPolicy, VisualConfig,
 };
 use neomacs_renderer_wgpu::WgpuRenderer;
 use neovm_core::emacs_core::image_catalog::ResolvedImageMetadata;
@@ -627,6 +628,53 @@ pub(super) struct RenderGpuContext {
     pub(super) queue: Arc<wgpu::Queue>,
 }
 
+pub(super) fn is_cpu_adapter(device_type: wgpu::DeviceType) -> bool {
+    device_type == wgpu::DeviceType::Cpu
+}
+
+pub(super) fn needs_offscreen_render(
+    policy: TransitionPolicy,
+    frame_has_theme_transition: bool,
+    cpu_adapter: bool,
+) -> bool {
+    !cpu_adapter && (policy.needs_offscreen() || frame_has_theme_transition)
+}
+
+pub(super) fn effective_visual_config(requested: &VisualConfig, cpu_adapter: bool) -> VisualConfig {
+    if !cpu_adapter {
+        return requested.clone();
+    }
+
+    let mut effective = requested.clone();
+    effective.cursor_motion.enabled = false;
+    effective.cursor_size_transition.enabled = false;
+    effective.crossfade_transition.enabled = false;
+    effective.scroll_transition.enabled = false;
+
+    let disable_effects = effective
+        .effects
+        .effect_names()
+        .into_iter()
+        .filter(|name| {
+            effective
+                .effects
+                .effect_values(name)
+                .is_ok_and(|properties| {
+                    properties.iter().any(|(property, _)| property == "enabled")
+                })
+        })
+        .map(|name| EffectOperation::set(name, [("enabled", EffectValue::Bool(false))]))
+        .collect::<Vec<_>>();
+    effective.effects = effective
+        .effects
+        .apply_effects(&disable_effects)
+        .expect("effect registry must be able to disable every enabled effect");
+    effective.effects.bg_pattern.style = 0;
+    effective.effects.mode_line_separator.style = 0;
+    effective.effects.scroll_bar.width = 0;
+    effective
+}
+
 pub(super) struct RenderApp {
     pub(super) comms: RenderComms,
 
@@ -639,6 +687,7 @@ pub(super) struct RenderApp {
 
     pub(super) gpu: Option<RenderGpuContext>,
     pub(super) renderer: Option<WgpuRenderer>,
+    pub(super) cpu_adapter: bool,
 
     /// Shared device-lost latch (`Arc<AtomicBool>` inside) plus the
     /// consecutive surface-Lost streak. Fed by the wgpu device-lost callback
@@ -659,6 +708,7 @@ pub(super) struct RenderApp {
 
     pub(super) cursor_defaults: CursorState,
 
+    pub(super) requested_visual_config: VisualConfig,
     pub(super) effects: EffectsConfig,
 
     pub(super) transition_policy: TransitionPolicy,
@@ -732,6 +782,23 @@ pub(super) fn media_budget_env_limit() -> Option<usize> {
 }
 
 impl RenderApp {
+    pub(super) fn apply_requested_visual_config(&mut self) {
+        let effective = effective_visual_config(&self.requested_visual_config, self.cpu_adapter);
+        self.cursor_defaults.apply_visual_config(&effective);
+        self.transition_policy = TransitionPolicy::from(&effective);
+        self.frame_windows
+            .apply_top_level_transition_policy(self.transition_policy);
+        self.effects = effective.effects.clone();
+        if let Some(renderer) = self.renderer.as_mut() {
+            renderer.effects = self.effects.clone();
+        }
+        self.frame_windows
+            .sync_top_level_cursor_config(&self.cursor_defaults, true);
+        if !self.cursor_defaults.blink_enabled {
+            self.frame_windows.force_top_level_cursor_blink_on();
+        }
+    }
+
     pub(super) fn new(
         comms: RenderComms,
         width: u32,
@@ -769,12 +836,14 @@ impl RenderApp {
             clipboard: Err("clipboard is unavailable before display initialization".to_owned()),
             gpu: None,
             renderer: None,
+            cpu_adapter: false,
             device_lost: super::device_loss::DeviceLossDetector::new(),
             faces: HashMap::new(),
             faces_signature: Vec::new(),
             modifiers: 0,
             image_metadata,
             cursor_defaults: CursorState::default(),
+            requested_visual_config: VisualConfig::default(),
             effects: EffectsConfig::default(),
             transition_policy: TransitionPolicy::default(),
             #[cfg(feature = "wpe-webkit")]

--- a/neomacs-display-runtime/src/render_thread/tests.rs
+++ b/neomacs-display-runtime/src/render_thread/tests.rs
@@ -1,5 +1,7 @@
 use super::RenderApp;
-use super::state::GuiChromeInteractionState;
+use super::state::{
+    GuiChromeInteractionState, effective_visual_config, is_cpu_adapter, needs_offscreen_render,
+};
 use crate::core::frame_glyphs::FrameGlyphBuffer;
 use crate::core::types::DisplayWindowId;
 use crate::thread_comm::FrameRef;
@@ -8,8 +10,8 @@ use crate::thread_comm::{
 };
 use neomacs_display_protocol::glyph_matrix::FrameDisplayState;
 use neomacs_display_protocol::{
-    Color, CursorStyle, DisplaySlotId, EffectsConfig, FrameRate, PhysCursor, PopupMenuItem,
-    SealedFramePresentation,
+    Color, CursorStyle, DisplaySlotId, EffectValue, EffectsConfig, FrameRate, PhysCursor,
+    PopupMenuItem, SealedFramePresentation, VisualConfig,
 };
 use neovm_core::window::GuiFrameGeometryHints;
 use std::collections::HashMap;
@@ -30,6 +32,76 @@ fn make_test_app() -> RenderApp {
         #[cfg(feature = "neo-term")]
         crate::terminal::new_shared_terminals(),
     )
+}
+
+#[test]
+fn only_cpu_device_type_selects_cpu_compatibility_mode() {
+    assert!(is_cpu_adapter(wgpu::DeviceType::Cpu));
+    for device_type in [
+        wgpu::DeviceType::Other,
+        wgpu::DeviceType::IntegratedGpu,
+        wgpu::DeviceType::DiscreteGpu,
+        wgpu::DeviceType::VirtualGpu,
+    ] {
+        assert!(!is_cpu_adapter(device_type));
+    }
+}
+
+#[test]
+fn cpu_effective_visual_config_disables_motion_transitions_and_effects() {
+    let mut requested = VisualConfig::default();
+    requested.cursor_motion.enabled = true;
+    requested.cursor_size_transition.enabled = true;
+    requested.crossfade_transition.enabled = true;
+    requested.scroll_transition.enabled = true;
+    requested.effects.cursor_glow.enabled = true;
+    requested.effects.bg_pattern.style = 1;
+    requested.effects.mode_line_separator.style = 1;
+    requested.effects.scroll_bar.width = 8;
+
+    let effective = effective_visual_config(&requested, true);
+
+    assert!(!effective.cursor_motion.enabled);
+    assert!(!effective.cursor_size_transition.enabled);
+    assert!(!effective.crossfade_transition.enabled);
+    assert!(!effective.scroll_transition.enabled);
+    for name in effective.effects.effect_names() {
+        for (property, value) in effective.effects.effect_values(&name).unwrap() {
+            if property == "enabled" {
+                assert_eq!(value, EffectValue::Bool(false), "{name} remained enabled");
+            }
+        }
+    }
+    assert_eq!(effective.effects.bg_pattern.style, 0);
+    assert_eq!(effective.effects.mode_line_separator.style, 0);
+    assert_eq!(effective.effects.scroll_bar.width, 0);
+    assert!(requested.cursor_motion.enabled);
+    assert!(requested.effects.cursor_glow.enabled);
+    assert_eq!(requested.effects.bg_pattern.style, 1);
+}
+
+#[test]
+fn hardware_effective_visual_config_preserves_user_settings() {
+    let mut requested = VisualConfig::default();
+    requested.cursor_motion.enabled = false;
+    requested.cursor_size_transition.enabled = true;
+    requested.crossfade_transition.enabled = false;
+    requested.scroll_transition.enabled = true;
+    requested.effects.cursor_glow.enabled = true;
+    requested.effects.bg_pattern.style = 2;
+    requested.effects.mode_line_separator.style = 1;
+    requested.effects.scroll_bar.width = 9;
+
+    assert_eq!(effective_visual_config(&requested, false), requested);
+}
+
+#[test]
+fn cpu_adapter_never_uses_offscreen_transition_rendering() {
+    let policy = neomacs_display_protocol::TransitionPolicy::default();
+
+    assert!(!needs_offscreen_render(policy, false, true));
+    assert!(!needs_offscreen_render(policy, true, true));
+    assert!(needs_offscreen_render(policy, false, false));
 }
 
 #[test]

--- a/neomacs-display-runtime/src/render_thread/ui_commands.rs
+++ b/neomacs-display-runtime/src/render_thread/ui_commands.rs
@@ -233,19 +233,8 @@ impl RenderApp {
                 tracing::info!("Ligatures enabled: {}", enabled);
             }
             ConfigCommand::SetVisualConfig(config) => {
-                self.cursor_defaults.apply_visual_config(&config);
-                self.transition_policy = neomacs_display_protocol::TransitionPolicy::from(&config);
-                self.frame_windows
-                    .apply_top_level_transition_policy(self.transition_policy);
-                self.effects = config.effects;
-                if let Some(renderer) = self.renderer.as_mut() {
-                    renderer.effects = self.effects.clone();
-                }
-                self.frame_windows
-                    .sync_top_level_cursor_config(&self.cursor_defaults, true);
-                if !self.cursor_defaults.blink_enabled {
-                    self.frame_windows.force_top_level_cursor_blink_on();
-                }
+                self.requested_visual_config = config;
+                self.apply_requested_visual_config();
                 self.frame_windows.mark_top_level_dirty();
             }
             ConfigCommand::SetScrollIndicators { enabled } => {


### PR DESCRIPTION
## Issue

Software wgpu adapters currently use the same visual pipeline as hardware GPUs. On CPU adapters, animated transitions, effects, offscreen composition, cursor color cycling, and frame post-processing add substantial rendering cost without hardware acceleration.

## Solution

- Detect `wgpu::DeviceType::Cpu` during renderer initialization.
- Preserve the requested visual configuration while deriving a CPU-friendly effective configuration that disables motion transitions and effects.
- Avoid offscreen transition rendering, frame post-processing shaders, and cursor color-cycle demand on CPU adapters.
- Reapply the requested configuration after GPU initialization or recovery while leaving hardware-adapter behavior unchanged.
- Add focused tests for adapter classification, effective configuration, hardware preservation, and offscreen-render selection.

## Verification

- `cargo test -p neomacs-display-runtime --lib --no-default-features --features neo-term -- render_thread::` passes (354 tests).
- `cargo fmt --all -- --check` passes.
- `git diff --check upstream/main...HEAD` passes.
- Windows validation temporarily applied the separate Unix-signal gating from #276; that change is not included in this PR.