### PR TITLE
fix(reader): process batch minibuffer input

### DIFF
--- a/neomacs-bin/tests/argv_parity.rs
+++ b/neomacs-bin/tests/argv_parity.rs
@@ -19,7 +19,10 @@
 
 mod common;
 
-use common::{ProbeResult, run_neomacs, run_oracle_emacs};
+use common::{
+    ProbeResult, oracle_enabled, run_neomacs, run_neomacs_with_stdin, run_oracle_emacs,
+    run_oracle_emacs_with_stdin,
+};
 
 fn assert_status_eq(neomacs: &ProbeResult, emacs: &ProbeResult, label: &str) {
     assert_eq!(
@@ -42,6 +45,28 @@ fn assert_stdout_parity(neomacs: &ProbeResult, emacs: &ProbeResult, label: &str)
 }
 
 // ---------- enabled today ----------
+
+#[test]
+fn batch_read_from_minibuffer_honors_read_and_default_with_stdin() {
+    let argv = [
+        "--quick",
+        "--batch",
+        "--eval",
+        "(prin1 (list (read-from-minibuffer \"\" nil nil t) \
+                      (read-from-minibuffer \"\" nil nil t nil \"42\") \
+                      (read-from-minibuffer \"\" nil nil nil)))",
+    ];
+    let stdin = "(a b)\n\nplain\n";
+    let n = run_neomacs_with_stdin(&argv, stdin);
+    assert_eq!(n.status, 0, "batch minibuffer read failed: {n:?}");
+    assert_eq!(n.stdout.trim(), "((a b) 42 \"plain\")", "{n:?}");
+
+    if oracle_enabled() {
+        let e = run_oracle_emacs_with_stdin(&argv, stdin);
+        assert_status_eq(&n, &e, "batch read-from-minibuffer exit");
+        assert_stdout_parity(&n, &e, "batch read-from-minibuffer result");
+    }
+}
 
 #[test]
 fn version_flag_exits_zero_and_prints_something() {

--- a/neomacs-bin/tests/common/mod.rs
+++ b/neomacs-bin/tests/common/mod.rs
@@ -15,9 +15,10 @@
 
 #![allow(dead_code)]
 
+use std::io::{ErrorKind, Write};
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 
 /// Captured outcome of running a binary with a specific argv.
 #[derive(Debug, Clone)]
@@ -138,30 +139,59 @@ fn apply_memory_limit(cmd: &mut Command) {
 /// Stdin is closed; stdout and stderr are captured. The subprocess is
 /// memory-limited via RLIMIT_AS the same way oracle Emacs is.
 pub fn run_neomacs(argv: &[&str]) -> ProbeResult {
+    run_neomacs_with_stdin(argv, "")
+}
+
+/// Spawn the under-test `neomacs` binary with text supplied on stdin.
+pub fn run_neomacs_with_stdin(argv: &[&str], stdin: &str) -> ProbeResult {
     let neomacs_bin = env!("CARGO_BIN_EXE_neomacs");
     let mut cmd = Command::new(neomacs_bin);
     cmd.args(argv);
     cmd.env("HOME", std::env::temp_dir());
     cmd.env_remove("NEOMACS_LOG_FILE");
     cmd.env_remove("NEOMACS_LOG_TO_FILE");
-    apply_memory_limit(&mut cmd);
-    let output = cmd
-        .output()
-        .unwrap_or_else(|e| panic!("failed to run neomacs: {e}"));
-    ProbeResult::from(output)
+    run_with_stdin(&mut cmd, stdin, "neomacs")
 }
 
 /// Spawn GNU oracle Emacs with the given argv. The caller is
 /// responsible for `--batch` (or equivalent) so the spawn cannot block
 /// on a tty.
 pub fn run_oracle_emacs(argv: &[&str]) -> ProbeResult {
+    run_oracle_emacs_with_stdin(argv, "")
+}
+
+/// Spawn GNU oracle Emacs with text supplied on stdin.
+pub fn run_oracle_emacs_with_stdin(argv: &[&str], stdin: &str) -> ProbeResult {
     let oracle = oracle_emacs_path();
     let mut cmd = Command::new(&oracle);
     cmd.args(argv);
     cmd.env("HOME", std::env::temp_dir());
-    apply_memory_limit(&mut cmd);
-    let output = cmd
-        .output()
-        .unwrap_or_else(|e| panic!("failed to run oracle emacs at {oracle}: {e}"));
+    run_with_stdin(&mut cmd, stdin, &format!("oracle emacs at {oracle}"))
+}
+
+fn run_with_stdin(cmd: &mut Command, stdin: &str, label: &str) -> ProbeResult {
+    apply_memory_limit(cmd);
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let mut child = cmd
+        .spawn()
+        .unwrap_or_else(|e| panic!("failed to run {label}: {e}"));
+    let mut child_stdin = child.stdin.take().expect("piped child stdin");
+    let input = stdin.as_bytes().to_vec();
+    let writer_label = label.to_string();
+    let stdin_writer = std::thread::spawn(move || {
+        if let Err(error) = child_stdin.write_all(&input)
+            && error.kind() != ErrorKind::BrokenPipe
+        {
+            panic!("failed to write stdin for {writer_label}: {error}");
+        }
+    });
+    let output = child
+        .wait_with_output()
+        .unwrap_or_else(|e| panic!("failed to wait for {label}: {e}"));
+    if let Err(payload) = stdin_writer.join() {
+        std::panic::resume_unwind(payload);
+    }
     ProbeResult::from(output)
 }

--- a/neovm-core/src/emacs_core/lisp/reader/mod.rs
+++ b/neovm-core/src/emacs_core/lisp/reader/mod.rs
@@ -1436,7 +1436,8 @@ pub fn builtin_read_impl(
 /// Read a string from the minibuffer.
 /// In interactive mode, sets up the minibuffer buffer, enters recursive-edit,
 /// and returns the user's input when they press RET (exit-minibuffer).
-/// In batch mode, signals `end-of-file`.
+/// In batch mode, reads one line from standard input and applies the same
+/// READ/DEFAULT result processing as an interactive minibuffer read.
 pub(crate) fn builtin_read_from_minibuffer(
     eval: &mut super::eval::Context,
     args: Vec<Value>,
@@ -1610,7 +1611,7 @@ fn finish_read_from_minibuffer_in_eval_with_setup(
 }
 
 pub(crate) fn builtin_read_from_minibuffer_in_runtime(
-    runtime: &impl KeyboardInputRuntime,
+    runtime: &mut super::eval::Context,
     args: &[Value],
 ) -> Result<Option<Value>, Flow> {
     expect_min_args("read-from-minibuffer", args, 1)?;
@@ -1622,10 +1623,15 @@ pub(crate) fn builtin_read_from_minibuffer_in_runtime(
 
     match runtime.minibuffer_input_source() {
         MinibufferInputSource::CommandLoop => Ok(None),
-        MinibufferInputSource::StandardInput => read_from_stdin_noninteractive(
-            &crate::emacs_core::emacs_char::to_utf8_lossy(prompt.as_bytes()),
-        )
-        .map(Some),
+        MinibufferInputSource::StandardInput => {
+            let result = read_from_stdin_noninteractive(
+                &crate::emacs_core::emacs_char::to_utf8_lossy(prompt.as_bytes()),
+            )?;
+            let result = expect_lisp_string(&result)?;
+            let read = args.get(3).copied().unwrap_or(Value::NIL);
+            let default = args.get(5).copied().unwrap_or(Value::NIL);
+            finish_minibuffer_result_after_unwind(runtime, result, read, default).map(Some)
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Batch callers such as `el-job-ng` send serialized Lisp objects to child Emacs processes over stdin with `read-from-minibuffer` and `READ` enabled. Neomacs' noninteractive path returned the raw line as a string and ignored both `READ` and `DEFAULT`, so workers later failed with type errors and exited with status 255.

## Solution

Pass batch stdin through the same result processing used by interactive minibuffer reads. Lisp forms are now parsed when requested, empty input uses the supplied default, and ordinary string reads retain their existing behavior.
