### PR TITLE
build: fix aarch64-darwin build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,6 @@
         fontconfig
         freetype
         harfbuzz
-        libotf
         cairo
         pango
         glib
@@ -86,6 +85,7 @@
         # is Rust. Keep libstdc++ in both the package and development runtime
         # closure so freshly linked bootstrap executables are runnable.
         stdenv.cc.cc.lib
+        libotf
         alsa-lib
         gst_all_1.gst-vaapi
         libva
@@ -117,6 +117,11 @@
         pkgs.pkg-config
         pkgs.llvmPackages.clang
         pkgs.makeWrapper
+      ] ++ lib.optionals pkgs.stdenv.isDarwin [
+        # xtask's fresh-build pipeline re-signs role binaries after patching
+        # the pdump fingerprint (xtask/src/main.rs:657). `codesign` isn't on
+        # PATH in the Nix sandbox; sigtool provides a compatible shim.
+        pkgs.darwin.sigtool
       ];
 
       mkNeomacsPackage = system:

--- a/neovm-core/src/emacs_core/process/sys/serial/termios_backend.rs
+++ b/neovm-core/src/emacs_core/process/sys/serial/termios_backend.rs
@@ -46,7 +46,7 @@ pub fn open(path: &OsStr) -> io::Result<Device> {
     // src/sysdep.c:2985-2987): a port that does not support it is still usable.
     // SAFETY: `TIOCEXCL` takes no pointer argument.
     unsafe {
-        libc::ioctl(fd.as_raw_fd(), libc::TIOCEXCL, 0 as libc::c_int);
+        libc::ioctl(fd.as_raw_fd(), libc::TIOCEXCL as _, 0 as libc::c_int);
     }
     Ok(Device { fd })
 }

--- a/neovm-core/src/emacs_core/process/sys/tty.rs
+++ b/neovm-core/src/emacs_core/process/sys/tty.rs
@@ -116,7 +116,7 @@ pub unsafe fn establish_pty_controlling_terminal(tty: &std::ffi::CStr) -> std::i
 pub fn fd_foreground_pgrp(fd: RawFd) -> Option<i32> {
     let mut gid: libc::pid_t = -1;
     // SAFETY: `TIOCGPGRP` writes the pgrp through the provided `&mut gid`.
-    let ok = unsafe { libc::ioctl(fd, libc::TIOCGPGRP, &mut gid) } != -1;
+    let ok = unsafe { libc::ioctl(fd, libc::TIOCGPGRP as _, &mut gid) } != -1;
     (ok && gid != -1).then_some(gid)
 }
 


### PR DESCRIPTION
- ioctl request arg is c_ulong on BSD; cast TIOCEXCL/TIOCGPGRP with `as _` so the i32 constants coerce to u64 on Darwin (matches the existing TIOCSCTTY site).
- libotf's meta.platforms excludes Darwin; move it to the Linux-only buildInputs branch. Text shaping on macOS is covered by harfbuzz.
- xtask fresh-build re-signs patched binaries with `codesign` on macOS, which isn't in the Nix sandbox PATH. Add darwin.sigtool to nativeBuildInputs — it ships a codesign shim that handles ad-hoc `--sign -` signing.