### PR TITLE
fix(layout): floor degenerate line height so early frames don't overlap glyphs

### DIFF
--- a/neomacs-layout-engine/src/font/metrics.rs
+++ b/neomacs-layout-engine/src/font/metrics.rs
@@ -206,6 +206,7 @@ impl FrameCellMetrics {
         advances: FontAdvanceMetrics,
     ) -> Self {
         let column = FrameColumnWidth::from_advances(prefer_monospace, font_size, advances);
+        let vertical = vertical_metrics_with_floor(font_size, vertical);
 
         Self {
             column_width: column.pixels,
@@ -214,6 +215,46 @@ impl FrameCellMetrics {
             descent: vertical.descent,
             confidence: column.confidence,
         }
+    }
+}
+
+/// Guard against a backend that hands back degenerate vertical metrics.
+///
+/// This is the vertical twin of the `column_width` fallback in
+/// [`FrameColumnWidth::from_advances`]: when a font has not been realized yet
+/// (e.g. the default face's font is applied from `after-make-frame-functions`,
+/// so an early frame paints before its metrics exist) the backend reports a
+/// `line_height` of ~0. Passing that straight through collapses the row pitch
+/// to a couple of pixels while glyph bitmaps stay ~8px tall, so consecutive
+/// rows overlap and the renderer's `char_overlap` guard fires (garbled first
+/// paint). When the reported line height is missing or absurdly small relative
+/// to the font size, synthesize typographic defaults from `font_size` instead
+/// — the same shape GNU uses for a font with no usable vertical metrics.
+fn vertical_metrics_with_floor(
+    font_size: f32,
+    vertical: FontVerticalMetrics,
+) -> FontVerticalMetrics {
+    // Only rescue genuinely degenerate answers. A line height that is finite
+    // and at least one unit tall is legitimate — notably a TTY frame reports
+    // exactly 1.0 (one terminal cell) while carrying a nominal font pixel size,
+    // and that must pass through untouched. The bug is specifically a GUI font
+    // that has not been realized yet, where the backend reports a line height
+    // of ~0; that collapses the row pitch below the glyph bitmaps and overlaps
+    // rows on the first paint.
+    if vertical.line_height.is_finite() && vertical.line_height >= 1.0 {
+        return vertical;
+    }
+    let font_size = if font_size.is_finite() && font_size > 0.0 {
+        font_size
+    } else {
+        // No usable font size either: mirror the column fallback's 13px
+        // baseline so the cell is at least legibly sized rather than 1x3.
+        13.0
+    };
+    FontVerticalMetrics {
+        ascent: font_size * 0.8,
+        descent: font_size * 0.2,
+        line_height: font_size * 1.2,
     }
 }
 

--- a/neomacs-layout-engine/src/font/metrics_test.rs
+++ b/neomacs-layout-engine/src/font/metrics_test.rs
@@ -234,6 +234,52 @@ fn frame_cell_metrics_for_proportional_use_ascii_average_not_space() {
 }
 
 #[test]
+fn frame_cell_metrics_floors_degenerate_line_height() {
+    // Regression: an unrealized font (default face applied from
+    // `after-make-frame-functions`) reports line_height ~0, collapsing the
+    // row pitch to a few pixels and overlapping glyph bitmaps. The cell must
+    // synthesize a sane line height from the font size instead.
+    let widths = [8.0f32; 128];
+    let advances = FontAdvanceMetrics::from_ascii_widths(8.0, &widths);
+    let cell = FrameCellMetrics::derive(
+        true,
+        14.0,
+        FontVerticalMetrics {
+            ascent: 0.0,
+            descent: 0.0,
+            line_height: 0.0,
+        },
+        advances,
+    );
+    assert!(
+        cell.line_height >= 14.0,
+        "degenerate line height must be floored to ~font size, got {}",
+        cell.line_height
+    );
+    assert!(cell.ascent > 0.0 && cell.descent > 0.0);
+}
+
+#[test]
+fn frame_cell_metrics_keeps_realized_line_height() {
+    // A healthy backend answer must pass through untouched.
+    let widths = [8.0f32; 128];
+    let advances = FontAdvanceMetrics::from_ascii_widths(8.0, &widths);
+    let cell = FrameCellMetrics::derive(
+        true,
+        14.0,
+        FontVerticalMetrics {
+            ascent: 12.0,
+            descent: 4.0,
+            line_height: 18.0,
+        },
+        advances,
+    );
+    assert_eq!(cell.line_height, 18.0);
+    assert_eq!(cell.ascent, 12.0);
+    assert_eq!(cell.descent, 4.0);
+}
+
+#[test]
 fn frame_cell_metrics_falls_back_when_backend_reports_no_valid_advances() {
     let widths = [0.0f32; 128];
 


### PR DESCRIPTION
Fixes #282.

## what was wrong

when the default face's font gets applied from `after-make-frame-functions` (pretty standard so daemon/early frames pick up the font once fonts exist), the first frame paints *before* its font is realized. the backend hands back a line height of ~0 for that frame, and nothing floored it — so the row pitch collapsed to a couple of pixels while the glyph bitmaps stayed ~8px tall. rows ended up stacked on top of each other and the renderer's `char_overlap` guard lit up 40+ times a frame. the log tell is `font=0.0 cell=(...,1.0x3.0)` — a 1px×3px cell.

`neomacs -Q` was fine (healthy cells are `cell=(...,7.8x18.0)`), which is what pointed at "font applied after the frame is made" as the trigger.

## the fix

`FrameCellMetrics::derive` already guards the horizontal axis — `FrameColumnWidth::from_advances` falls back to `font_size * 0.6` when the backend reports no valid advances. but the vertical axis (line height / ascent / descent) was passed straight through, so a ~0 line height went unchecked.

this adds the vertical twin: if the reported line height is non-finite or below one unit, synthesize typographic defaults from the font size (`1.2` em line height, `0.8` ascent, `0.2` descent). anything realized passes through untouched, and importantly a TTY frame's legitimate `1.0` (one terminal cell, with a nominal font pixel size) is *not* touched — the guard only trips on a genuinely degenerate `< 1.0` value.

## testing

- new unit tests: `frame_cell_metrics_floors_degenerate_line_height` (a 0.0 line height gets floored to ~font size) and `frame_cell_metrics_keeps_realized_line_height` (a healthy 18.0 passes through unchanged).
- full `neomacs-layout-engine` lib suite is green apart from two `select_font_for_char_*` tests that already fail on master here (they depend on specific font weight instances being installed) — my change doesn't touch them.
- live GUI smoke run with the repro init: no more `char_overlap` errors, no `font=0.0` / `1.0x3.0` cells.

repro init if you want to see it:

```elisp
(defun my/apply-font (&optional frame)
  (when (display-graphic-p frame)
    (set-face-attribute 'default frame :family "monospace" :height 105)))
(add-hook 'after-make-frame-functions #'my/apply-font)
```
