### PR TITLE
fix(font): don'\''t WARN-spam startup over bitmap fonts GNU opens silently

### DIFF
--- a/neomacs-layout-engine/src/font/loader.rs
+++ b/neomacs-layout-engine/src/font/loader.rs
@@ -73,7 +73,12 @@ impl FontFileCache {
         };
 
         if ids.is_empty() {
-            tracing::warn!("FontFileCache: failed to load font file: {}", file_path);
+            // Routine, not an error: fontconfig indexes legacy bitmap formats
+            // (PCF/OTB, e.g. Terminus) that GNU's FreeType driver opens but
+            // fontdb/ttf-parser cannot parse. The caller falls back cleanly
+            // and the negative result is cached, so this is a `debug!`, not a
+            // `warn!` — GNU logs nothing when it opens the same files.
+            tracing::debug!("FontFileCache: failed to load font file: {}", file_path);
             return None;
         }
 

--- a/neomacs-layout-engine/src/font/metrics.rs
+++ b/neomacs-layout-engine/src/font/metrics.rs
@@ -791,7 +791,14 @@ impl FontMetricsService {
             .pin_file_as_family(path, matched.identity.file_face_index())
             .is_none()
         {
-            tracing::warn!(
+            // A fontconfig match the render stack can't materialize (legacy
+            // bitmap fonts like Terminus `.otb`, which GNU's FreeType opens
+            // but fontdb/cosmic-text cannot). The ordinary fallback path takes
+            // over, so this is expected and routine — `debug!`, not `warn!`,
+            // to match GNU, which is silent when it opens the same files. It
+            // is also reached once per fallback probe, so a `warn!` here spams
+            // startup for every candidate lookup that touches such a font.
+            tracing::debug!(
                 target: "font_boundary",
                 identity = %matched.identity.stable_key,
                 "platform font is unsupported by the layout/render font stack; using resolved fallback"


### PR DESCRIPTION
no linked issue — hit this on my own box (Garuda, Terminus installed).

## what was wrong

launching neomacs on a machine that has legacy bitmap fonts installed dumps a wall of WARNs and drags out startup. on mine it's Terminus — ~36 `.otb` faces in `/usr/share/fonts/misc`:

```
WARN fontdb: Failed to load a font face 0 from source cause font doesn't have a family name.
WARN neomacs_layout_engine::font::loader: FontFileCache: failed to load font file: /usr/share/fonts/misc/ter-u22b.otb
WARN font_boundary: platform font is unsupported by the layout/render font stack; using resolved fallback identity=/usr/share/fonts/misc/ter-u22b.otb#0
```

`ter-u22b.otb` is a bitmap-only OpenType font — its glyphs live in the `EBDT` table, no outlines. fontconfig happily indexes it and offers it as a fallback candidate, but fontdb/cosmic-text can't materialize a bitmap face, so `materialize_platform_match` rejects it. that rejection is fine — the ordinary fallback path takes over — but it logs a WARN, and it runs *once per fallback probe*, so you get the same font screaming past over and over as different chars/faces get resolved.

the thing is: **GNU Emacs uses these exact same fonts without a peep.** its FreeType driver just opens the bitmap. so on GNU this is a non-event, and on neomacs it's a noisy slow launch — that mismatch is the bug.

## the fix

these paths aren't error conditions, they're expected fallback:
- the fallback path takes over cleanly (you get a usable glyph from another font),
- and the negative result is already cached — `FontFileCache` stores the `None` per file, `resolve_for_char` caches the miss per char — so we're not re-parsing the file forever, just re-logging.

so demote both warnings (`FontFileCache: failed to load` in `loader.rs`, and `platform font is unsupported` in `metrics.rs`) from `warn!` to `debug!`. a normal launch is now quiet like GNU's; anyone who wants to see which fonts got rejected and why can still ask for it with `RUST_LOG=...=debug`. no logic changed — the fallback behavior is identical, only the log level moved.

## testing

- `cargo build -p neomacs-layout-engine` clean.
- layout-engine font suite green, except two pre-existing env-dependent failures (`select_font_for_char_reports_realized_face_metadata`, `select_font_for_char_preserves_resolved_weight_for_variable_family_reports`) that also fail on a clean `main` on this box — a variable font realizes to weight 900 here while the tests assert 800. unrelated to this change.
- live: relaunching on my box, startup log is quiet — no more `ter-u*.otb` wall.