### PR TITLE
fix(font): preserve DirectWrite family names

### DIFF
--- a/neomacs-layout-engine/src/font_backend/direct_write.rs
+++ b/neomacs-layout-engine/src/font_backend/direct_write.rs
@@ -3,12 +3,15 @@ use super::{
     PlatformFontDesignMetrics, PlatformFontMatch, PlatformFontMetadata, TextDirection,
 };
 use dwrote::{
-    Font, FontCollection, FontFallback, FontStretch, FontStyle, FontWeight, InformationalStringId,
-    TextAnalysisSource, TextAnalysisSourceMethods,
+    Font, FontCollection, FontFallback, FontFamily, FontStretch, FontStyle, FontWeight,
+    InformationalStringId, TextAnalysisSource, TextAnalysisSourceMethods,
 };
 use neomacs_display_protocol::font::{FontBackendKind, FontVariationCoord};
 use neovm_core::face::{FontSlant, FontWidth};
 use std::borrow::Cow;
+use std::ptr;
+use winapi::shared::winerror::S_OK;
+use winapi::um::dwrite::IDWriteLocalizedStrings;
 
 /// DirectWrite adapter for native Windows matching and system fallback.
 pub struct DirectWriteBackend;
@@ -19,10 +22,16 @@ impl FontBackend for DirectWriteBackend {
     }
 
     fn list_families(&self) -> Vec<FontFamilyName> {
-        FontCollection::system()
+        let collection = FontCollection::system();
+        collection
             .families_iter()
-            .filter_map(|family| family.family_name().ok())
+            .flat_map(localized_family_names)
             .filter_map(FontFamilyName::new)
+            .filter(|name| {
+                collection
+                    .font_family_by_name(name.as_str())
+                    .is_ok_and(|family| family.is_some())
+            })
             .collect()
     }
 
@@ -159,6 +168,31 @@ fn native_fallback_candidate(query: &FontCandidateQuery) -> Option<FontCandidate
         )
         .mapped_font
         .and_then(font_candidate_from_font)
+}
+
+fn localized_family_names(family: FontFamily) -> Vec<String> {
+    let mut strings: *mut IDWriteLocalizedStrings = ptr::null_mut();
+    unsafe {
+        if (*family.as_ptr()).GetFamilyNames(&mut strings) != S_OK || strings.is_null() {
+            return Vec::new();
+        }
+
+        let mut names = Vec::new();
+        for index in 0..(*strings).GetCount() {
+            let mut length = 0;
+            if (*strings).GetStringLength(index, &mut length) != S_OK {
+                continue;
+            }
+            let mut buffer = vec![0; length as usize + 1];
+            if (*strings).GetString(index, buffer.as_mut_ptr(), length + 1) == S_OK
+                && let Ok(name) = String::from_utf16(&buffer[..length as usize])
+            {
+                names.push(name);
+            }
+        }
+        (*strings).Release();
+        names
+    }
 }
 
 fn font_candidate_from_font(font: Font) -> Option<FontCandidate> {

--- a/neomacs-layout-engine/tests/direct_write.rs
+++ b/neomacs-layout-engine/tests/direct_write.rs
@@ -1,0 +1,102 @@
+#![cfg(windows)]
+
+use dwrote::{FontCollection, FontFamily};
+use neomacs_layout_engine::font_backend::{DirectWriteBackend, FontBackend, FontFamilyName};
+use std::collections::HashSet;
+use std::ptr;
+use winapi::shared::winerror::S_OK;
+use winapi::um::dwrite::IDWriteLocalizedStrings;
+
+fn localized_family_names(family: FontFamily) -> Vec<String> {
+    let mut strings: *mut IDWriteLocalizedStrings = ptr::null_mut();
+    unsafe {
+        if (*family.as_ptr()).GetFamilyNames(&mut strings) != S_OK || strings.is_null() {
+            return Vec::new();
+        }
+
+        let mut names = Vec::new();
+        for index in 0..(*strings).GetCount() {
+            let mut length = 0;
+            if (*strings).GetStringLength(index, &mut length) != S_OK {
+                continue;
+            }
+            let mut buffer = vec![0; length as usize + 1];
+            if (*strings).GetString(index, buffer.as_mut_ptr(), length + 1) == S_OK
+                && let Ok(name) = String::from_utf16(&buffer[..length as usize])
+            {
+                names.push(name);
+            }
+        }
+        (*strings).Release();
+        names
+    }
+}
+
+#[test]
+fn list_families_includes_all_usable_directwrite_family_names() {
+    let listed = DirectWriteBackend
+        .list_families()
+        .into_iter()
+        .map(|family| family.into_string())
+        .collect::<HashSet<_>>();
+    let collection = FontCollection::system();
+    let missing = collection
+        .families_iter()
+        .flat_map(localized_family_names)
+        .filter_map(FontFamilyName::new)
+        .filter(|family| {
+            collection
+                .font_family_by_name(family.as_str())
+                .is_ok_and(|match_| match_.is_some())
+        })
+        .filter(|family| !listed.contains(family.as_str()))
+        .map(|family| family.into_string())
+        .collect::<Vec<_>>();
+
+    assert!(
+        missing.is_empty(),
+        "DirectWrite family list omitted usable localized names: {missing:?}"
+    );
+}
+
+#[test]
+fn listed_families_resolve_through_directwrite() {
+    let collection = FontCollection::system();
+    let unresolved = DirectWriteBackend
+        .list_families()
+        .into_iter()
+        .filter(|family| {
+            collection
+                .font_family_by_name(family.as_str())
+                .ok()
+                .flatten()
+                .is_none()
+        })
+        .map(|family| family.into_string())
+        .collect::<Vec<_>>();
+
+    assert!(
+        unresolved.is_empty(),
+        "DirectWrite family list contained unresolved names: {unresolved:?}"
+    );
+}
+
+#[test]
+fn list_families_includes_accepted_family_alias() {
+    const ALIAS: &str = "CaskaydiaCove NF";
+    let collection = FontCollection::system();
+    if collection
+        .font_family_by_name(ALIAS)
+        .ok()
+        .flatten()
+        .is_none()
+    {
+        return;
+    }
+
+    let families = DirectWriteBackend.list_families();
+    assert!(
+        families.iter().any(|family| family.as_str() == ALIAS),
+        "DirectWrite family list omitted {ALIAS}"
+    );
+}

--- a/neovm-core/src/emacs_core/display/font/mod.rs
+++ b/neovm-core/src/emacs_core/display/font/mod.rs
@@ -307,12 +307,15 @@ fn face_from_named_font_string(name: &str) -> Option<RuntimeFace> {
     if !trimmed.starts_with('-') {
         if let Some((family, size)) = trimmed.rsplit_once('-')
             && !family.trim().is_empty()
-            && size.chars().all(|ch| ch.is_ascii_digit())
-            && let Ok(points) = size.parse::<i32>()
-            && points > 0
+            && size.chars().all(|ch| ch.is_ascii_digit() || ch == '.')
+            && size.chars().filter(|&ch| ch == '.').count() <= 1
+            && let Ok(points) = size.parse::<f64>()
+            && points.is_finite()
+            && points > 0.0
+            && points <= f64::from(i32::MAX) / 10.0
         {
             face.family = Some(Value::string(family.trim().to_string()));
-            face.height = Some(FaceHeight::Absolute(points * 10));
+            face.height = Some(FaceHeight::Absolute((points * 10.0) as i32));
             return Some(face);
         }
         face.family = Some(Value::string(trimmed.to_string()));

--- a/neovm-core/src/emacs_core/display/font/tests/mod.rs
+++ b/neovm-core/src/emacs_core/display/font/tests/mod.rs
@@ -82,6 +82,17 @@ fn raw_context_does_not_prebind_x_color_aliases() {
 }
 
 #[test]
+fn named_font_string_parses_fractional_point_size() {
+    let face =
+        face_from_named_font_string("CaskaydiaCove NF-10.5").expect("font name should parse");
+    assert_eq!(
+        face.family.as_ref().and_then(|family| family.as_utf8_str()),
+        Some("CaskaydiaCove NF")
+    );
+    assert_eq!(face.height, Some(FaceHeight::Absolute(105)));
+}
+
+#[test]
 fn gnu_faces_el_defines_x_color_aliases() {
     crate::test_utils::init_test_tracing();
     let source = fs::read_to_string(


### PR DESCRIPTION
## Issue

On Windows, native font discovery returned only one locale-selected name from each DirectWrite family. Other names accepted by DirectWrite, including `CaskaydiaCove NF` and localized CJK family names, were omitted from `font-family-list`, causing configurations to reject installed fonts and fall back to another family.

Live named-font parsing also accepted only integer point-size suffixes. A request such as `CaskaydiaCove NF-10.5` was treated as one family name, leaving frame metrics and the rendered font out of sync.

## Solution

- Enumerate every localized name exposed by `IDWriteFontFamily::GetFamilyNames`.
- Keep only normalized names that round-trip through DirectWrite family lookup.
- Parse finite positive fractional point-size suffixes into the internal tenths-of-a-point face height.
- Add Windows regressions for localized-name completeness, lookup round-tripping, and the accepted Caskaydia alias.
- Add a core regression for fractional named-font parsing.

## Verification

- `cargo test -p neomacs-layout-engine --test direct_write -- --nocapture` passes (3 tests).
- `cargo test --manifest-path neovm-core/Cargo.toml --lib -q emacs_core::font::tests:: -- --nocapture` passes (66 tests).
- `cargo fmt --package neomacs-layout-engine --manifest-path Cargo.toml -- --check` passes.
- `cargo fmt --manifest-path neovm-core/Cargo.toml -- --check` passes.
- `git diff --check upstream/main...HEAD` passes.
- With the existing Windows init unchanged, the GUI resolves `CaskaydiaCove NF-10.5` to `C:\Windows\Fonts\CaskaydiaCoveNerdFont-Regular.ttf` at height 105, and the custom mode-line retains its intended two-column right margin.