### PR TITLE
fix(syntax): keep back_comment from taking a comment char inside a string

### DIFF
--- a/neovm-core/src/emacs_core/syntax.rs
+++ b/neovm-core/src/emacs_core/syntax.rs
@@ -2882,6 +2882,12 @@ impl<'a> SyntaxPropByteRun<'a> {
         }
     }
 
+    /// The property source this cache reads from, for scanners that have to
+    /// hand it on to a char-addressed parse (see `back_comment_reparse`).
+    fn props(&self) -> SyntaxProperties<'a> {
+        self.props
+    }
+
     /// See [`SyntaxPropRange::ascii_entry`] — identical memo, byte-side.
     #[inline]
     fn ascii_entry(&self, table: &SyntaxTable, ch: char) -> Option<SyntaxEntry> {
@@ -4468,11 +4474,129 @@ fn forward_comment_backward(
     true
 }
 
+/// The delimiter of a string the backward comment walk is currently inside.
+///
+/// GNU keeps this as a single `int` (`string_style`), overloading it with the
+/// `ST_STRING_STYLE` / `ST_COMMENT_STYLE` sentinels for the two fence classes;
+/// naming the three cases keeps the sentinels from having to be reserved out of
+/// the character range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BackCommentStringStyle {
+    /// An ordinary string quote (`Sstring`), identified by its character:
+    /// two *different* quote characters cannot be told apart scanning backward.
+    Delim(char),
+    /// A generic string fence (`Sstring_fence`).
+    StringFence,
+    /// A generic comment fence (`Scomment_fence`), which GNU counts as a
+    /// string delimiter for parity purposes.
+    CommentFence,
+}
+
+/// GNU `char_quoted`, addressed by Emacs byte position: is the character
+/// starting at `pos` preceded by an odd number of escape / character-quote
+/// characters?
+fn char_quoted_at_byte(
+    buf: &Buffer,
+    pos: EmacsBytePos,
+    min: EmacsBytePos,
+    prop_cache: &SyntaxPropByteRun<'_>,
+) -> bool {
+    let table = SyntaxTable::for_buffer(buf);
+    let mut cursor = pos;
+    let mut quoted = false;
+    while cursor > min {
+        let Some(unit) = buffer_syntax_char_before(buf, cursor) else {
+            break;
+        };
+        let class =
+            effective_syntax_entry_for_char_at_byte(buf, &table, unit.ch, unit.start, prop_cache)
+                .class;
+        if !matches!(class, SyntaxClass::Escape | SyntaxClass::CharQuote) {
+            break;
+        }
+        quoted = !quoted;
+        cursor = unit.start;
+    }
+    quoted
+}
+
+/// GNU `back_comment`'s `lossage` fallback: re-parse *forward* and take the
+/// comment start from the resulting parse state.
+///
+/// Backward scanning cannot resolve which of two readings of a mixed
+/// string/comment run is the real one -- GNU's own examples are `" { " a { " }`
+/// and `{ a (* " *)` -- so once the walk knows it is guessing it throws the
+/// guess away and parses forward from a position that is known not to be inside
+/// a string or a comment.
+///
+/// GNU picks that position with `find_defun_start`, which by default (with
+/// `comment-use-syntax-ppss` non-nil) asks `syntax-ppss` for the start of the
+/// construct containing `comment_end` -- itself a `parse-partial-sexp` from
+/// `BEGV`.  Parsing straight from `BEGV` reaches the same answer without a Lisp
+/// call and without GNU's retry loop, whose only purpose is to recover when the
+/// heuristic start point turns out to be inside another comment.  `BEGV` is
+/// always outside every string and comment, so one parse settles it.
+///
+/// Returns the comment's start position, or `None` when the forward parse says
+/// `comment_end` does not end a comment of this style after all.
+///
+/// Cost: one forward parse of everything before `comment_end`, with no cache
+/// across calls.  GNU pays the same parse but gets it from `syntax-ppss`, whose
+/// cache is incremental and shared with the rest of the editor.  Reaching that
+/// cache from here needs the evaluator, which the byte-addressed comment
+/// scanners do not carry; until they do, this is the slow-but-correct half of
+/// the trade, and it only runs on the rare buffers that reach lossage at all.
+fn back_comment_reparse(
+    buf: &ForwardCommentCursor<'_>,
+    comment_end: EmacsBytePos,
+    style: CommentStyle,
+    nested: bool,
+    prop_cache: &SyntaxPropByteRun<'_>,
+) -> Option<EmacsBytePos> {
+    let begv = buf.accessible_char_region().start();
+    let from = char_pos_to_lisp_i64(begv.get());
+    let to = buffer_byte_to_lisp_pos(buf, comment_end);
+    if to <= from {
+        return None;
+    }
+
+    let table = SyntaxTable::for_buffer(buf);
+    let (state, _) = parse_state_from_range_core(
+        buf,
+        &table,
+        from,
+        to,
+        None,
+        false,
+        None,
+        CommentStopMode::None,
+        prop_cache.props(),
+    );
+
+    // GNU's acceptance test is `state.incomment == (comnested ? 1 : -1) &&
+    // state.comstyle == comstyle`: the parse has to end inside a comment of
+    // exactly this style, at exactly this nesting depth.
+    let ParseCommentState::Syntax {
+        depth,
+        style: parsed_style,
+        nestable,
+    } = state.in_comment?
+    else {
+        return None;
+    };
+    if parsed_style != style || nestable != nested || (nested && depth != 1) {
+        return None;
+    }
+
+    let start = lisp_pos_to_byte(buf, LispCharPos1::new(state.comment_or_string_start?));
+    (start != comment_end).then_some(start)
+}
+
 /// Scan backward through comment body to find matching comment start.
 ///
-/// This is a simplified version of GNU Emacs's `back_comment()`.  Point
-/// should be positioned right after the comment-end delimiter has been
-/// consumed (i.e. just before the comment body).
+/// This is GNU Emacs's `back_comment()`.  Point should be positioned right
+/// after the comment-end delimiter has been consumed (i.e. just before the
+/// comment body).
 ///
 /// For **nested** comments the function returns as soon as the nesting
 /// count drops to zero.
@@ -4482,18 +4606,42 @@ fn forward_comment_backward(
 /// finds.  A same-style comment-ender encountered during the scan means
 /// "anything before this belongs to a different comment" and stops the
 /// search.  At the end, point is set to the recorded position.
+///
+/// Scanning backward cannot tell whether a comment starter it walks over is
+/// real or merely sitting inside a string, so the walk also tracks
+/// string-quote parity.  A comment starter reached while inside a string --
+/// or after any other sign that the walk is guessing -- is *not* accepted;
+/// the whole question is handed to [`back_comment_reparse`] instead.
+///
+/// One GNU safeguard is still missing: the `goto lossage` for two-char comment
+/// markers that partly overlap (snmp-mode's `-- c --`, C's `|*|`).  This
+/// scanner instead resolves the ambiguous-`--` case by giving the delimiter
+/// nearest the ender opener precedence, in the two-char branches below.
 fn scan_backward_comment_body(
     buf: &mut ForwardCommentCursor<'_>,
     style: CommentStyle,
     nested: bool,
     prop_cache: &SyntaxPropByteRun<'_>,
 ) -> bool {
+    let comment_end = buf.point_emacs_byte_pos();
     let mut nesting = 1i32;
     let min = buf.accessible_emacs_byte_region().start();
 
     // For non-nested comments: record the earliest matching comment-start
     // seen so far.
     let mut comstart_pos: Option<EmacsBytePos> = None;
+
+    // GNU `string_style`: the string the walk is currently inside, presumed
+    // to be none at the point the walk starts.
+    let mut string_style: Option<BackCommentStringStyle> = None;
+    // GNU `string_lossage`: two different kinds of string delimiter were seen,
+    // which backward scanning cannot untangle.
+    let mut string_lossage = false;
+    // GNU `comment_lossage`: a comment-ender of *another* style was crossed, so
+    // a comment starter found further back may belong to that other comment.
+    let mut comment_lossage = false;
+    // GNU's `goto lossage`: the walk knows its answer would be a guess.
+    let mut lossage = false;
 
     loop {
         let pt = buf.point_emacs_byte_pos();
@@ -4515,6 +4663,19 @@ fn scan_backward_comment_body(
         let class = entry.class;
         let flags = entry.flags;
 
+        // GNU: "Ignore escaped characters, except comment-enders which cannot
+        // be escaped."  (`comment-end-can-be-escaped' is not yet threaded into
+        // the scanners; this is its default, nil, behaviour.)  Without this an
+        // escaped string quote flips the parity and the guard below stops
+        // seeing the string it is inside.
+        if class != SyntaxClass::EndComment
+            && !flags.contains(SyntaxFlags::COMMENT_END_SECOND)
+            && char_quoted_at_byte(buf, unit.start, min, prop_cache)
+        {
+            buf.goto_emacs_byte_pos(unit.start);
+            continue;
+        }
+
         // ── Comment-end (same style) ──────────────────────────────
         // For nested: increases nesting.
         // For non-nested: means our comment can't extend past this,
@@ -4532,6 +4693,15 @@ fn scan_backward_comment_body(
             }
         }
 
+        // GNU `case Sendcomment`, else branch: an ender of a *different* style.
+        // We are mixing comment styles, so any comment starter found further
+        // back might belong to that other comment rather than to ours.  GNU
+        // exempts a bare newline before the first comment starter, because
+        // otherwise every multi-line C comment would take the slow path.
+        if class == SyntaxClass::EndComment && (comstart_pos.is_some() || unit.ch != '\n') {
+            comment_lossage = true;
+        }
+
         // Two-char comment end backward.
         if flags.contains(SyntaxFlags::COMMENT_END_SECOND) {
             let prev_pos = unit.start;
@@ -4547,37 +4717,72 @@ fn scan_backward_comment_body(
                     prop_cache,
                 );
                 let flags2 = entry2.flags;
-                if flags2.contains(SyntaxFlags::COMMENT_END_FIRST)
-                    && CommentStyle::from_end_flags(flags2, flags) == style
-                {
-                    // GNU `back_comment` gives the first ambiguous two-char
-                    // delimiter opener precedence.  This matters for `--`,
-                    // whose two characters can carry both start and end flags:
-                    // the delimiter nearest the terminating newline starts the
-                    // comment; only an earlier occurrence can end the backward
-                    // search for that opener.
-                    let first_ambiguous_opener = comstart_pos.is_none()
-                        && flags2.contains(SyntaxFlags::COMMENT_START_FIRST)
-                        && flags.contains(SyntaxFlags::COMMENT_START_SECOND)
-                        && CommentStyle::from_start_flags(flags2, flags) == style
-                        && (flags2.contains(SyntaxFlags::COMMENT_NESTABLE)
-                            || flags.contains(SyntaxFlags::COMMENT_NESTABLE))
-                            == nested;
-                    if !first_ambiguous_opener {
-                        if nested {
-                            nesting += 1;
-                            buf.goto_emacs_byte_pos(unit2.start);
-                            continue;
-                        } else {
-                            break;
+                if flags2.contains(SyntaxFlags::COMMENT_END_FIRST) {
+                    if CommentStyle::from_end_flags(flags2, flags) == style {
+                        // GNU `back_comment` gives the first ambiguous two-char
+                        // delimiter opener precedence.  This matters for `--`,
+                        // whose two characters can carry both start and end flags:
+                        // the delimiter nearest the terminating newline starts the
+                        // comment; only an earlier occurrence can end the backward
+                        // search for that opener.
+                        let first_ambiguous_opener = comstart_pos.is_none()
+                            && flags2.contains(SyntaxFlags::COMMENT_START_FIRST)
+                            && flags.contains(SyntaxFlags::COMMENT_START_SECOND)
+                            && CommentStyle::from_start_flags(flags2, flags) == style
+                            && (flags2.contains(SyntaxFlags::COMMENT_NESTABLE)
+                                || flags.contains(SyntaxFlags::COMMENT_NESTABLE))
+                                == nested;
+                        if !first_ambiguous_opener {
+                            if nested {
+                                nesting += 1;
+                                buf.goto_emacs_byte_pos(unit2.start);
+                                continue;
+                            } else {
+                                break;
+                            }
                         }
+                    } else if comstart_pos.is_some() || unit2.ch != '\n' {
+                        // Same mixed-style caution as for one-char enders.
+                        comment_lossage = true;
                     }
                 }
             }
         }
 
+        // ── String quotes and fences ─────────────────────────────
+        // GNU tracks the parity of string delimiters across the whole walk so
+        // that a comment starter *inside* a string is never mistaken for a real
+        // one.  Both fence classes count as delimiters here; a generic comment
+        // fence is opened and closed by `scan_backward_comment_fence`, never by
+        // this function, so it only contributes parity.
+        let quote_style = match class {
+            SyntaxClass::StringDelim => Some(BackCommentStringStyle::Delim(unit.ch)),
+            SyntaxClass::StringFence => Some(BackCommentStringStyle::StringFence),
+            SyntaxClass::CommentFence => Some(BackCommentStringStyle::CommentFence),
+            _ => None,
+        };
+        if let Some(quote_style) = quote_style {
+            match string_style {
+                // Entering a string, walking backward out of it.
+                None => string_style = Some(quote_style),
+                // Leaving it again.
+                Some(open) if open == quote_style => string_style = None,
+                // Two kinds of string delimiter: there is no way to grok this
+                // scanning backward.
+                Some(_) => string_lossage = true,
+            }
+            buf.goto_emacs_byte_pos(unit.start);
+            continue;
+        }
+
         // ── Single-char comment start (class `<`) ────────────────
         if class == SyntaxClass::Comment && CommentStyle::from_main_flags(flags) == style {
+            if string_style.is_some() || comment_lossage || string_lossage {
+                // GNU: "There are odd string quotes involved, so let's be
+                // careful.  Test case in Pascal: " { " a { " }"
+                lossage = true;
+                break;
+            }
             let new_pos = unit.start;
             if nested {
                 buf.goto_emacs_byte_pos(new_pos);
@@ -4593,21 +4798,6 @@ fn scan_backward_comment_body(
                 buf.goto_emacs_byte_pos(new_pos);
                 continue;
             }
-        }
-
-        // ── Comment fence ────────────────────────────────────────
-        if class == SyntaxClass::CommentFence {
-            let new_pos = unit.start;
-            buf.goto_emacs_byte_pos(new_pos);
-            if nested {
-                nesting -= 1;
-                if nesting <= 0 {
-                    return true;
-                }
-            } else {
-                comstart_pos = Some(new_pos);
-            }
-            continue;
         }
 
         // ── Two-char comment start backward ──────────────────────
@@ -4630,6 +4820,10 @@ fn scan_backward_comment_body(
                 if flags2.contains(SyntaxFlags::COMMENT_START_FIRST)
                     && CommentStyle::from_start_flags(flags2, flags) == style
                 {
+                    if string_style.is_some() || comment_lossage || string_lossage {
+                        lossage = true;
+                        break;
+                    }
                     let new_pos = unit2.start;
                     if nested {
                         buf.goto_emacs_byte_pos(new_pos);
@@ -4649,6 +4843,16 @@ fn scan_backward_comment_body(
 
         // Default: skip this character and continue scanning.
         buf.goto_emacs_byte_pos(unit.start);
+    }
+
+    if lossage {
+        // The backward walk cannot be trusted; decide it going forwards.
+        if let Some(start) = back_comment_reparse(buf, comment_end, style, nested, prop_cache) {
+            buf.goto_emacs_byte_pos(start);
+            return true;
+        }
+        buf.goto_emacs_byte_pos(comment_end);
+        return false;
     }
 
     // For non-nested comments, check if we recorded any comment-start.
@@ -5622,6 +5826,35 @@ fn parse_state_from_range_with_options(
     commentstop: CommentStopMode,
     props: SyntaxProperties<'_>,
 ) -> (Value, i64) {
+    let (state, stopped_at) = parse_state_from_range_core(
+        buf,
+        table,
+        from,
+        to,
+        target_depth,
+        stop_before,
+        oldstate,
+        commentstop,
+        props,
+    );
+    (state.into_value(), stopped_at)
+}
+
+/// GNU `scan_sexps_forward`.  The parse state is returned unencoded so that
+/// in-tree callers -- `parse-partial-sexp` and `back_comment`'s forward
+/// re-parse -- can read it without going through the Lisp representation.
+#[allow(clippy::too_many_arguments)] // mirrors GNU `scan_sexps_forward`'s parameters
+fn parse_state_from_range_core(
+    buf: &Buffer,
+    table: &SyntaxTable,
+    from: i64,
+    to: i64,
+    target_depth: Option<i64>,
+    stop_before: bool,
+    oldstate: Option<&Value>,
+    commentstop: CommentStopMode,
+    props: SyntaxProperties<'_>,
+) -> (PartialParseState, i64) {
     let accessible_chars = buf.accessible_char_region();
     let point_min = accessible_chars.start().get();
     let point_max = accessible_chars.end().get();
@@ -5995,7 +6228,7 @@ fn parse_state_from_range_with_options(
 
     finish_atom(&mut state, &mut atom_start);
 
-    (state.into_value(), char_pos_to_lisp_i64(from_char + idx))
+    (state, char_pos_to_lisp_i64(from_char + idx))
 }
 
 /// `(parse-partial-sexp FROM TO &optional TARGETDEPTH STOPBEFORE STATE COMMENTSTOP)`

--- a/neovm-core/src/emacs_core/syntax_gnu_parity_regression_test.rs
+++ b/neovm-core/src/emacs_core/syntax_gnu_parity_regression_test.rs
@@ -1000,3 +1000,25 @@ fn a_strings_interval_takes_syntax_from_default_text_properties() {
     );
     assert_eq!(result, "OK 0");
 }
+
+/// The upstream report's headline case: backward sexp motion in `emacs-lisp-mode`
+/// over a form whose string contains a `;`.  The closing paren sits on a later
+/// line, so the backward scan crosses the newline that ends line 2, and
+/// `back_comment` has to decide whether that `;` starts a comment.  It does not
+/// -- it is inside a string -- and `backward-list` must reach the `(` at 2.
+#[test]
+fn backward_list_crosses_an_elisp_string_holding_a_comment_char() {
+    crate::test_utils::init_test_tracing();
+    let result = crate::test_utils::runtime_startup_eval_one(
+        r#"
+        (with-temp-buffer
+          (emacs-lisp-mode)
+          (insert " (progn\n  (setq a \";\")\n  nil)\n")
+          (goto-char (point-max))
+          (skip-chars-backward "\n")
+          (backward-list)
+          (point))
+        "#,
+    );
+    assert_eq!(result, "OK 2");
+}

--- a/neovm-core/src/emacs_core/syntax_test.rs
+++ b/neovm-core/src/emacs_core/syntax_test.rs
@@ -1704,6 +1704,161 @@ fn backward_comment_treats_first_ambiguous_two_char_delimiter_as_opener() {
     assert_eq!(current_point_lisp_pos(&eval), 3);
 }
 
+/// `#` starts a comment, `\n` ends one; `"` and `\` keep their standard
+/// string-quote and escape syntax.  This is the three-entry table from the
+/// upstream reproducer for backward sexp motion across a comment character
+/// that only *appears* inside a string.
+fn install_hash_line_comment_syntax(eval: &mut crate::emacs_core::eval::Context) {
+    builtin_modify_syntax_entry(eval, vec![Value::fixnum('#' as i64), Value::string("<")])
+        .expect("install hash comment start syntax");
+    builtin_modify_syntax_entry(eval, vec![Value::fixnum('\n' as i64), Value::string(">")])
+        .expect("install newline comment end syntax");
+}
+
+fn scan_lists_backward_from(eval: &mut crate::emacs_core::eval::Context, from: i64) -> Value {
+    builtin_scan_lists(
+        eval,
+        vec![Value::fixnum(from), Value::fixnum(-1), Value::fixnum(0)],
+    )
+    .expect("scan-lists backward")
+}
+
+/// GNU `back_comment` tracks string-quote parity across its backward walk and
+/// refuses a comment starter found while inside a string (`src/syntax.c`,
+/// `case Scomment`).  Without that, the `#` inside `"#"` is taken for a real
+/// comment start, the closing quote is swallowed, and the scan runs off the
+/// beginning of the buffer.
+#[test]
+fn scan_lists_backward_ignores_comment_char_inside_string() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::eval::Context::new();
+    //           1234 5 6  789012345 6 78 9
+    //           x = { \n   a = "#"; \n }  \n
+    replace_current_buffer_text(&mut eval, "x = {\n  a = \"#\";\n}\n");
+    install_hash_line_comment_syntax(&mut eval);
+    eval.obarray
+        .set_symbol_value("parse-sexp-ignore-comments", Value::T);
+
+    assert_eq!(scan_lists_backward_from(&mut eval, 19), Value::fixnum(5));
+}
+
+/// An escaped string quote must not flip the parity: GNU skips characters that
+/// `char_quoted` reports as escaped before classifying them.
+#[test]
+fn scan_lists_backward_ignores_escaped_string_quote_before_comment_char() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::eval::Context::new();
+    replace_current_buffer_text(&mut eval, "x = {\n  a = \"y\\\"#\\\"z\";\n}\n");
+    install_hash_line_comment_syntax(&mut eval);
+    eval.obarray
+        .set_symbol_value("parse-sexp-ignore-comments", Value::T);
+
+    assert_eq!(scan_lists_backward_from(&mut eval, 25), Value::fixnum(5));
+}
+
+/// The parity guard must not cost us genuine comments: the same motion over a
+/// real `# hi` line still has to reach the opening brace.
+#[test]
+fn scan_lists_backward_still_crosses_a_genuine_comment() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::eval::Context::new();
+    replace_current_buffer_text(&mut eval, "x = {\n  # hi\n  a = 1;\n}\n");
+    install_hash_line_comment_syntax(&mut eval);
+    eval.obarray
+        .set_symbol_value("parse-sexp-ignore-comments", Value::T);
+
+    assert_eq!(scan_lists_backward_from(&mut eval, 24), Value::fixnum(5));
+}
+
+/// A lone string quote *inside* a real comment makes the backward walk
+/// untrustworthy, so GNU falls back to re-parsing forward from a known-safe
+/// point and takes the comment start from that parse.  Refusing the comment
+/// outright would leave the unbalanced `"` to be scanned as a string.
+#[test]
+fn scan_lists_backward_reparses_forward_when_the_comment_body_holds_a_string_quote() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::eval::Context::new();
+    replace_current_buffer_text(&mut eval, "x = {\n  # a \" b\n}\n");
+    install_hash_line_comment_syntax(&mut eval);
+    eval.obarray
+        .set_symbol_value("parse-sexp-ignore-comments", Value::T);
+
+    assert_eq!(scan_lists_backward_from(&mut eval, 18), Value::fixnum(5));
+}
+
+/// Two string quotes inside the comment body leave the parity even again, so
+/// the backward walk reaches the `#` outside any string and never needs the
+/// forward re-parse.  Pins that the parity guard is a parity guard and not a
+/// blanket "a quote appeared" refusal.
+#[test]
+fn scan_lists_backward_accepts_a_comment_whose_body_holds_balanced_string_quotes() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::eval::Context::new();
+    replace_current_buffer_text(&mut eval, "x = {\n  # a \" b \" c\n}\n");
+    install_hash_line_comment_syntax(&mut eval);
+    eval.obarray
+        .set_symbol_value("parse-sexp-ignore-comments", Value::T);
+
+    assert_eq!(scan_lists_backward_from(&mut eval, 22), Value::fixnum(5));
+}
+
+/// `(forward-comment -1)` over a newline whose line holds a comment character
+/// inside a string finds no comment: it stops just before the newline.
+#[test]
+fn backward_comment_rejects_comment_start_inside_string() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::eval::Context::new();
+    replace_current_buffer_text(&mut eval, "a = \"#\";\nb\n");
+    install_hash_line_comment_syntax(&mut eval);
+    {
+        let buf = eval.buffers.current_buffer_mut().expect("current buffer");
+        buf.goto_emacs_byte_pos(crate::buffer::EmacsBytePos::new(char_pos_to_byte(buf, 9)));
+    }
+
+    let moved = builtin_forward_comment(&mut eval, vec![Value::fixnum(-1)]).unwrap();
+
+    assert_eq!(moved, Value::NIL);
+    assert_eq!(current_point_lisp_pos(&eval), 9);
+}
+
+/// The escaped-quote variant of the same rejection: the `#` is still inside the
+/// string, because `\"` does not close it.
+#[test]
+fn backward_comment_rejects_comment_start_inside_string_with_escaped_quotes() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::eval::Context::new();
+    replace_current_buffer_text(&mut eval, "a = \"y\\\"#\\\"z\";\nb\n");
+    install_hash_line_comment_syntax(&mut eval);
+    {
+        let buf = eval.buffers.current_buffer_mut().expect("current buffer");
+        buf.goto_emacs_byte_pos(crate::buffer::EmacsBytePos::new(char_pos_to_byte(buf, 15)));
+    }
+
+    let moved = builtin_forward_comment(&mut eval, vec![Value::fixnum(-1)]).unwrap();
+
+    assert_eq!(moved, Value::NIL);
+    assert_eq!(current_point_lisp_pos(&eval), 15);
+}
+
+/// A string quote inside the comment body sends the backward walk to the
+/// forward re-parse, which still reports the comment: point lands on `#`.
+#[test]
+fn backward_comment_finds_comment_start_through_forward_reparse() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::eval::Context::new();
+    replace_current_buffer_text(&mut eval, "a\n# x \" y\nb\n");
+    install_hash_line_comment_syntax(&mut eval);
+    {
+        let buf = eval.buffers.current_buffer_mut().expect("current buffer");
+        buf.goto_emacs_byte_pos(crate::buffer::EmacsBytePos::new(char_pos_to_byte(buf, 10)));
+    }
+
+    let moved = builtin_forward_comment(&mut eval, vec![Value::fixnum(-1)]).unwrap();
+
+    assert_eq!(moved, Value::T);
+    assert_eq!(current_point_lisp_pos(&eval), 3);
+}
+
 #[test]
 fn forward_comment_validates_arity_and_type() {
     crate::test_utils::init_test_tracing();


### PR DESCRIPTION
## Problem

Backward `scan-lists` / `scan-sexps` mistake a comment character that merely *appears inside a
string* for a real comment start. Every backward sexp motion across such a line fails with a
bogus `scan-error`; forward motion over the same text is correct.

```elisp
;; `#' is `<', `\n' is `>', `"' is `"'; braces are already parens in the standard table.
(setq-local parse-sexp-ignore-comments t)
(insert "x = {\n  a = \"#\";\n}\n")
(goto-char 19)
(backward-list)   ; GNU => 5,  neomacs => (scan-error "Unbalanced parentheses" 18 1)
```

Three conditions must coincide:

1. `parse-sexp-ignore-comments` is non-nil — which essentially every programming mode sets,
2. the backward scan crosses a comment ender (here, a newline),
3. that ender's line contains a comment-start character inside a string.

It reaches real major modes. `emacs-lisp-mode` is the one that stings: this breaks `C-M-b` /
`backward-sexp` / `backward-list` in Emacs Lisp itself on any form containing a string with a
`;` in it.

| mode              | buffer                                  | GNU | neomacs before |
| ----------------- | --------------------------------------- | --- | -------------- |
| `emacs-lisp-mode` | `" (progn\n  (setq a \";\")\n  nil)\n"` | 2   | `scan-error`   |
| `sh-mode`         | `f() {\n  a="#"\n}\n`                   | 5   | `scan-error`   |
| `python-mode`     | `d = {\n  'a': "#",\n}\n`               | 5   | `scan-error`   |
| `nix-mode`        | any attrset containing `x = "#";`       | ok  | `scan-error`   |

It surfaced through Evil's `%` (`evil-jump-item`) in a `.nix` file: jumping forward from `{`
works, jumping back from the matching `}` fails with `No matching item found on the current
line`. `evil-jump-item` is asymmetric by construction — forward it calls `(scan-lists (point)
1 -1)`, which never scans backward; backward it calls `backward-list`. Only the return trip
hit the broken path, which is why the jump was one-way.

`(setq-local parse-sexp-ignore-comments nil)` avoids the path but is not a usable workaround:
parens inside real comments then count toward balance, which breaks the same motions on any
file with commented-out code.

## Cause

`neovm-core/src/emacs_core/syntax.rs`, `scan_backward_comment_body`. Its doc comment was
accurate about what it was:

> This is a simplified version of GNU Emacs's `back_comment()`.

The simplification dropped both of GNU's safeguards against exactly this case
(`emacs/src/syntax.c`, `back_comment`):

**1. String-quote parity.** GNU maintains `string_style` across the backward walk, toggled by
`Sstring` / `Sstring_fence` / `Scomment_fence`, and refuses a comment starter found while
inside a string:

```c
	case Scomment:
	  /* We've already checked that it is the relevant comstyle.  */
	  if (string_style != -1 || comment_lossage || string_lossage)
	    /* There are odd string quotes involved, so let's be careful.
	       Test case in Pascal: " { " a { " } */
	    goto lossage;
```

`scan_backward_comment_body` had no `string_style` equivalent and no `SyntaxClass::String` /
`StringFence` arm at all — string delimiters fell through to the loop's `default:` branch and
were skipped like ordinary characters. The `#` inside `"#"` was therefore recorded as the
comment start, the closing `"` was swallowed into a phantom comment, string delimiters stopped
balancing, and the scan ran to `BEGV` and raised `Unbalanced parentheses`.

**2. The `lossage` fallback.** When GNU cannot trust the backward walk it re-parses *forward*
from a known-safe point and takes the comment start from `state.comstr_start`. There was no
such fallback.

## Fix

**String-quote parity**, counting `Sstring`, `Sstring_fence` and `Scomment_fence` alike, with
`string_lossage` when two different delimiters make the parity unreadable.

**`char_quoted` skip** for escaped characters, except comment enders, so an escaped quote no
longer flips that parity. Without it `"y\"#\"z"` still mis-reads: the escaped `"` would clear
`string_style` and the `#` would be recorded as a real comment start.

**`comment_lossage`** when the walk crosses a comment ender of another style — GNU's caution
against claiming a starter that belongs to that other comment.

**The lossage fallback.** Refusing alone would lose the comments GNU still finds, so
`back_comment_reparse` parses forward and takes the comment start from the resulting parse
state. GNU picks its safe start with `find_defun_start`, which by default
(`comment-use-syntax-ppss` is `t`) asks `syntax-ppss` — itself a `parse-partial-sexp` from
`BEGV`. Parsing straight from `BEGV` reaches the same answer without a Lisp call and without
GNU's retry loop, whose only purpose is recovering from a heuristic start point that turns out
to be inside another comment. To make that state readable,
`parse_state_from_range_with_options` is split into a core returning `PartialParseState` and a
thin wrapper that encodes it for `parse-partial-sexp`.

Falling out of the parity work: a **generic comment fence** now only contributes parity, as in
GNU, instead of recording a comment start it was never entitled to record — fences are opened
and closed by `scan_backward_comment_fence`, never by this function.

## Not in this change

- GNU's `goto lossage` for **overlapping two-char comment markers** (snmp-mode's `-- c --`,
  C's `|*|`). This scanner already carries its own tuned approximation for the ambiguous-`--`
  case; replacing it needs GNU's `prev_syntax` bookkeeping, which is a different shape of
  change. Noted in the function's doc comment.
- The forward re-parse has **no cross-call cache**, where GNU gets one from `syntax-ppss`.
  Reaching that cache needs the evaluator, which the byte-addressed comment scanners do not
  carry. It only runs on the rare buffers that reach lossage at all. Also noted in the doc
  comment.

## Tests

Written first, each confirmed red on the parent commit and green after
(`ERR (scan-error ("Unbalanced parentheses" 29 1))` → `2` for the `emacs-lisp-mode` case).

In `syntax_test.rs`:

- `scan_lists_backward_ignores_comment_char_inside_string` — the reported case.
- `scan_lists_backward_ignores_escaped_string_quote_before_comment_char` — the `char_quoted`
  case.
- `scan_lists_backward_still_crosses_a_genuine_comment` — the parity guard must not cost us
  real comments.
- `scan_lists_backward_reparses_forward_when_the_comment_body_holds_a_string_quote` and
  `backward_comment_finds_comment_start_through_forward_reparse` — these two fail if the
  fallback is stubbed out, so it is load-bearing rather than decorative.
- `scan_lists_backward_accepts_a_comment_whose_body_holds_balanced_string_quotes` — pins that
  the guard is a *parity* guard, not a blanket "a quote appeared" refusal.
- `backward_comment_rejects_comment_start_inside_string{,_with_escaped_quotes}` — the
  `(forward-comment -1)` surface directly.

In `syntax_gnu_parity_regression_test.rs`:

- `backward_list_crosses_an_elisp_string_holding_a_comment_char` — the reported
  `emacs-lisp-mode` case, through the real mode.

Every expected value above was taken from GNU Emacs 32.0.50 on the same machine, not derived
from the implementation.

## Verification

- All 7 cases of the reporter's standalone reproducer pass against the built binary, including
  `emacs-lisp-mode`, `sh-mode` and `python-mode`.
- `cargo test -p neovm-core`: the serial failures are byte-for-byte identical on the parent
  commit and on this branch (44 sandbox filesystem/process tests — raw unibyte paths,
  `call_process`, symlinks). `emacs_core::syntax` is clean apart from two parallel-isolation
  flakes that also predate this branch.
- `cargo fmt --check` clean; no new `cargo clippy` findings in the touched range.
- `test/src/syntax-tests.el` overflows the stack under a debug build both before and after, so
  it gave no signal either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNqoHHHMDq4SwKQKpYxyZ4
