### PR TITLE
fix(font): restore font query and shaping compatibility

### DIFF
--- a/neovm-core/src/emacs_core/builtins/mod.rs
+++ b/neovm-core/src/emacs_core/builtins/mod.rs
@@ -5830,12 +5830,7 @@ pub(crate) fn init_builtins(ctx: &mut super::eval::Context) {
         3,
         Some(3),
     );
-    ctx.defsubr(
-        "query-font",
-        |_ctx, args| builtin_query_font(args),
-        1,
-        Some(1),
-    );
+    ctx.defsubr("query-font", super::font::builtin_query_font, 1, Some(1));
     ctx.defsubr(
         "query-fontset",
         |_ctx, args| builtin_query_fontset(args),

--- a/neovm-core/src/emacs_core/builtins/stubs.rs
+++ b/neovm-core/src/emacs_core/builtins/stubs.rs
@@ -1480,7 +1480,6 @@ pub(crate) fn builtin_font_shape_gstring(args: Vec<Value>) -> EvalResult {
             vec![Value::string("Invalid glyph-string: ")],
         ));
     }
-    let _ = expect_fixnum(&args[1])?;
     Ok(Value::NIL)
 }
 

--- a/neovm-core/src/emacs_core/builtins/symbols.rs
+++ b/neovm-core/src/emacs_core/builtins/symbols.rs
@@ -2848,11 +2848,6 @@ pub(crate) fn builtin_recordp_1(_eval: &mut super::eval::Context, arg: Value) ->
     Ok(Value::bool_val(arg.is_record()))
 }
 
-pub(crate) fn builtin_query_font(args: Vec<Value>) -> EvalResult {
-    expect_args("query-font", &args, 1)?;
-    Ok(Value::NIL)
-}
-
 pub(crate) fn builtin_query_fontset(args: Vec<Value>) -> EvalResult {
     expect_args_range("query-fontset", &args, 1, 2)?;
     let pattern = expect_string_lossy(&args[0])?;

--- a/neovm-core/src/emacs_core/builtins/tests.rs
+++ b/neovm-core/src/emacs_core/builtins/tests.rs
@@ -6498,7 +6498,7 @@ fn pure_dispatch_position_placeholders_match_compat_contracts() {
 }
 
 #[test]
-fn pure_dispatch_record_query_placeholders_match_compat_contracts() {
+fn pure_dispatch_record_placeholders_match_compat_contracts() {
     crate::test_utils::init_test_tracing();
     let record = dispatch_builtin_pure("record", vec![Value::symbol("tag"), Value::fixnum(1)])
         .expect("builtin record should resolve")
@@ -6520,11 +6520,6 @@ fn pure_dispatch_record_query_placeholders_match_compat_contracts() {
         .expect("builtin recordp should resolve")
         .expect("builtin recordp should evaluate");
     assert!(recordp.is_nil());
-
-    let query_font = dispatch_builtin_pure("query-font", vec![Value::NIL])
-        .expect("builtin query-font should resolve")
-        .expect("builtin query-font should evaluate");
-    assert!(query_font.is_nil());
 
     super::symbols::reset_symbols_thread_locals();
     let query_fontset =

--- a/neovm-core/src/emacs_core/bytecode/vm_test.rs
+++ b/neovm-core/src/emacs_core/bytecode/vm_test.rs
@@ -7625,7 +7625,7 @@ fn vm_font_stub_tail_uses_direct_dispatch() {
                  (null (font-has-char-p (font-spec :family "Mono") ?a))
                  (null (font-info "Mono"))
                  (null (font-match-p (font-spec) (font-spec)))
-                 (null (font-shape-gstring [0] 0))
+                 (null (font-shape-gstring [0] nil))
                  (condition-case nil
                      (font-variation-glyphs nil ?a)
                    (wrong-type-argument t))

--- a/neovm-core/src/emacs_core/font.rs
+++ b/neovm-core/src/emacs_core/font.rs
@@ -3279,6 +3279,36 @@ pub(crate) fn builtin_font_info(eval: &mut super::eval::Context, args: Vec<Value
     }
 }
 
+pub(crate) fn builtin_query_font(eval: &mut super::eval::Context, args: Vec<Value>) -> EvalResult {
+    expect_args("query-font", &args, 1)?;
+    if !is_font_object(&args[0]) {
+        return Err(signal(
+            LispCondition::WrongTypeArgument,
+            vec![Value::symbol("font-object"), args[0]],
+        ));
+    }
+
+    let info = if let Some(info) = font_info_vector_for_entity(eval, &args[0]) {
+        info
+    } else {
+        let capability = font_value_otf_capability(eval, &args[0]);
+        let frame_id = super::window_cmds::ensure_selected_frame_id(eval);
+        let frame = eval
+            .frames
+            .get(frame_id)
+            .ok_or_else(|| signal("error", vec![Value::string("No selected frame")]))?;
+        font_info_vector_for_runtime_font(&args[0], frame, capability)
+    };
+    let values = info
+        .as_vector_data()
+        .filter(|values| values.len() >= 14)
+        .ok_or_else(|| signal("error", vec![Value::string("Invalid font-info result")]))?;
+    Ok(Value::vector(vec![
+        values[0], values[12], values[2], values[7], values[8], values[9], values[10], values[11],
+        values[13],
+    ]))
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================

--- a/neovm-core/src/emacs_core/font_test.rs
+++ b/neovm-core/src/emacs_core/font_test.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::buffer::{Buffer, CharPos0};
 use crate::emacs_core::eval::{
-    Context, DisplayHost, FontResolveRequest, FontSpecResolveRequest, GuiFrameHostRequest,
-    ResolvedFontMatch, ResolvedFontSpecMatch,
+    Context, DisplayHost, FontOtfCapability, FontPxProbeResult, FontResolveRequest,
+    FontSpecResolveRequest, GuiFrameHostRequest, ResolvedFontMatch, ResolvedFontSpecMatch,
 };
 use crate::emacs_core::value::ValueKind;
 use crate::emacs_core::xfaces::*;
@@ -221,6 +221,8 @@ fn gnu_font_style_tables_are_constant_symbols() {
 #[derive(Default)]
 struct FontAtDisplayHost {
     matched: Option<ResolvedFontMatch>,
+    metrics: Option<FontPxProbeResult>,
+    capability: Option<FontOtfCapability>,
 }
 
 impl DisplayHost for FontAtDisplayHost {
@@ -241,6 +243,24 @@ impl DisplayHost for FontAtDisplayHost {
         } else {
             Ok(None)
         }
+    }
+
+    fn probe_font_px_metrics(
+        &mut self,
+        _file: &str,
+        _face_index: u32,
+        _pixel_size: u32,
+        _wght: Option<f32>,
+    ) -> Result<Option<FontPxProbeResult>, String> {
+        Ok(self.metrics)
+    }
+
+    fn font_otf_capability(
+        &mut self,
+        _file: &str,
+        _face_index: u32,
+    ) -> Result<Option<FontOtfCapability>, String> {
+        Ok(self.capability.clone())
     }
 }
 
@@ -932,6 +952,7 @@ fn font_at_eval_prefers_backend_selected_font_match_when_available() {
             postscript_name: Some(LispString::from_utf8("NotoSansMonoCJKsc-Regular")),
             glyph_code: Some(0x2A),
         }),
+        ..Default::default()
     }));
 
     let buffer = eval
@@ -994,6 +1015,7 @@ fn internal_char_font_returns_font_object_and_glyph_code() {
             postscript_name: Some(LispString::from_utf8("NotoSansMonoCJKsc-Regular")),
             glyph_code: Some(0x2A),
         }),
+        ..Default::default()
     }));
     let buffer = eval
         .buffers
@@ -1045,6 +1067,83 @@ fn font_info_eval_accepts_font_object_on_live_gui_frame() {
     assert_eq!(values[3].as_int(), Some(18));
     assert_eq!(values[10].as_int(), Some(9));
     assert_eq!(values[11].as_int(), Some(9));
+}
+
+#[test]
+fn query_font_eval_returns_metrics_with_terminal_frame_selected() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::Context::new();
+    let frame_id = crate::emacs_core::window_cmds::ensure_selected_frame_id(&mut eval);
+    {
+        let frame = eval
+            .frame_manager_mut()
+            .get_mut(frame_id)
+            .expect("selected frame");
+        frame.window_system = Some(Value::symbol("neo"));
+        frame.font_pixel_size = 18.0;
+        frame.char_width = 9.0;
+        frame.char_height = 18.0;
+    }
+    eval.set_display_host(Box::new(FontAtDisplayHost {
+        matched: Some(ResolvedFontMatch {
+            pixel_size_px: 17,
+            family: LispString::from_utf8("Noto Sans Mono CJK SC"),
+            foundry: None,
+            file: Some(LispString::from_utf8("/tmp/NotoSansMonoCJKsc-Regular.otf")),
+            weight: FontWeight::NORMAL,
+            slant: FontSlant::Normal,
+            width: FontWidth::Normal,
+            postscript_name: Some(LispString::from_utf8("NotoSansMonoCJKsc-Regular")),
+            glyph_code: Some(0x2A),
+        }),
+        metrics: Some(FontPxProbeResult {
+            pixel_size: 17,
+            height: 18,
+            ascent: 13,
+            descent: 5,
+            max_width: 19,
+            space_width: 11,
+            average_width: 12,
+        }),
+        capability: Some(FontOtfCapability {
+            gsub: vec![("latn".to_owned(), vec![(None, vec!["liga".to_owned()])])],
+            gpos: Vec::new(),
+        }),
+    }));
+    eval.buffers
+        .current_buffer_mut()
+        .expect("current buffer")
+        .insert("a好b");
+
+    let font = builtin_font_at(&mut eval, vec![Value::fixnum(2)]).unwrap();
+    eval.frame_manager_mut()
+        .get_mut(frame_id)
+        .expect("selected frame")
+        .window_system = None;
+    let query = builtin_query_font(&mut eval, vec![font]).unwrap();
+    let values = query.as_vector_data().expect("query-font vector");
+
+    assert_eq!(values.len(), 9);
+    assert!(
+        values[0]
+            .as_utf8_str()
+            .is_some_and(|name| name.contains("-17-"))
+    );
+    assert_eq!(
+        values[1].as_utf8_str(),
+        Some("/tmp/NotoSansMonoCJKsc-Regular.otf")
+    );
+    for (index, expected) in [(2, 17), (3, 19), (4, 13), (5, 5), (6, 11), (7, 12)] {
+        assert_eq!(values[index].as_int(), Some(expected), "slot {index}");
+    }
+    assert_eq!(values[8].cons_car().as_symbol_name(), Some("opentype"));
+    assert!(values[8].cons_cdr().cons_car().is_cons());
+
+    let err = builtin_query_font(&mut eval, vec![Value::NIL]).unwrap_err();
+    match err {
+        Flow::Signal(sig) => assert_eq!(sig.data, vec![Value::symbol("font-object"), Value::NIL]),
+        other => panic!("expected wrong-type-argument, got {other:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Issue

`query-font` is currently a placeholder that always returns nil, so Lisp callers cannot retrieve the font name, file, metrics, or OpenType capability from a resolved font object. `font-shape-gstring` also incorrectly requires its second argument to be an integer, while GNU callers pass optional values such as nil or symbols.

## Solution

- Implement `query-font` for font objects using the existing font-info and runtime font metric paths.
- Return GNU-compatible name, file, pixel size, width, ascent, descent, spacing, and capability slots.
- Preserve GNU-compatible `font-object` type errors for invalid inputs.
- Stop imposing an incorrect fixnum requirement on `font-shape-gstring`'s optional shaping argument.
- Add focused font query and bytecode dispatch regressions.

## Verification

- `cargo test -p neovm-core --lib query_font_eval_returns_metrics_with_terminal_frame_selected -- --nocapture` passes.
- `cargo test -p neovm-core --lib vm_font_stub_tail_uses_direct_dispatch -- --nocapture` passes.
- `cargo check -p neovm-core` passes.
- `cargo fmt --all -- --check` passes.
- `git diff --check upstream/main...HEAD` passes.
- Windows validation temporarily applied the separate Unix-signal gating from #276; that change is not included in this PR.