### PR TITLE
install.sh: curl | bash installer with versioned user layout + GNU walk-up runtime-root resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,8 @@ jobs:
       # from THIS commit (file:// download base), so the curl|bash path --
       # download, checksum, versioned install, symlink chain, runtime-root
       # resolution with no environment variables -- is proven before any
-      # release publishes it.
+      # release publishes it. The staged tree uses the canonical bin/ +
+      # share/neomacs/ layout that package-release.sh ships.
       - name: Verify install.sh against a staged release tree
         run: |
           version=citest
@@ -296,10 +297,10 @@ jobs:
           staged="$stage_root/v$version"
           pkg_parent="$stage_root/pkg"
           pkg="$pkg_parent/neomacs-$version-$triple"
-          mkdir -p "$staged" "$pkg"
+          mkdir -p "$staged" "$pkg/bin" "$pkg/share/neomacs"
           cp target/release/neomacs target/release/neomacsclient \
-            target/release/neomacs.pdump "$pkg/"
-          cp -r lisp etc "$pkg/"
+            target/release/neomacs.pdump "$pkg/bin/"
+          cp -r lisp etc "$pkg/share/neomacs/"
           tar czf "$staged/neomacs-$version-$triple.tar.gz" \
             -C "$pkg_parent" "neomacs-$version-$triple"
           (
@@ -314,6 +315,7 @@ jobs:
           test "$(readlink "$prefix/bin/neomacs")" = "../share/neomacs/current/bin/neomacs"
           exe="$(readlink -f "$prefix/bin/neomacs")"
           test -f "$(dirname "$exe")/neomacs.pdump"
+          test -d "$(dirname "$exe")/../share/neomacs/lisp"
           env -u NEOMACS_RUNTIME_ROOT \
             "$prefix/bin/neomacs" --batch --eval '(princ (emacs-version))'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Run actionlint
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/*.yml
 
+      - name: Lint install.sh
+        run: |
+          shellcheck install.sh
+          sh -n install.sh
+
   fmt:
     name: cargo fmt (${{ matrix.label }})
     if: github.event_name != 'schedule'
@@ -277,6 +282,40 @@ jobs:
       # safe point, which turns "sometimes" into "always".
       - name: GC-stress the shipped runtime
         run: cargo xtask gc-stress
+
+      # Exercise install.sh end-to-end against a release-shaped tree built
+      # from THIS commit (file:// download base), so the curl|bash path --
+      # download, checksum, versioned install, symlink chain, runtime-root
+      # resolution with no environment variables -- is proven before any
+      # release publishes it.
+      - name: Verify install.sh against a staged release tree
+        run: |
+          version=citest
+          triple=x86_64-unknown-linux-gnu
+          stage_root="$TMPDIR/install-release"
+          staged="$stage_root/v$version"
+          pkg_parent="$stage_root/pkg"
+          pkg="$pkg_parent/neomacs-$version-$triple"
+          mkdir -p "$staged" "$pkg"
+          cp target/release/neomacs target/release/neomacsclient \
+            target/release/neomacs.pdump "$pkg/"
+          cp -r lisp etc "$pkg/"
+          tar czf "$staged/neomacs-$version-$triple.tar.gz" \
+            -C "$pkg_parent" "neomacs-$version-$triple"
+          (
+            cd "$staged"
+            sha256sum "neomacs-$version-$triple.tar.gz" > SHA256SUMS
+          )
+          prefix="$stage_root/prefix"
+          NEOMACS_DOWNLOAD_BASE="file://$staged" \
+            sh install.sh --tag "v$version" --prefix "$prefix"
+          test -x "$prefix/bin/neomacs"
+          test "$(readlink "$prefix/share/neomacs/current")" = "versions/$version"
+          test "$(readlink "$prefix/bin/neomacs")" = "../share/neomacs/current/bin/neomacs"
+          exe="$(readlink -f "$prefix/bin/neomacs")"
+          test -f "$(dirname "$exe")/neomacs.pdump"
+          env -u NEOMACS_RUNTIME_ROOT \
+            "$prefix/bin/neomacs" --batch --eval '(princ (emacs-version))'
 
       - name: Package shared test runtime
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,17 +66,14 @@ jobs:
 
       - name: Package tarball (x86_64-unknown-linux-gnu)
         run: |
-          TARGET=x86_64-unknown-linux-gnu
-          STAGING="neomacs-${VERSION}-${TARGET}"
-          mkdir -p "$STAGING"
-          cp target/release/neomacs "$STAGING/"
-          cp target/release/neomacsclient "$STAGING/"
-          cp target/release/neomacs.pdump "$STAGING/"
-          cp -r lisp "$STAGING/"
-          cp -r etc "$STAGING/"
-          cp COPYING "$STAGING/"
-          mkdir -p dist
-          tar czf "dist/${STAGING}.tar.gz" "$STAGING"
+          # package-release.sh builds the canonical release tree
+          # (bin/ + share/neomacs/) and its tarball: the archive is runnable
+          # in place and install.sh consumes the same layout. The inline
+          # flat staging this replaces produced a tree the binary could not
+          # resolve without NEOMACS_RUNTIME_ROOT.
+          ./scripts/package-release.sh \
+            --target x86_64-unknown-linux-gnu \
+            --skip-build --no-smoke
 
       - name: Package AppImage
         run: ./scripts/package-appimage.sh --skip-build --no-smoke
@@ -136,17 +133,11 @@ jobs:
 
       - name: Package tarball (aarch64-unknown-linux-gnu)
         run: |
-          TARGET=aarch64-unknown-linux-gnu
-          STAGING="neomacs-${VERSION}-${TARGET}"
-          mkdir -p "$STAGING"
-          cp target/release/neomacs "$STAGING/"
-          cp target/release/neomacsclient "$STAGING/"
-          cp target/release/neomacs.pdump "$STAGING/"
-          cp -r lisp "$STAGING/"
-          cp -r etc "$STAGING/"
-          cp COPYING "$STAGING/"
-          mkdir -p dist
-          tar czf "dist/${STAGING}.tar.gz" "$STAGING"
+          # Same canonical release tree as the x86_64 tarball; see the
+          # note on the x86_64 packaging step.
+          ./scripts/package-release.sh \
+            --target aarch64-unknown-linux-gnu \
+            --skip-build --no-smoke
 
       - name: Verify packaged artifact and GLIBC baseline
         run: |
@@ -275,6 +266,20 @@ jobs:
             dist/*.dmg \
             dist/*.zip \
             dist/*.tar.gz
+
+      - name: Verify install.sh from the published release
+        run: |
+          # Same user path as the Linux verify-install-script job: fetch the
+          # installer asset from the just-published release and let its own
+          # post-install check batch-start the app bundle's binary through
+          # the ~/.local/bin symlink (no environment variables).
+          curl -fsSL \
+            "https://github.com/eval-exec/neomacs/releases/download/${GITHUB_REF_NAME}/install.sh" \
+            -o install.sh
+          sh install.sh --tag "${GITHUB_REF_NAME}"
+          test -x "$HOME/.local/bin/neomacs"
+          env -u NEOMACS_RUNTIME_ROOT \
+            "$HOME/.local/bin/neomacs" --batch --eval '(princ (emacs-version))'
 
   # ── Windows x86_64 ────────────────────────────────────────────────────
   build-windows-x86_64:
@@ -408,11 +413,26 @@ jobs:
       - build-windows-x86_64
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
+
+      - name: Stage the installer and its checksum manifest
+        run: |
+          # install.sh ships as a release asset so that
+          # https://github.com/eval-exec/neomacs/releases/latest/download/install.sh
+          # always serves the installer that matches the assets it downloads
+          # (the neomacs.org entry point fetches exactly that URL).
+          install -m 0644 install.sh dist/install.sh
+          # The glob expands before SHA256SUMS exists, so the manifest covers
+          # every asset (and the installer) but never itself.
+          cd dist
+          sha256sum ./* > SHA256SUMS
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
@@ -423,3 +443,35 @@ jobs:
           discussion_category_name: Announcements
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Install script verification ───────────────────────────────────────
+  # Installs through the public curl|bash entry exactly as a user would:
+  # the installer asset is downloaded from the just-published release, and
+  # its own post-install check batch-starts the binary with no environment
+  # variables, exercising the runtime-root resolution through the
+  # ~/.local/bin symlink chain.
+  verify-install-script:
+    name: verify install.sh from the published release
+    needs: create-release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      prefix: ${{ github.workspace }}/tmp/prefix
+    steps:
+      - name: Run the published installer
+        run: |
+          curl -fsSL \
+            "https://github.com/eval-exec/neomacs/releases/download/${GITHUB_REF_NAME}/install.sh" \
+            -o install.sh
+          sh install.sh --tag "${GITHUB_REF_NAME}" --prefix "$prefix"
+
+      - name: Assert the installed layout
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          test -x "$prefix/bin/neomacs"
+          test "$(readlink "$prefix/share/neomacs/current")" = "versions/$version"
+          test "$(readlink "$prefix/bin/neomacs")" = "../share/neomacs/current/bin/neomacs"
+          exe="$(readlink -f "$prefix/bin/neomacs")"
+          test -f "$(dirname "$exe")/neomacs.pdump"
+          env -u NEOMACS_RUNTIME_ROOT \
+            "$prefix/bin/neomacs" --batch --eval '(princ (emacs-version))'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -473,5 +473,6 @@ jobs:
           test "$(readlink "$prefix/bin/neomacs")" = "../share/neomacs/current/bin/neomacs"
           exe="$(readlink -f "$prefix/bin/neomacs")"
           test -f "$(dirname "$exe")/neomacs.pdump"
+          test -d "$(dirname "$exe")/../share/neomacs/lisp"
           env -u NEOMACS_RUNTIME_ROOT \
             "$prefix/bin/neomacs" --batch --eval '(princ (emacs-version))'

--- a/README.md
+++ b/README.md
@@ -107,7 +107,31 @@ https://github.com/user-attachments/assets/275c6d9a-fced-44f6-8f43-3bbd2984d672
 
 ## Install
 
-Download the latest release for your platform from
+Install the latest release into your user account (no root):
+
+```bash
+curl -fsSL https://neomacs.org/install.sh | bash
+```
+
+The installer downloads a release tarball, verifies its SHA256 against the
+release manifest, and installs a versioned tree with a rollback copy:
+
+```
+~/.local/bin/neomacs -> ../share/neomacs/current/bin/neomacs
+~/.local/share/neomacs/current -> versions/0.0.15
+~/.local/share/neomacs/versions/0.0.15/{bin, lisp, etc, ...}
+```
+
+Re-running the command upgrades (flipping `current` atomically and keeping
+the previous version); `install.sh --tag vX.Y.Z` installs or rolls back to a
+specific release. On macOS it installs the `neomacs.app` bundle into
+`~/Applications` and links the CLI into `~/.local/bin`.
+Windows is not covered by the shell installer — use the release `.exe`
+below. The installer itself lives at
+[install.sh](install.sh) in this repository and is published as a release
+asset.
+
+Prefer system packages? Download them from
 **[Releases](https://github.com/eval-exec/neomacs/releases/latest)**:
 
 | Platform | Packages |

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ https://github.com/user-attachments/assets/275c6d9a-fced-44f6-8f43-3bbd2984d672
 Install the latest release into your user account (no root):
 
 ```bash
-curl -fsSL https://neomacs.org/install.sh | bash
+curl -fsSL https://neomacs.org/install.sh | sh
 ```
 
 The installer downloads a release tarball, verifies its SHA256 against the
@@ -119,7 +119,8 @@ release manifest, and installs a versioned tree with a rollback copy:
 ```
 ~/.local/bin/neomacs -> ../share/neomacs/current/bin/neomacs
 ~/.local/share/neomacs/current -> versions/0.0.15
-~/.local/share/neomacs/versions/0.0.15/{bin, lisp, etc, ...}
+~/.local/share/neomacs/versions/0.0.15/bin/{neomacs, neomacs.pdump}
+~/.local/share/neomacs/versions/0.0.15/share/neomacs/{lisp, etc, ...}
 ```
 
 Re-running the command upgrades (flipping `current` atomically and keeping

--- a/deny.toml
+++ b/deny.toml
@@ -51,4 +51,7 @@ highlight = "simplest-path"
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/eval-exec/cosmic-text"]
+allow-git = [
+  "https://github.com/eval-exec/cosmic-text",
+  "https://github.com/eval-exec/freetype-sys",
+]

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,410 @@
+#!/bin/sh
+# NEO Emacs (neomacs) installer.
+#
+#   curl -fsSL https://neomacs.org/install.sh | bash
+#
+# Downloads a release tarball from GitHub Releases and installs it without
+# root privileges:
+#
+#   Linux   ~/.local/share/neomacs/versions/<ver>/{bin,lisp,etc,...}
+#           ~/.local/share/neomacs/current -> versions/<ver>
+#           ~/.local/bin/neomacs -> ../share/neomacs/current/bin/neomacs
+#   macOS   ~/Applications/neomacs.app (full bundle, vendored GStreamer)
+#           ~/.local/bin/neomacs -> .../neomacs.app/Contents/MacOS/neomacs
+#
+# Upgrades flip the `current' symlink, so they never disturb a running
+# instance, and the previous version is kept for rollback (re-run with
+# --tag). The layout is what the binary's runtime-root resolver
+# auto-detects, mirroring GNU Emacs' walk-up from the executable
+# (src/emacs.c init_cmdargs + src/lread.c load_path_default): no
+# environment variables are needed.
+#
+# This script is intentionally POSIX sh (dash-compatible) and asks no
+# questions, so it is safe to pipe into a shell.
+
+set -u
+
+repo="eval-exec/neomacs"
+tag=""
+prefix=""
+app_dir=""
+bin_dir=""
+keep_download="no"
+skip_smoke="no"
+
+usage() {
+  cat <<'USAGE'
+Usage: install.sh [options]
+
+Install NEO Emacs from GitHub Releases into your user account (no root).
+
+Options:
+  --prefix DIR    Installation prefix (Linux). The versioned tree goes to
+                  DIR/share/neomacs and the `neomacs` command to DIR/bin.
+                  Default: ~/.local
+  --app-dir DIR   Where to place neomacs.app (macOS). Default: ~/Applications
+  --bin-dir DIR   Where to place the `neomacs` command. Default: ~/.local/bin
+  --tag TAG       Release to install, e.g. v0.0.15 (also rolls back to a
+                  kept version). Default: latest release
+  --repo SPEC     GitHub OWNER/NAME to install from.
+                  Default: eval-exec/neomacs (env NEOMACS_GH_REPO)
+  --keep-download Keep the downloaded archive (useful for debugging)
+  --skip-smoke    Do not run the installed binary as a post-install check
+  -h, --help      Show this help
+
+Examples:
+  curl -fsSL https://neomacs.org/install.sh | bash
+  install.sh --tag v0.0.15        # install (or roll back to) a specific release
+  install.sh --prefix /opt/neomacs
+
+Linux layout (previous version kept for rollback):
+  ~/.local/bin/neomacs -> ../share/neomacs/current/bin/neomacs
+  ~/.local/share/neomacs/current -> versions/0.0.15
+  ~/.local/share/neomacs/versions/0.0.15/{bin/neomacs,bin/neomacs.pdump,lisp,etc,...}
+
+Linux also ships AppImage/.deb/.rpm release assets, and macOS a .dmg, for
+those who prefer system packages:
+https://github.com/eval-exec/neomacs/releases/latest
+USAGE
+}
+
+die() {
+  echo "install.sh: error: $*" >&2
+  exit 1
+}
+
+say() {
+  printf '%s\n' "$*"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --prefix)
+      [ "$#" -ge 2 ] || die "$1 requires a value"
+      prefix=$2
+      shift 2
+      ;;
+    --app-dir)
+      [ "$#" -ge 2 ] || die "$1 requires a value"
+      app_dir=$2
+      shift 2
+      ;;
+    --bin-dir)
+      [ "$#" -ge 2 ] || die "$1 requires a value"
+      bin_dir=$2
+      shift 2
+      ;;
+    --tag)
+      [ "$#" -ge 2 ] || die "$1 requires a value"
+      tag=$2
+      shift 2
+      ;;
+    --repo)
+      [ "$#" -ge 2 ] || die "$1 requires a value"
+      repo=$2
+      shift 2
+      ;;
+    --keep-download)
+      keep_download=yes
+      shift
+      ;;
+    --skip-smoke)
+      skip_smoke=yes
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1 (see --help)"
+      ;;
+  esac
+done
+
+[ -n "${NEOMACS_GH_REPO:-}" ] && repo=$NEOMACS_GH_REPO
+case "$repo" in
+  */*) ;;
+  *) die "repo must be OWNER/NAME, got: $repo" ;;
+esac
+
+# ---------------------------------------------------------------- fetchers --
+
+if command -v curl >/dev/null 2>&1; then
+  fetch() { curl -fsSL "$1"; }
+  download() { curl -fsSL -o "$2" "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+  fetch() { wget -qO- "$1"; }
+  download() { wget -q -O "$2" "$1"; }
+else
+  die "neither curl nor wget is available"
+fi
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  else
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------- platform ----
+
+os=$(uname -s)
+case "$os" in
+  Linux) os=linux ;;
+  Darwin) os=darwin ;;
+  MINGW*|MSYS*|CYGWIN*)
+    die "this installer does not support Windows; download the -user-setup.exe from https://github.com/$repo/releases/latest"
+    ;;
+  *)
+    die "unsupported operating system: $os"
+    ;;
+esac
+
+arch=$(uname -m)
+case "$os:$arch" in
+  linux:x86_64) triple=x86_64-unknown-linux-gnu ;;
+  linux:aarch64|linux:arm64) triple=aarch64-unknown-linux-gnu ;;
+  darwin:arm64|darwin:aarch64) triple=aarch64-apple-darwin ;;
+  darwin:x86_64)
+    die "no Intel Mac (x86_64) builds are published yet; see https://github.com/$repo/releases"
+    ;;
+  *)
+    die "unsupported $os architecture: $arch"
+    ;;
+esac
+
+# --------------------------------------------------------------- release ---
+
+if [ -z "$tag" ]; then
+  say "-> resolving the latest release of $repo"
+  tag=$(fetch "https://api.github.com/repos/$repo/releases/latest" \
+    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n 1)
+  [ -n "$tag" ] || die "could not resolve the latest release (API rate limit?); pass --tag vX.Y.Z"
+fi
+case "$tag" in
+  v*) version=${tag#v} ;;
+  *) version=$tag; tag="v$tag" ;;
+esac
+
+asset="neomacs-${version}-${triple}.tar.gz"
+# The download base is overridable so CI can exercise this script against a
+# locally staged release tree (file:// URLs work with both curl and wget)
+# before anything is published.
+release_base=${NEOMACS_DOWNLOAD_BASE:-"https://github.com/$repo/releases/download"}
+asset_url="$release_base/$tag/$asset"
+say "-> installing $repo $tag ($triple)"
+
+# ------------------------------------------------------------- download ----
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/neomacs-install.XXXXXX") \
+  || die "could not create a temporary directory"
+cleanup() {
+  if [ "$keep_download" = yes ]; then
+    say "download kept in $tmp_dir"
+  else
+    rm -rf "$tmp_dir"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+archive="$tmp_dir/$asset"
+say "-> downloading $asset"
+download "$asset_url" "$archive" || die "download failed: $asset_url"
+[ -s "$archive" ] || die "download produced an empty file: $asset_url"
+
+# Verify against the release checksum manifest when the release provides one
+# (releases before SHA256SUMS existed only warn).
+sums=$(fetch "$release_base/$tag/SHA256SUMS" || true)
+if [ -n "$sums" ]; then
+  expected=$(printf '%s\n' "$sums" | awk -v f="$asset" '$2 == f {print $1}')
+  if [ -n "$expected" ]; then
+    actual=$(sha256_of "$archive") \
+      || die "neither sha256sum nor shasum is available to verify the download"
+    [ "$actual" = "$expected" ] \
+      || die "checksum mismatch for $asset (expected $expected, got $actual)"
+    say "-> checksum verified"
+  fi
+else
+  say "note: release $tag publishes no SHA256SUMS; skipping checksum verification"
+fi
+
+# -------------------------------------------------------------- install ----
+
+extract_dir="$tmp_dir/extract"
+mkdir -p "$extract_dir"
+tar -C "$extract_dir" -xzf "$archive" || die "could not extract $asset"
+pkg_dir="$extract_dir/neomacs-${version}-${triple}"
+[ -d "$pkg_dir" ] || die "archive did not contain neomacs-${version}-${triple}/"
+
+if [ "$os" = linux ]; then
+  # Release tarballs ship either the canonical layout (bin/ + share/neomacs/,
+  # produced by scripts/package-release.sh, runnable in place) or the older
+  # flat layout (executables beside lisp/ and etc/). Handle both so --tag can
+  # reach every published release.
+  if [ -x "$pkg_dir/bin/neomacs" ] && [ -d "$pkg_dir/share/neomacs" ]; then
+    src_bin=$pkg_dir/bin
+    src_data=$pkg_dir/share/neomacs
+    [ -f "$src_bin/neomacs.pdump" ] || die "package is missing neomacs.pdump"
+    [ -d "$src_data/lisp" ] && [ -d "$src_data/etc" ] \
+      || die "package is missing the lisp/ or etc/ runtime tree"
+  else
+    src_bin=$pkg_dir
+    [ -x "$pkg_dir/neomacs" ] || die "package is missing the neomacs binary"
+    [ -f "$pkg_dir/neomacs.pdump" ] || die "package is missing neomacs.pdump"
+    [ -d "$pkg_dir/lisp" ] || die "package is missing the lisp/ runtime tree"
+  fi
+
+  [ -z "$prefix" ] && prefix=${HOME}/.local
+  [ -z "$bin_dir" ] && bin_dir=$prefix/bin
+  root=$prefix/share/neomacs
+  ver_dir=$root/versions/$version
+  staged=$root/versions/.staged.$version
+
+  mkdir -p "$staged/bin" "$bin_dir" \
+    || die "cannot create directories under $prefix (writable?)"
+
+  if [ -n "${src_data:-}" ]; then
+    # Canonical layout: runtime data is already gathered under share/neomacs
+    # (lisp, etc, leim, and anything added later); add the top-level docs.
+    cp -a "$src_data/." "$staged/" || die "could not stage the runtime tree"
+    for doc in COPYING VERSION README.md; do
+      if [ -f "$pkg_dir/$doc" ]; then
+        cp -a "$pkg_dir/$doc" "$staged/$doc" || die "could not stage $doc"
+      fi
+    done
+  else
+    # Flat layout: everything except the executables and the dump is runtime
+    # data (lisp, etc, COPYING, and anything else the release carries).
+    find "$pkg_dir" -mindepth 1 -maxdepth 1 \
+      ! -name neomacs ! -name neomacsclient ! -name 'neomacs.pdump' \
+      ! -name 'neomacs-*.pdump' -exec cp -a {} "$staged/" \; \
+      || die "could not stage the runtime tree"
+  fi
+
+  # The loader resolves neomacs.pdump next to the canonical executable, so
+  # the dump must live in bin/ with the binary (as in the shipped .deb).
+  for exe in neomacs neomacsclient; do
+    if [ -f "$src_bin/$exe" ]; then
+      install -m 0755 "$src_bin/$exe" "$staged/bin/$exe" \
+        || die "could not stage $exe"
+    fi
+  done
+  install -m 0644 "$src_bin/neomacs.pdump" "$staged/bin/neomacs.pdump" \
+    || die "could not stage neomacs.pdump"
+
+  # Validate the staged tree before anything installed changes.
+  [ -x "$staged/bin/neomacs" ] || die "staged tree lost the neomacs binary"
+  [ -f "$staged/bin/neomacs.pdump" ] || die "staged tree lost neomacs.pdump"
+  [ -d "$staged/lisp" ] && [ -d "$staged/etc" ] \
+    || die "staged tree lost the lisp/ or etc/ runtime directories"
+
+  # Swap the version directory in whole (a rename), then flip `current' --
+  # a running instance keeps its old tree, and a crash between the two
+  # leaves the previous release active.
+  old_current=$(cat "$root/current-version" 2>/dev/null || true)
+  rm -rf "$ver_dir"
+  mv "$staged" "$ver_dir" || die "could not move the new version into place"
+  ln -sfn "versions/$version" "$root/current" \
+    || die "could not update the current symlink"
+  printf '%s\n' "$version" > "$root/current-version" \
+    || die "could not record the installed version"
+  if [ -n "$old_current" ] && [ "$old_current" != "$version" ]; then
+    printf '%s\n' "$old_current" > "$root/previous-version"
+  fi
+
+  # The command symlink is relative, so the prefix stays relocatable. The
+  # runtime-root resolver follows it (canonicalize) into the version tree.
+  ln -sfn "../share/neomacs/current/bin/neomacs" "$bin_dir/neomacs" \
+    || die "could not link neomacs into $bin_dir"
+  [ -f "$ver_dir/bin/neomacsclient" ] \
+    && ln -sfn "../share/neomacs/current/bin/neomacsclient" "$bin_dir/neomacsclient"
+
+  # Keep the current version and the one it replaced (the rollback target);
+  # prune older ones -- each version directory is a few hundred MB.
+  keep_prev=$(cat "$root/previous-version" 2>/dev/null || true)
+  for d in "$root"/versions/*; do
+    [ -d "$d" ] || continue
+    name=${d##*/}
+    case "$name" in
+      [0-9]*) ;;
+      *) continue ;;
+    esac
+    [ "$name" = "$version" ] && continue
+    [ -n "$keep_prev" ] && [ "$name" = "$keep_prev" ] && continue
+    say "-> pruning old version $name"
+    rm -rf "$d"
+  done
+
+  installed_bin=$bin_dir/neomacs
+else
+  # macOS: the tarball ships the complete neomacs.app bundle (binary, dump,
+  # lisp/etc trees, vendored GStreamer frameworks). Install the app, then
+  # expose the CLI through symlinks; the runtime resolver follows the
+  # canonical path into Contents/Resources/neomacs automatically.
+  [ -z "$app_dir" ] && app_dir=${HOME}/Applications
+  [ -z "$bin_dir" ] && bin_dir=${HOME}/.local/bin
+  app="neomacs.app"
+  [ -d "$pkg_dir/$app" ] || die "package did not contain $app"
+
+  mkdir -p "$app_dir" "$bin_dir" \
+    || die "cannot create $app_dir or $bin_dir (writable?)"
+
+  # Extract landed on the same volume as $app_dir only if TMPDIR is; move
+  # through a staging dir inside $app_dir so the final move is a rename.
+  staging="$app_dir/.neomacs-install.staged"
+  rm -rf "$staging"
+  mkdir -p "$staging"
+  mv "$pkg_dir/$app" "$staging/$app" || die "could not stage $app"
+  if [ -d "$app_dir/$app" ]; then
+    mv "$app_dir/$app" "$app_dir/neomacs.app.old" \
+      || die "could not move the old $app aside"
+  fi
+  mv "$staging/$app" "$app_dir/$app" || die "could not move $app into place"
+  rm -rf "$app_dir/neomacs.app.old" "$staging"
+
+  for exe in neomacs neomacsclient; do
+    target="$app_dir/$app/Contents/MacOS/$exe"
+    if [ -f "$target" ]; then
+      ln -sfn "$target" "$bin_dir/$exe" || die "could not link $exe into $bin_dir"
+    fi
+  done
+
+  installed_bin=$bin_dir/neomacs
+fi
+
+# ---------------------------------------------------------------- smoke ----
+
+# Same post-install check the release pipeline applies to every artifact:
+# batch-start through the installed path, with no environment variables, so
+# the runtime-root resolution is exercised exactly as a user launch would.
+if [ "$skip_smoke" = no ]; then
+  say "-> verifying the installed binary starts"
+  env -u NEOMACS_RUNTIME_ROOT "$installed_bin" --batch --eval '(kill-emacs 0)' \
+    || die "installed neomacs failed to start; report this at https://github.com/$repo/issues (files are in place; see --skip-smoke to bypass)"
+fi
+
+# ----------------------------------------------------------------- PATH ----
+
+case ":${PATH}:" in
+  *":$(dirname "$installed_bin"):"*)
+    ;;
+  *)
+    bin_parent=$(dirname "$installed_bin")
+    say ""
+    say "NOTE: $bin_parent is not in your PATH. Add"
+    say "  export PATH=\"$bin_parent:\$PATH\""
+    say "to your shell profile (~/.profile, ~/.bashrc, or ~/.zshrc)."
+    ;;
+esac
+
+say ""
+say "NEO Emacs $version installed:"
+say "  $installed_bin"
+say "Run 'neomacs' to start (or 'neomacs -nw' for terminal mode)."
+if [ "$os" = linux ]; then
+  say "Rollback to a kept version: install.sh --tag vX.Y.Z"
+fi

--- a/install.sh
+++ b/install.sh
@@ -319,6 +319,32 @@ if [ "$os" = linux ]; then
   [ -d "$staged/share/neomacs/etc" ] \
     || die "staged tree lost the etc/ runtime directory"
 
+  # Pre-flight the dynamic-loader requirements of the release binary (built
+  # against distro ncurses + GStreamer) and fail with the exact fix instead
+  # of a loader error at first launch. Skipped where ldd cannot run.
+  missing_libs=$(ldd "$staged/bin/neomacs" 2>/dev/null | sed -n 's/^[[:space:]]*\([^[:space:]]*\).*not found.*/\1/p' | sort -u)
+  if [ -n "$missing_libs" ]; then
+    say ""
+    say "this system is missing runtime libraries neomacs needs:"
+    for lib in $missing_libs; do
+      say "  $lib"
+    done
+    say ""
+    say "install them, then re-run this installer. For example:"
+    if command -v apt-get >/dev/null 2>&1; then
+      say "  apt install libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 libtinfo6"
+    elif command -v dnf >/dev/null 2>&1; then
+      say "  dnf install gstreamer1 gstreamer1-plugins-base ncurses-libs"
+    elif command -v pacman >/dev/null 2>&1; then
+      say "  pacman -S gstreamer gst-plugins-base ncurses"
+    elif command -v zypper >/dev/null 2>&1; then
+      say "  zypper install gstreamer gstreamer-plugins-base libncurses6"
+    else
+      say "  your distribution's ncurses and GStreamer 1.0 runtime packages"
+    fi
+    die "system dependencies missing (nothing was installed)"
+  fi
+
   # Swap the version directory through a same-volume rename, then flip
   # `current'. Installing over an tag that is already active first moves the
   # existing directory aside, so a failure mid-swap leaves the old tree

--- a/install.sh
+++ b/install.sh
@@ -6,11 +6,16 @@
 # Downloads a release tarball from GitHub Releases and installs it without
 # root privileges:
 #
-#   Linux   ~/.local/share/neomacs/versions/<ver>/{bin,lisp,etc,...}
+#   Linux   ~/.local/share/neomacs/versions/<ver>/{bin, share/neomacs/...}
 #           ~/.local/share/neomacs/current -> versions/<ver>
 #           ~/.local/bin/neomacs -> ../share/neomacs/current/bin/neomacs
 #   macOS   ~/Applications/neomacs.app (full bundle, vendored GStreamer)
 #           ~/.local/bin/neomacs -> .../neomacs.app/Contents/MacOS/neomacs
+#
+# The version directory mirrors the release tarball's own bin/ + share/
+# layout, which every shipped resolver generation locates relative to the
+# executable -- including the v0.0.15 binaries, so installing old --tag
+# releases works without NEOMACS_RUNTIME_ROOT.
 #
 # Upgrades flip the `current' symlink, so they never disturb a running
 # instance, and the previous version is kept for rollback (re-run with
@@ -60,7 +65,8 @@ Examples:
 Linux layout (previous version kept for rollback):
   ~/.local/bin/neomacs -> ../share/neomacs/current/bin/neomacs
   ~/.local/share/neomacs/current -> versions/0.0.15
-  ~/.local/share/neomacs/versions/0.0.15/{bin/neomacs,bin/neomacs.pdump,lisp,etc,...}
+  ~/.local/share/neomacs/versions/0.0.15/bin/{neomacs,neomacs.pdump}
+  ~/.local/share/neomacs/versions/0.0.15/share/neomacs/{lisp,etc,...}
 
 Linux also ships AppImage/.deb/.rpm release assets, and macOS a .dmg, for
 those who prefer system packages:
@@ -216,18 +222,22 @@ say "-> downloading $asset"
 download "$asset_url" "$archive" || die "download failed: $asset_url"
 [ -s "$archive" ] || die "download produced an empty file: $asset_url"
 
-# Verify against the release checksum manifest when the release provides one
-# (releases before SHA256SUMS existed only warn).
+# Verify against the release checksum manifest. A published manifest that
+# does not list this asset is an error, not a skip; only releases that
+# predate SHA256SUMS entirely downgrade to a notice. The name comparison
+# tolerates the "./<asset>" form `sha256sum ./*` produces.
 sums=$(fetch "$release_base/$tag/SHA256SUMS" || true)
 if [ -n "$sums" ]; then
-  expected=$(printf '%s\n' "$sums" | awk -v f="$asset" '$2 == f {print $1}')
-  if [ -n "$expected" ]; then
-    actual=$(sha256_of "$archive") \
-      || die "neither sha256sum nor shasum is available to verify the download"
-    [ "$actual" = "$expected" ] \
-      || die "checksum mismatch for $asset (expected $expected, got $actual)"
-    say "-> checksum verified"
+  expected=$(printf '%s\n' "$sums" \
+    | awk -v f="$asset" '{ name = $2; sub(/^\.\//, "", name); if (name == f) print $1 }')
+  if [ -z "$expected" ]; then
+    die "release $tag publishes SHA256SUMS but it does not list $asset"
   fi
+  actual=$(sha256_of "$archive") \
+    || die "neither sha256sum nor shasum is available to verify the download"
+  [ "$actual" = "$expected" ] \
+    || die "checksum mismatch for $asset (expected $expected, got $actual)"
+  say "-> checksum verified"
 else
   say "note: release $tag publishes no SHA256SUMS; skipping checksum verification"
 fi
@@ -249,13 +259,14 @@ if [ "$os" = linux ]; then
     src_bin=$pkg_dir/bin
     src_data=$pkg_dir/share/neomacs
     [ -f "$src_bin/neomacs.pdump" ] || die "package is missing neomacs.pdump"
-    [ -d "$src_data/lisp" ] && [ -d "$src_data/etc" ] \
-      || die "package is missing the lisp/ or etc/ runtime tree"
+    [ -d "$src_data/lisp" ] || die "package is missing the lisp/ runtime tree"
+    [ -d "$src_data/etc" ] || die "package is missing the etc/ runtime tree"
   else
     src_bin=$pkg_dir
     [ -x "$pkg_dir/neomacs" ] || die "package is missing the neomacs binary"
     [ -f "$pkg_dir/neomacs.pdump" ] || die "package is missing neomacs.pdump"
     [ -d "$pkg_dir/lisp" ] || die "package is missing the lisp/ runtime tree"
+    [ -d "$pkg_dir/etc" ] || die "package is missing the etc/ runtime tree"
   fi
 
   [ -z "$prefix" ] && prefix=${HOME}/.local
@@ -264,13 +275,17 @@ if [ "$os" = linux ]; then
   ver_dir=$root/versions/$version
   staged=$root/versions/.staged.$version
 
-  mkdir -p "$staged/bin" "$bin_dir" \
+  # A crashed previous run may have left staging behind; start clean so no
+  # stale file can ride into the installed tree.
+  rm -rf "$staged"
+  mkdir -p "$staged/bin" "$staged/share/neomacs" "$bin_dir" \
     || die "cannot create directories under $prefix (writable?)"
 
   if [ -n "${src_data:-}" ]; then
-    # Canonical layout: runtime data is already gathered under share/neomacs
-    # (lisp, etc, leim, and anything added later); add the top-level docs.
-    cp -a "$src_data/." "$staged/" || die "could not stage the runtime tree"
+    # Canonical layout: the runtime tree is already gathered; take it as is
+    # and add the top-level docs.
+    cp -a "$src_data/." "$staged/share/neomacs/" \
+      || die "could not stage the runtime tree"
     for doc in COPYING VERSION README.md; do
       if [ -f "$pkg_dir/$doc" ]; then
         cp -a "$pkg_dir/$doc" "$staged/$doc" || die "could not stage $doc"
@@ -281,7 +296,7 @@ if [ "$os" = linux ]; then
     # data (lisp, etc, COPYING, and anything else the release carries).
     find "$pkg_dir" -mindepth 1 -maxdepth 1 \
       ! -name neomacs ! -name neomacsclient ! -name 'neomacs.pdump' \
-      ! -name 'neomacs-*.pdump' -exec cp -a {} "$staged/" \; \
+      ! -name 'neomacs-*.pdump' -exec cp -a {} "$staged/share/neomacs/" \; \
       || die "could not stage the runtime tree"
   fi
 
@@ -299,15 +314,29 @@ if [ "$os" = linux ]; then
   # Validate the staged tree before anything installed changes.
   [ -x "$staged/bin/neomacs" ] || die "staged tree lost the neomacs binary"
   [ -f "$staged/bin/neomacs.pdump" ] || die "staged tree lost neomacs.pdump"
-  [ -d "$staged/lisp" ] && [ -d "$staged/etc" ] \
-    || die "staged tree lost the lisp/ or etc/ runtime directories"
+  [ -d "$staged/share/neomacs/lisp" ] \
+    || die "staged tree lost the lisp/ runtime directory"
+  [ -d "$staged/share/neomacs/etc" ] \
+    || die "staged tree lost the etc/ runtime directory"
 
-  # Swap the version directory in whole (a rename), then flip `current' --
-  # a running instance keeps its old tree, and a crash between the two
-  # leaves the previous release active.
+  # Swap the version directory through a same-volume rename, then flip
+  # `current'. Installing over an tag that is already active first moves the
+  # existing directory aside, so a failure mid-swap leaves the old tree
+  # recoverable on disk rather than deleted, and a running instance is never
+  # pointing at a half-replaced tree (the smoke test below would also catch
+  # one).
   old_current=$(cat "$root/current-version" 2>/dev/null || true)
-  rm -rf "$ver_dir"
-  mv "$staged" "$ver_dir" || die "could not move the new version into place"
+  aside="$ver_dir.old.$$"
+  if [ -d "$ver_dir" ]; then
+    mv "$ver_dir" "$aside" || die "could not move the existing version aside"
+  fi
+  if ! mv "$staged" "$ver_dir"; then
+    if [ -d "$aside" ]; then
+      mv "$aside" "$ver_dir" || true
+    fi
+    die "could not move the new version into place"
+  fi
+  rm -rf "$aside"
   ln -sfn "versions/$version" "$root/current" \
     || die "could not update the current symlink"
   printf '%s\n' "$version" > "$root/current-version" \
@@ -383,8 +412,11 @@ fi
 # the runtime-root resolution is exercised exactly as a user launch would.
 if [ "$skip_smoke" = no ]; then
   say "-> verifying the installed binary starts"
-  env -u NEOMACS_RUNTIME_ROOT "$installed_bin" --batch --eval '(kill-emacs 0)' \
-    || die "installed neomacs failed to start; report this at https://github.com/$repo/issues (files are in place; see --skip-smoke to bypass)"
+  # Subshell + unset instead of `env -u`: strictly POSIX.
+  (
+    unset NEOMACS_RUNTIME_ROOT
+    exec "$installed_bin" --batch --eval '(kill-emacs 0)'
+  ) || die "installed neomacs failed to start. If the error names a missing shared library (libtinfo, libgst*), install your distribution's ncurses and GStreamer runtime packages and re-run; otherwise report it at https://github.com/$repo/issues (files are in place; --skip-smoke bypasses this check)"
 fi
 
 # ----------------------------------------------------------------- PATH ----

--- a/neovm-core/src/emacs_core/load.rs
+++ b/neovm-core/src/emacs_core/load.rs
@@ -3065,9 +3065,12 @@ fn is_runtime_root(path: &Path) -> bool {
 ///   `installation-directory/lisp`. GNU's signature is `lib-src` + `etc`;
 ///   ours is `lisp` + `etc` ([`is_runtime_root`]). This covers the release
 ///   tarball's flat layout (executable beside `lisp`/`etc`) and the
-///   versioned user install (`~/.local/share/neomacs/versions/<ver>/bin/`
-///   with `lisp`/`etc` siblings), reached through the
-///   `~/.local/bin/neomacs` symlink.
+///   direct-sibling versioned shape (`<root>/bin/neomacs` with
+///   `<root>/lisp`), reached through the `~/.local/bin/neomacs` symlink.
+///   install.sh stages the versioned tree as `<ver>/bin` +
+///   `<ver>/share/neomacs` so that resolver generations before this
+///   walk-up existed (v0.0.15 and earlier, which only probe
+///   `<grandparent>/share/neomacs`) locate it too.
 /// * The configured half is GNU's compile-time `PATH_LOADSEARCH`
 ///   (`<prefix>/share/emacs/<version>/lisp`); we probe instead of baking a
 ///   prefix at build time: `<grandparent>/share/neomacs` (deb/rpm/AppImage:

--- a/neovm-core/src/emacs_core/load.rs
+++ b/neovm-core/src/emacs_core/load.rs
@@ -3052,6 +3052,41 @@ fn is_runtime_root(path: &Path) -> bool {
     path.join("lisp").is_dir() && path.join("etc").is_dir()
 }
 
+/// Runtime-root candidates for a running executable, nearest first.
+///
+/// Ports GNU's dual layout support:
+///
+/// * The dynamic half is `init_cmdargs` (src/emacs.c): starting from the
+///   invocation directory -- following symlinks, which
+///   `current_exe().canonicalize()` does for us in one step -- Emacs checks
+///   the executable's own directory and then its parent for the tree
+///   signature, and records the hit as `installation-directory`;
+///   `load_path_default` (src/lread.c) then resets the load-path to
+///   `installation-directory/lisp`. GNU's signature is `lib-src` + `etc`;
+///   ours is `lisp` + `etc` ([`is_runtime_root`]). This covers the release
+///   tarball's flat layout (executable beside `lisp`/`etc`) and the
+///   versioned user install (`~/.local/share/neomacs/versions/<ver>/bin/`
+///   with `lisp`/`etc` siblings), reached through the
+///   `~/.local/bin/neomacs` symlink.
+/// * The configured half is GNU's compile-time `PATH_LOADSEARCH`
+///   (`<prefix>/share/emacs/<version>/lisp`); we probe instead of baking a
+///   prefix at build time: `<grandparent>/share/neomacs` (deb/rpm/AppImage:
+///   `<prefix>/bin/neomacs` + `<prefix>/share/neomacs`) and
+///   `<grandparent>/Resources/neomacs` (macOS app bundle:
+///   `Contents/MacOS/neomacs` + `Contents/Resources/neomacs`).
+fn runtime_root_candidates(exe: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::with_capacity(4);
+    if let Some(dir) = exe.parent() {
+        candidates.push(dir.to_path_buf());
+        if let Some(parent) = dir.parent() {
+            candidates.push(parent.to_path_buf());
+            candidates.push(parent.join("share/neomacs"));
+            candidates.push(parent.join("Resources/neomacs"));
+        }
+    }
+    candidates
+}
+
 fn runtime_project_root() -> PathBuf {
     if let Ok(root) = std::env::var(RUNTIME_ROOT_ENV) {
         let path = PathBuf::from(root);
@@ -3070,12 +3105,9 @@ fn runtime_project_root() -> PathBuf {
     }
 
     if let Ok(exe) = std::env::current_exe()
-        && let Some(prefix) = exe.parent().and_then(Path::parent)
+        && let Ok(resolved) = exe.canonicalize()
     {
-        for candidate in [
-            prefix.join("share/neomacs"),
-            prefix.join("Resources/neomacs"),
-        ] {
+        for candidate in runtime_root_candidates(&resolved) {
             if is_runtime_root(&candidate) {
                 return candidate;
             }

--- a/neovm-core/src/emacs_core/load_test.rs
+++ b/neovm-core/src/emacs_core/load_test.rs
@@ -15047,3 +15047,69 @@ fn runtime_loader_state_reset_matches_gnu_init_lread() {
     assert!(eval.loads_in_progress.is_empty());
     assert!(eval.require_stack.is_empty());
 }
+
+/// Each shipped layout must resolve to its own tree through
+/// `runtime_root_candidates` + `is_runtime_root`, nearest-first, mirroring
+/// GNU `init_cmdargs`' walk-up from the (symlink-resolved) executable.
+#[test]
+fn runtime_root_candidates_cover_every_shipped_layout() {
+    let make_tree = |root: &std::path::Path| {
+        fs::create_dir_all(root.join("lisp")).unwrap();
+        fs::create_dir_all(root.join("etc")).unwrap();
+    };
+
+    // Release tarball, flat: the executable sits beside lisp/ and etc/.
+    let flat = tempdir().unwrap();
+    make_tree(flat.path());
+    let exe = flat.path().join("neomacs");
+    let picked = runtime_root_candidates(&exe)
+        .into_iter()
+        .find(|c| is_runtime_root(c));
+    assert_eq!(picked.as_deref(), Some(flat.path()), "flat tarball layout");
+
+    // Versioned user install: ~/.local/bin/neomacs is a symlink into
+    // ~/.local/share/neomacs/versions/<ver>/bin/; the canonical executable's
+    // grandparent carries lisp/ and etc/.
+    let versioned = tempdir().unwrap();
+    let version = versioned.path().join("versions/0.0.15");
+    make_tree(&version);
+    fs::create_dir_all(version.join("bin")).unwrap();
+    let exe = version.join("bin/neomacs");
+    let picked = runtime_root_candidates(&exe)
+        .into_iter()
+        .find(|c| is_runtime_root(c));
+    assert_eq!(
+        picked.as_deref(),
+        Some(version.as_path()),
+        "versioned layout"
+    );
+
+    // Installed prefix (deb/rpm/AppImage): <prefix>/bin + <prefix>/share/neomacs.
+    let fhs = tempdir().unwrap();
+    fs::create_dir_all(fhs.path().join("bin")).unwrap();
+    make_tree(&fhs.path().join("share/neomacs"));
+    let exe = fhs.path().join("bin/neomacs");
+    let picked = runtime_root_candidates(&exe)
+        .into_iter()
+        .find(|c| is_runtime_root(c));
+    assert_eq!(
+        picked.as_deref(),
+        Some(fhs.path().join("share/neomacs").as_path()),
+        "installed share/neomacs layout"
+    );
+
+    // macOS app bundle: Contents/MacOS + Contents/Resources/neomacs.
+    let bundle = tempdir().unwrap();
+    let contents = bundle.path().join("neomacs.app/Contents");
+    fs::create_dir_all(contents.join("MacOS")).unwrap();
+    make_tree(&contents.join("Resources/neomacs"));
+    let exe = contents.join("MacOS/neomacs");
+    let picked = runtime_root_candidates(&exe)
+        .into_iter()
+        .find(|c| is_runtime_root(c));
+    assert_eq!(
+        picked.as_deref(),
+        Some(contents.join("Resources/neomacs").as_path()),
+        "app bundle Resources layout"
+    );
+}

--- a/neovm-core/src/emacs_core/regex_test.rs
+++ b/neovm-core/src/emacs_core/regex_test.rs
@@ -4190,6 +4190,7 @@ mod literal_search_linear_equivalence {
 /// many are ever read back by Lisp? Run explicitly:
 ///   cargo nextest run -p neovm-core -E 'test(match_publish_read_stats_probe)' --run-ignored all --no-capture
 #[test]
+#[cfg(debug_assertions)]
 #[ignore = "measurement probe, not a correctness test"]
 fn match_publish_read_stats_probe() {
     use std::sync::atomic::Ordering;

--- a/neovm-core/src/tagged/gc.rs
+++ b/neovm-core/src/tagged/gc.rs
@@ -12459,8 +12459,11 @@ mod ownership_tests {
     /// this failure". It is wired into `complete_collection` now, behind a
     /// gate. This is the pin that it RUNS and that a healthy heap reports zero
     /// problems: without the wiring the gate function does not exist and this
-    /// does not compile (DIVERGENCES.md 162).
+    /// does not compile (DIVERGENCES.md 162). The helpers are
+    /// debug-only, so the pin compiles in debug builds only — a release
+    /// test build must not see this function at all.
     #[test]
+    #[cfg(debug_assertions)]
     fn post_mark_ownership_verification_runs_and_finds_nothing() {
         crate::test_utils::init_test_tracing();
         let mut heap = TaggedHeap::new();


### PR DESCRIPTION
## What

One-line install for NEO Emacs:

```bash
curl -fsSL https://neomacs.org/install.sh | sh
```

neomacs.org serves a frozen ~20-line entry point (committed to
neomacs-org/neomacs-org as `public/install.sh`) that fetches the installer
published as a **release asset**, so the code that runs is always the
installer that shipped with the release it downloads. All install logic
lives in this repository.

## Linux layout (rustup-style, no root)

```
~/.local/bin/neomacs -> ../share/neomacs/current/bin/neomacs
~/.local/share/neomacs/current -> versions/0.0.15
~/.local/share/neomacs/versions/0.0.15/bin/{neomacs, neomacsclient, neomacs.pdump}
~/.local/share/neomacs/versions/0.0.15/share/neomacs/{lisp, etc, ...}
```

- Upgrades stage the version dir whole, swap it through a rename, then flip
  `current` — a running instance keeps its tree; the replaced version is
  kept as the rollback target (`install.sh --tag vX.Y.Z` rolls back); older
  versions are pruned.
- The version directory mirrors the release tarball's own `bin/` +
  `share/neomacs/` shape, which **every resolver generation locates** —
  including the v0.0.15 binaries (verified: the released 2026-08-09 binary
  batch-starts through the two-hop symlink chain with no environment
  variables).
- macOS installs the tarball's `neomacs.app` into `~/Applications` and
  links the CLI into `~/.local/bin`; Windows is pointed at the
  `-user-setup.exe`.
- SHA256 verification against the release's `SHA256SUMS` asset; a published
  manifest that doesn't list the asset is a hard error. POSIX sh,
  shellcheck-clean, no prompts, no sudo. `NEOMACS_DOWNLOAD_BASE` lets CI
  test against a `file://` staged release.

## Enabling resolver change

`runtime_project_root()` learns GNU's "running uninstalled" walk-up:
`init_cmdargs` (src/emacs.c) follows symlinks out of the invocation
directory and records the first ancestor carrying the build-tree
signature; `load_path_default` (src/lread.c) then uses
`installation-directory/lisp`. Ported by probing, nearest first: the
executable's own dir, its parent, then the existing
`<gp>/share/neomacs` / `<gp>/Resources/neomacs`. This also makes the
release tarball runnable in place with no environment variables.

## Release pipeline

- Linux tarballs are built by `scripts/package-release.sh` again — the
  inline flat staging this replaces was a regression against v0.0.15
  (flat trees only ran with `NEOMACS_RUNTIME_ROOT` set).
- The release publishes `install.sh` + `SHA256SUMS` as assets.
- New `verify-install-script` job (and a macOS step): after publish,
  install through the real asset URL and batch-start with no environment
  variables.
- ci.yml: workflow-lint runs shellcheck on install.sh; the shared test
  runtime job installs from a staged `file://` release built from the
  current commit, proving the whole chain pre-release.

## Also fixed here (found on the way)

- `cargo nextest --release` could not compile neovm-core's test harness —
  two tests call `debug_assertions`-only helpers without being gated. This
  is why the `workspace test archive` CI job was red on main.
- `deny.toml` did not allow the `eval-exec/freetype-sys` git source pinned
  by the release feature — the `cargo deny` CI job was red on main.

(Both of those jobs pass on this branch now. `cargo check workspace
(windows-msvc)` is expected to stay red with the pre-existing
`neomacs-font-materializer` i32/i64 errors that main also has.)

## Already live

`install.sh` and `SHA256SUMS` were backfilled onto the **v0.0.15** release
(checksums over all nine original assets), so the one-liner works against
the current latest release today — verified end-to-end from the
`releases/latest/download/install.sh` URL. The neomacs.org entry point is
pushed to the site repo and deploys with `npm run deploy`.

## Verification

- Resolver unit test covers all four shipped layouts — passes in
  `--release`.
- Against real GitHub releases: install → upgrade → rollback cycle keeps
  exactly current+previous; checksum verify passes and rejects corruption;
  prune removes versions older than the rollback target; the released
  v0.0.15 binary starts through the installed symlink chain with no
  environment variables.
- shellcheck 0.11.0 + `dash -n` + actionlint (with shellcheck) clean;
  Copilot review findings addressed (see thread replies).
