### PR TITLE
fix(buffer): propagate forwarded top-level defaults

### DIFF
--- a/neovm-core/src/emacs_core/builtins/symbols.rs
+++ b/neovm-core/src/emacs_core/builtins/symbols.rs
@@ -426,8 +426,12 @@ pub(crate) fn set_default_toplevel_value_impl(
         resolved,
         value,
     ) {
-        ctx.obarray.set_symbol_value_id(resolved, value);
-        ctx.sync_cached_runtime_binding_by_id(resolved, value);
+        if let Some(info) = crate::emacs_core::custom::forwarded_buffer_slot_info(ctx, resolved) {
+            ctx.buffers.set_buffer_default_slot(info, value);
+        } else {
+            ctx.obarray.set_symbol_value_id(resolved, value);
+            ctx.sync_cached_runtime_binding_by_id(resolved, value);
+        }
     }
     ctx.refresh_gc_runtime_settings_after_change_by_id(resolved);
     // Finding 6: `set-default-toplevel-value` (the `setq-default` /

--- a/neovm-core/src/emacs_core/custom.rs
+++ b/neovm-core/src/emacs_core/custom.rs
@@ -725,24 +725,7 @@ pub(crate) fn builtin_set_default(eval: &mut super::eval::Context, args: Vec<Val
     // `buffer_defaults` AND propagates to every live buffer whose
     // local_flags bit is clear. Mirrors GNU `set_default_internal`
     // SYMBOL_FORWARDED arm (`data.c:2044-2078`).
-    let forwarded_slot = {
-        use crate::emacs_core::forward::{LispBufferObjFwd, LispFwdType};
-        use crate::emacs_core::symbol::SymbolRedirect;
-        eval.obarray()
-            .get_by_id(resolved)
-            .filter(|sym| sym.redirect() == SymbolRedirect::Forwarded)
-            .and_then(|sym| {
-                let fwd = unsafe { &*sym.val.fwd };
-                if matches!(fwd.ty, LispFwdType::BufferObj) {
-                    let buf_fwd = unsafe { &*(fwd as *const _ as *const LispBufferObjFwd) };
-                    let info_name = crate::emacs_core::intern::resolve_sym(resolved);
-                    crate::buffer::buffer::lookup_buffer_slot(info_name)
-                        .map(|info| (info, buf_fwd.offset))
-                } else {
-                    None
-                }
-            })
-    };
+    let forwarded_slot = forwarded_buffer_slot_info(eval, resolved);
     // GNU `set_default_internal` calls `notify_variable_watchers` before the
     // value cell is changed, so callbacks observe the previous value through
     // `symbol-value`.
@@ -750,7 +733,7 @@ pub(crate) fn builtin_set_default(eval: &mut super::eval::Context, args: Vec<Val
     if resolved != symbol {
         eval.run_variable_watchers_by_id(resolved, &value, &Value::NIL, "set")?;
     }
-    if let Some((info, _off)) = forwarded_slot {
+    if let Some(info) = forwarded_slot {
         eval.buffers.set_buffer_default_slot(info, value);
     } else {
         eval.obarray_mut().set_symbol_value_id(resolved, value);
@@ -767,6 +750,24 @@ pub(crate) fn builtin_set_default(eval: &mut super::eval::Context, args: Vec<Val
     eval.mark_redisplay_dirty_if_display_var(resolved);
 
     Ok(value)
+}
+
+pub(crate) fn forwarded_buffer_slot_info(
+    eval: &super::eval::Context,
+    resolved: SymId,
+) -> Option<&'static crate::buffer::buffer::BufferSlotInfo> {
+    use crate::emacs_core::forward::LispFwdType;
+    use crate::emacs_core::symbol::SymbolRedirect;
+
+    eval.obarray()
+        .get_by_id(resolved)
+        .filter(|sym| sym.redirect() == SymbolRedirect::Forwarded)
+        .and_then(|sym| {
+            let fwd = unsafe { &*sym.val.fwd };
+            matches!(fwd.ty, LispFwdType::BufferObj)
+                .then(|| crate::buffer::buffer::lookup_buffer_slot(resolve_sym(resolved)))
+                .flatten()
+        })
 }
 
 // ---------------------------------------------------------------------------

--- a/neovm-core/src/emacs_core/custom_test.rs
+++ b/neovm-core/src/emacs_core/custom_test.rs
@@ -661,6 +661,35 @@ fn set_default_toplevel_alias_triggers_variable_watchers_twice() {
     assert_eq!(results[5], "OK 2");
 }
 
+#[test]
+fn set_default_toplevel_updates_forwarded_buffer_defaults() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = Context::new();
+    let current = eval.buffers.current_buffer_id().expect("current buffer");
+    let other = eval.buffers.create_buffer("*other*");
+    let custom = Value::list(vec![Value::string("CUSTOM")]);
+
+    crate::emacs_core::builtins::symbols::builtin_set_default_toplevel_value(
+        &mut eval,
+        vec![Value::symbol("mode-line-format"), custom],
+    )
+    .expect("set-default-toplevel-value");
+
+    assert_eq!(
+        builtin_default_value(&mut eval, vec![Value::symbol("mode-line-format")])
+            .expect("default-value"),
+        custom
+    );
+    for buffer_id in [current, other] {
+        assert_eq!(
+            eval.buffers
+                .get(buffer_id)
+                .and_then(|buffer| buffer.buffer_local_value("mode-line-format")),
+            Some(custom)
+        );
+    }
+}
+
 // -- make-variable-buffer-local builtin --------------------------------
 
 #[test]


### PR DESCRIPTION
## Issue

`set-default-toplevel-value` writes resolved symbol values directly. For forwarded buffer-local variables such as `mode-line-format`, that bypasses the buffer default slot, so the default value and live buffers without local overrides are not updated.

## Solution

- Detect forwarded buffer slots through a shared helper.
- Route `set-default-toplevel-value` updates through the buffer default slot so they propagate to eligible live buffers.
- Reuse the same forwarded-slot lookup in `set-default`.
- Add a regression covering the default value and propagation to multiple buffers.

## Verification

- `cargo test -p neovm-core --lib set_default_toplevel_updates_forwarded_buffer_defaults -- --nocapture` passes.
- `cargo fmt --all -- --check` passes.
- `git diff --check upstream/main...HEAD` passes.
- Windows validation temporarily applied the separate Unix-signal gating from #276; that change is not included in this PR.