### PR TITLE
fix(font): interpret integer font-spec sizes as pixels

### DIFF
--- a/neomacs-bin/src/main.rs
+++ b/neomacs-bin/src/main.rs
@@ -156,7 +156,7 @@ use neovm_core::emacs_core::Value;
 use neovm_core::emacs_core::builtins::set_neomacs_monitor_info;
 use neovm_core::emacs_core::display::gui_window_system_symbol;
 use neovm_core::emacs_core::display_host::{
-    AvailableFontFamilyName, FontResolveRequest, XwidgetScriptRequestId,
+    AvailableFontFamilyName, FontResolveRequest, FrameFontRequest, XwidgetScriptRequestId,
 };
 #[cfg(feature = "neo-term")]
 use neovm_core::emacs_core::display_host::{
@@ -1763,26 +1763,43 @@ impl DisplayHost for PrimaryWindowDisplayHost {
 
     fn resolve_frame_font(
         &mut self,
-        _frame_id: FrameId,
-        face: neovm_core::face::Face,
+        frame_id: FrameId,
+        request: FrameFontRequest,
     ) -> Result<Option<ResolvedFrameFont>, String> {
+        // Every frame in this host shares one frontend/display connection.
+        // Its logical point policy is therefore shared just like GNU's
+        // display-level FRAME_RES; backing/device scale remains frame-local
+        // and is applied later by the renderer.
+        let font_sizing = self.font_sizing;
+        let face = request.face();
         let requested_family_storage = face.family_runtime_string_owned();
         let requested_family = requested_family_storage.as_deref().unwrap_or("Monospace");
         let requested_weight = face.weight.unwrap_or(FontWeight::NORMAL).css_weight();
         let requested_italic = face.slant.map(|slant| slant.is_italic()).unwrap_or(false);
-        let font_size = self.font_sizing.font_size_px_for_face(&face);
+        let Some(font_size) = font_sizing.font_size_px_for_request(request.size()) else {
+            return Ok(None);
+        };
         let selected = self.synchronized_font_metrics().select_font_for_char(
             'M',
             requested_family,
             requested_weight,
             requested_italic,
-            font_size,
+            font_size.get(),
         );
         let Some(font) = selected else {
             return Ok(None);
         };
+        let height_tenths =
+            font_sizing.face_height_tenths_for_layout_pixels(font.metrics.pixel_size.max(1));
+        tracing::debug!(
+            frame_id = frame_id.0,
+            requested_size = ?request.size(),
+            realized_pixel_size = font.metrics.pixel_size,
+            height_tenths,
+            "resolved frame-local font geometry"
+        );
         Ok(Some(ResolvedFrameFont {
-            height_tenths: font_height_tenths_for_face(&face),
+            height_tenths,
             font: core_opened_font_from_selection(font, font_otf_capability_for_file),
         }))
     }
@@ -2741,14 +2758,6 @@ fn gui_font_sizing() -> FontSizing {
     #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
     {
         FontSizing::native_gui()
-    }
-}
-
-fn font_height_tenths_for_face(face: &neovm_core::face::Face) -> i32 {
-    match &face.height {
-        Some(FaceHeight::Absolute(tenths)) => *tenths,
-        Some(FaceHeight::Relative(scale)) => (100.0 * *scale as f32).round().max(1.0) as i32,
-        None => 100,
     }
 }
 

--- a/neomacs-layout-engine/src/font/frame_metrics.rs
+++ b/neomacs-layout-engine/src/font/frame_metrics.rs
@@ -15,10 +15,10 @@ const DEFAULT_GRAPHIC_FONT_SIZE_PX: f32 = 13.0;
 /// frame-publication paths to accidentally treat the transient `0.0` "not
 /// realized yet" value as an opened font size.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) struct GraphicFontSizePx(f32);
+pub struct GraphicFontSizePx(f32);
 
 impl GraphicFontSizePx {
-    pub(crate) fn new(pixels: f32) -> Option<Self> {
+    pub fn new(pixels: f32) -> Option<Self> {
         (pixels.is_finite() && pixels > 0.0).then_some(Self(pixels))
     }
 
@@ -28,7 +28,7 @@ impl GraphicFontSizePx {
             .unwrap_or_default()
     }
 
-    pub(crate) fn get(self) -> f32 {
+    pub fn get(self) -> f32 {
         self.0
     }
 }

--- a/neomacs-layout-engine/src/font/sizing.rs
+++ b/neomacs-layout-engine/src/font/sizing.rs
@@ -5,8 +5,11 @@
 //! pixels. Keeping this module independent prevents X11 policy from leaking
 //! into the CoreText and DirectWrite catalogs.
 
+use neovm_core::emacs_core::display_host::FrameFontSize;
 use neovm_core::face::{Face, FaceHeight};
 use std::sync::OnceLock;
+
+pub use super::frame_metrics::GraphicFontSizePx;
 
 #[cfg(target_os = "linux")]
 use std::ffi::{CStr, CString};
@@ -17,7 +20,7 @@ use x11_dl::xlib;
 
 /// GNU uses the printer's point rather than the desktop-publishing 72 DPI
 /// point for its `POINT_TO_PIXEL` conversion (`src/font.h`).
-pub const GNU_POINTS_PER_INCH: f32 = 72.27;
+pub const GNU_POINTS_PER_INCH: f64 = 72.27;
 
 /// The logical-coordinate rule selected by the active display frontend.
 ///
@@ -44,7 +47,7 @@ pub enum LogicalFontScale {
 impl LogicalFontScale {
     fn layout_dpi(self) -> f32 {
         let dpi = match self {
-            Self::GnuCocoaPoint => GNU_POINTS_PER_INCH,
+            Self::GnuCocoaPoint => GNU_POINTS_PER_INCH as f32,
             Self::WindowsDip | Self::WaylandLogical => 96.0,
             Self::X11 { effective_dpi } | Self::ExplicitDpi(effective_dpi) => effective_dpi,
         };
@@ -120,10 +123,35 @@ impl FontSizing {
             None => default_font_size,
         }
     }
+
+    /// Convert a typed frame-font request to the logical pixel size consumed
+    /// by the native font selector. Pixel requests deliberately bypass DPI;
+    /// point and relative requests use this frame's frontend policy.
+    pub fn font_size_px_for_request(self, request: FrameFontSize) -> Option<GraphicFontSizePx> {
+        let pixels = match request {
+            FrameFontSize::Default => self.face_height_to_layout_pixels(100),
+            FrameFontSize::Pixels(pixels) => pixels.get() as f32,
+            FrameFontSize::Points(points) => {
+                points_to_layout_pixels(points.get() as f32, self.layout_dpi())
+            }
+            FrameFontSize::Relative(scale) => {
+                self.face_height_to_layout_pixels(100) * scale.get() as f32
+            }
+        };
+        GraphicFontSizePx::new(pixels)
+    }
+
+    /// GNU `PIXEL_TO_POINT(pixel_size * 10, FRAME_RES(frame))` for one
+    /// realized logical pixel size. This is the inverse representation stored
+    /// in a Lisp face's absolute `:height` slot.
+    pub fn face_height_tenths_for_layout_pixels(self, pixels: u32) -> i32 {
+        let tenths = f64::from(pixels) * 10.0 * GNU_POINTS_PER_INCH / f64::from(self.layout_dpi());
+        tenths.round().clamp(1.0, f64::from(i32::MAX)) as i32
+    }
 }
 
 pub fn points_to_layout_pixels(points: f32, dpi: f32) -> f32 {
-    (points * dpi / GNU_POINTS_PER_INCH).round()
+    (f64::from(points) * f64::from(dpi) / GNU_POINTS_PER_INCH).round() as f32
 }
 
 /// Compatibility helper for GNU X11 callers.

--- a/neomacs-layout-engine/src/font/sizing_test.rs
+++ b/neomacs-layout-engine/src/font/sizing_test.rs
@@ -1,4 +1,5 @@
 use super::{FontSizing, LogicalFontScale, points_to_layout_pixels};
+use neovm_core::emacs_core::display_host::FrameFontSize;
 
 #[test]
 fn cocoa_points_are_cocoa_logical_units() {
@@ -25,4 +26,81 @@ fn platform_point_rules_are_explicit_and_distinct() {
 #[test]
 fn point_conversion_uses_gnu_printer_points() {
     assert_eq!(points_to_layout_pixels(22.0, 100.0), 30.0);
+}
+
+#[test]
+fn pixel_font_requests_keep_the_same_logical_size_on_every_frontend() {
+    let requested = FrameFontSize::pixels(15).expect("positive pixel size");
+
+    for sizing in [
+        FontSizing::new(LogicalFontScale::GnuCocoaPoint),
+        FontSizing::new(LogicalFontScale::WindowsDip),
+        FontSizing::new(LogicalFontScale::WaylandLogical),
+        FontSizing::new(LogicalFontScale::X11 {
+            effective_dpi: 100.0,
+        }),
+    ] {
+        assert_eq!(
+            sizing
+                .font_size_px_for_request(requested)
+                .expect("pixel request remains representable")
+                .get(),
+            15.0
+        );
+    }
+}
+
+#[test]
+fn point_font_requests_follow_each_frontends_logical_dpi() {
+    let requested = FrameFontSize::points(15.0).expect("representable point size");
+
+    for (sizing, expected_pixels) in [
+        (FontSizing::new(LogicalFontScale::GnuCocoaPoint), 15.0),
+        (FontSizing::new(LogicalFontScale::WindowsDip), 20.0),
+        (FontSizing::new(LogicalFontScale::WaylandLogical), 20.0),
+        (
+            FontSizing::new(LogicalFontScale::X11 {
+                effective_dpi: 100.0,
+            }),
+            21.0,
+        ),
+    ] {
+        assert_eq!(
+            sizing
+                .font_size_px_for_request(requested)
+                .expect("point request remains representable")
+                .get(),
+            expected_pixels
+        );
+    }
+}
+
+#[test]
+fn request_conversion_rejects_zero_or_infinite_logical_pixels() {
+    let cocoa = FontSizing::new(LogicalFontScale::GnuCocoaPoint);
+    let subpixel_point = FrameFontSize::points(0.1).expect("representable point selector");
+    let overflowing_relative =
+        FrameFontSize::relative(1.0e300).expect("finite positive relative selector");
+
+    assert_eq!(cocoa.font_size_px_for_request(subpixel_point), None);
+    assert_eq!(cocoa.font_size_px_for_request(overflowing_relative), None);
+}
+
+#[test]
+fn realized_pixels_round_trip_through_frame_specific_face_heights() {
+    for (sizing, expected_height_tenths) in [
+        (FontSizing::new(LogicalFontScale::GnuCocoaPoint), 150),
+        (FontSizing::new(LogicalFontScale::WindowsDip), 113),
+        (FontSizing::new(LogicalFontScale::WaylandLogical), 113),
+        (
+            FontSizing::new(LogicalFontScale::X11 {
+                effective_dpi: 100.0,
+            }),
+            108,
+        ),
+    ] {
+        let height_tenths = sizing.face_height_tenths_for_layout_pixels(15);
+        assert_eq!(height_tenths, expected_height_tenths);
+        assert_eq!(sizing.face_height_to_layout_pixels(height_tenths), 15.0);
+    }
 }

--- a/neovm-core/src/emacs_core/display/display/mod.rs
+++ b/neovm-core/src/emacs_core/display/display/mod.rs
@@ -1106,11 +1106,17 @@ pub(crate) fn builtin_display_supports_face_attributes_p(
         )));
     };
     let default_font = host
-        .resolve_frame_font(frame_id, default_face)
+        .resolve_frame_font(
+            frame_id,
+            super::display_host::FrameFontRequest::from_face(default_face),
+        )
         .ok()
         .flatten();
     let requested_font = host
-        .resolve_frame_font(frame_id, requested_face)
+        .resolve_frame_font(
+            frame_id,
+            super::display_host::FrameFontRequest::from_face(requested_face),
+        )
         .ok()
         .flatten();
     let supported = match (default_font, requested_font) {

--- a/neovm-core/src/emacs_core/display/display/tests/mod.rs
+++ b/neovm-core/src/emacs_core/display/display/tests/mod.rs
@@ -47,8 +47,9 @@ impl DisplayHost for ItalicCapableDisplayHost {
     fn resolve_frame_font(
         &mut self,
         _frame_id: crate::window::FrameId,
-        face: crate::face::Face,
+        request: crate::emacs_core::display_host::FrameFontRequest,
     ) -> Result<Option<crate::emacs_core::eval::ResolvedFrameFont>, String> {
+        let face = request.face();
         let metrics = crate::emacs_core::eval::FontPxProbeResult {
             pixel_size: 14,
             height: 16,

--- a/neovm-core/src/emacs_core/display/display_host/display_host_test.rs
+++ b/neovm-core/src/emacs_core/display/display_host/display_host_test.rs
@@ -1,0 +1,41 @@
+use super::{FrameFontRequest, FrameFontSize};
+use crate::face::{Face, FaceHeight};
+
+#[test]
+fn frame_font_size_constructors_reject_invalid_lisp_numbers() {
+    assert_eq!(FrameFontSize::pixels(0), None);
+    assert_eq!(FrameFontSize::pixels(-1), None);
+    assert_eq!(FrameFontSize::points(0.0), None);
+    assert_eq!(FrameFontSize::points(f64::NAN), None);
+    assert_eq!(FrameFontSize::points(f64::INFINITY), None);
+    assert_eq!(FrameFontSize::relative(0.0), None);
+    assert_eq!(FrameFontSize::relative(f64::NAN), None);
+    assert_eq!(FrameFontSize::relative(f64::INFINITY), None);
+}
+
+#[test]
+fn frame_font_request_has_one_sizing_authority() {
+    let mut face = Face::new("default");
+    face.height = Some(FaceHeight::Absolute(150));
+
+    let request = FrameFontRequest::from_face(face);
+
+    assert_eq!(
+        request.size(),
+        FrameFontSize::points(15.0).expect("positive point size")
+    );
+    assert_eq!(request.face().height, None);
+
+    let mut face = Face::new("default");
+    face.height = Some(FaceHeight::Relative(2.0));
+    let request = FrameFontRequest::with_size(
+        face,
+        FrameFontSize::pixels(15).expect("positive pixel size"),
+    );
+
+    assert_eq!(request.face().height, None);
+    assert_eq!(
+        request.size(),
+        FrameFontSize::pixels(15).expect("positive pixel size")
+    );
+}

--- a/neovm-core/src/emacs_core/display/display_host/mod.rs
+++ b/neovm-core/src/emacs_core/display/display_host/mod.rs
@@ -14,7 +14,7 @@ use super::eval::{
     WebKitResolveRequest,
 };
 use crate::buffer::BufferId;
-use crate::face::Face as RuntimeFace;
+use crate::face::{Face as RuntimeFace, FaceHeight};
 use crate::heap_types::LispString;
 use crate::window::FrameFullscreen;
 use neomacs_display_protocol::WebViewId;
@@ -139,6 +139,95 @@ pub struct FontResolveRequest {
     pub faces: RealizedFaceFontContext,
 }
 
+/// A finite, positive scalar used by point-size and relative-size requests.
+///
+/// Lisp numbers are validated once when they cross the display-host seam, so
+/// native font adapters never need to recover from NaN, infinity, zero, or a
+/// negative size.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PositiveFontScalar(f64);
+
+impl PositiveFontScalar {
+    pub fn new(value: f64) -> Option<Self> {
+        (value.is_finite() && value > 0.0).then_some(Self(value))
+    }
+
+    pub const fn get(self) -> f64 {
+        self.0
+    }
+}
+
+/// The semantic size attached to a frame-font request.
+///
+/// GNU keeps integer font-spec sizes in pixels until font realization, while
+/// floating sizes are points. Keeping those units in the type prevents a
+/// frame-independent conversion from silently assuming one platform DPI.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FrameFontSize {
+    Default,
+    Pixels(NonZeroU32),
+    Points(PositiveFontScalar),
+    Relative(PositiveFontScalar),
+}
+
+impl FrameFontSize {
+    pub fn pixels(value: i64) -> Option<Self> {
+        u32::try_from(value)
+            .ok()
+            .and_then(NonZeroU32::new)
+            .map(Self::Pixels)
+    }
+
+    pub fn points(value: f64) -> Option<Self> {
+        let value = PositiveFontScalar::new(value)?;
+        ((1.0..=f64::from(i32::MAX)).contains(&(value.get() * 10.0))).then_some(Self::Points(value))
+    }
+
+    pub fn relative(value: f64) -> Option<Self> {
+        PositiveFontScalar::new(value).map(Self::Relative)
+    }
+
+    fn from_face_height(height: FaceHeight) -> Option<Self> {
+        match height {
+            FaceHeight::Absolute(tenths) => Self::points(f64::from(tenths) / 10.0),
+            FaceHeight::Relative(scale) => Self::relative(scale),
+        }
+    }
+}
+
+/// Typed request crossing from frame-local face state into native font
+/// selection. The embedded face carries style; `size` is its sole sizing
+/// authority and therefore cannot disagree with `Face::height`.
+#[derive(Clone, Debug)]
+pub struct FrameFontRequest {
+    face: RuntimeFace,
+    size: FrameFontSize,
+}
+
+impl FrameFontRequest {
+    pub fn from_face(mut face: RuntimeFace) -> Self {
+        let size = face
+            .height
+            .take()
+            .and_then(FrameFontSize::from_face_height)
+            .unwrap_or(FrameFontSize::Default);
+        Self { face, size }
+    }
+
+    pub fn with_size(mut face: RuntimeFace, size: FrameFontSize) -> Self {
+        face.height = None;
+        Self { face, size }
+    }
+
+    pub const fn face(&self) -> &RuntimeFace {
+        &self.face
+    }
+
+    pub const fn size(&self) -> FrameFontSize {
+        self.size
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TerminalFloatPlacement {
     x: f32,
@@ -253,7 +342,7 @@ pub trait DisplayHost {
     fn resolve_frame_font(
         &mut self,
         _frame_id: crate::window::FrameId,
-        _face: RuntimeFace,
+        _request: FrameFontRequest,
     ) -> Result<Option<ResolvedFrameFont>, String> {
         Ok(None)
     }
@@ -436,3 +525,7 @@ pub trait DisplayHost {
     /// recovery path can be exercised against a healthy device.
     fn debug_lose_device(&self) {}
 }
+
+#[cfg(test)]
+#[path = "display_host_test.rs"]
+mod tests;

--- a/neovm-core/src/emacs_core/display/font/mod.rs
+++ b/neovm-core/src/emacs_core/display/font/mod.rs
@@ -26,11 +26,12 @@ use strum::EnumString;
 use super::error::{EvalResult, Flow, signal};
 use super::xfaces::{
     FrameFaceInitial, clear_font_cache_state, derived_face_attrs_from_font_value,
-    ensure_frame_lisp_face_vector, font_spec_size_to_face_height, lookup_frame_lisp_face_vector,
+    ensure_frame_lisp_face_vector, lookup_frame_lisp_face_vector,
     realize_default_lisp_face_for_frame, runtime_face_from_lisp_face_vector,
     runtime_face_table_from_frame_lisp_faces, set_lisp_face_vector_attr,
 };
 
+use super::display_host::{FrameFontRequest, FrameFontSize};
 use super::intern::{intern, resolve_sym};
 use super::value::*;
 use crate::buffer::{Buffer, CharPos0, EmacsBytePos, LispCharPos1};
@@ -298,15 +299,7 @@ pub(crate) struct LiveFrameFontResolution {
     pub(crate) font_value: Value,
 }
 
-/// Convert point sizes to Emacs's integer tenths-of-a-point representation.
-/// Positive values below 0.1 points cannot be represented and are rejected.
-fn absolute_face_height_from_point_size(points: f64) -> Option<FaceHeight> {
-    let tenths = points * 10.0;
-    (tenths.is_finite() && (1.0..=f64::from(i32::MAX)).contains(&tenths))
-        .then(|| FaceHeight::Absolute(tenths as i32))
-}
-
-fn face_from_named_font_string(name: &str) -> Option<RuntimeFace> {
+fn frame_font_request_from_named_font_string(name: &str) -> Option<FrameFontRequest> {
     let trimmed = name.trim();
     if trimmed.is_empty() {
         return None;
@@ -320,14 +313,13 @@ fn face_from_named_font_string(name: &str) -> Option<RuntimeFace> {
             && size.chars().all(|ch| ch.is_ascii_digit() || ch == '.')
             && size.chars().filter(|&ch| ch == '.').count() <= 1
             && let Ok(points) = size.parse::<f64>()
-            && let Some(height) = absolute_face_height_from_point_size(points)
+            && let Some(size) = FrameFontSize::points(points)
         {
             face.family = Some(Value::string(family.trim().to_string()));
-            face.height = Some(height);
-            return Some(face);
+            return Some(FrameFontRequest::with_size(face, size));
         }
         face.family = Some(Value::string(trimmed.to_string()));
-        return Some(face);
+        return Some(FrameFontRequest::from_face(face));
     }
 
     let fields = trimmed.split('-').collect::<Vec<_>>();
@@ -363,25 +355,26 @@ fn face_from_named_font_string(name: &str) -> Option<RuntimeFace> {
         "normal" | "*" => Some(FontWidth::Normal),
         other => FontWidth::from_symbol(other),
     };
-    if pixel.chars().all(|ch| ch.is_ascii_digit())
-        && let Ok(size_px) = pixel.parse::<i32>()
-        && size_px > 0
-    {
-        face.height = Some(FaceHeight::Absolute(size_px * 10));
-    }
+    let size = pixel
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+        .then(|| pixel.parse::<i64>().ok())
+        .flatten()
+        .and_then(FrameFontSize::pixels)
+        .unwrap_or(FrameFontSize::Default);
 
-    Some(face)
+    Some(FrameFontRequest::with_size(face, size))
 }
 
-fn face_from_font_value(value: &Value) -> Option<RuntimeFace> {
+fn frame_font_request_from_value(value: &Value) -> Option<FrameFontRequest> {
     if let Some(text) = font_value_text(value) {
-        return face_from_named_font_string(&text);
+        return frame_font_request_from_named_font_string(&text);
     }
     if !is_font(value) {
         return None;
     }
 
-    let font_spec = is_font_spec(value);
+    let pixel_sized_selector = is_font_spec(value) || is_font_entity(value);
     let elems = font_value_fields(value)?;
     let mut face = RuntimeFace::new("default");
 
@@ -397,19 +390,23 @@ fn face_from_font_value(value: &Value) -> Option<RuntimeFace> {
         ValueKind::Symbol(id) => FontWidth::from_symbol(resolve_sym(id)),
         _ => None,
     });
-    face.height = if let Some(value) = font_vector_get_flexible(&elems, "height") {
-        face_height_from_value(value)
+    let size = if let Some(value) = font_vector_get_flexible(&elems, "height") {
+        face.height = face_height_from_value(value);
+        None
     } else if let Some(value) = font_vector_get_flexible(&elems, "size") {
-        if font_spec {
-            font_spec_size_to_face_height(value).and_then(face_height_from_value)
-        } else {
-            face_height_from_value(value)
+        match value.kind() {
+            ValueKind::Fixnum(px) if pixel_sized_selector => FrameFontSize::pixels(px),
+            ValueKind::Float => FrameFontSize::points(value.xfloat()),
+            _ => None,
         }
     } else {
         None
     };
 
-    Some(face)
+    Some(match size {
+        Some(size) => FrameFontRequest::with_size(face, size),
+        None => FrameFontRequest::from_face(face),
+    })
 }
 
 fn face_height_from_value(value: Value) -> Option<FaceHeight> {
@@ -436,11 +433,7 @@ fn build_frame_font_object_from_resolution(
     selected.weight = Some(FontWeight::from_css_weight(canonical.weight));
     selected.slant = Some(opened.slant);
     selected.width = Some(opened.width());
-    selected.height = match requested_face.height {
-        Some(FaceHeight::Absolute(height)) => Some(FaceHeight::Absolute(height)),
-        Some(FaceHeight::Relative(scale)) => Some(FaceHeight::Relative(scale)),
-        None => Some(FaceHeight::Absolute(resolved.height_tenths)),
-    };
+    selected.height = Some(FaceHeight::Absolute(resolved.height_tenths));
 
     finish_opened_font(
         font_object_property_fields(&selected, Some(i64::from(opened.metrics.pixel_size))),
@@ -484,6 +477,18 @@ fn resolve_live_frame_font_request_in_state(
     frame_id: FrameId,
     requested: &Value,
 ) -> LiveFrameFontResolution {
+    // GNU only opens a font when the target (or, for new-frame defaults, the
+    // selected reference frame) is graphical. A TTY frame retains the Lisp
+    // selector without manufacturing native metrics.
+    if frames
+        .get(frame_id)
+        .is_none_or(|frame| frame.effective_window_system().is_none())
+    {
+        return LiveFrameFontResolution {
+            font_value: *requested,
+        };
+    }
+
     if is_font_object(requested) {
         return LiveFrameFontResolution {
             font_value: *requested,
@@ -498,18 +503,16 @@ fn resolve_live_frame_font_request_in_state(
         return LiveFrameFontResolution { font_value };
     }
 
-    let Some(requested_face) = face_from_font_value(requested) else {
+    let Some(request) = frame_font_request_from_value(requested) else {
         return LiveFrameFontResolution {
             font_value: *requested,
         };
     };
+    let requested_face = request.face().clone();
 
     let realized = display_host
         .as_mut()
-        .and_then(|host| {
-            host.resolve_frame_font(frame_id, requested_face.clone())
-                .ok()
-        })
+        .and_then(|host| host.resolve_frame_font(frame_id, request).ok())
         .flatten();
     let font_value = realized
         .as_ref()
@@ -641,8 +644,11 @@ pub(crate) fn sync_live_default_face_font_state(
         .display_host
         .as_mut()
         .and_then(|host| {
-            host.resolve_frame_font(frame_id, requested_face.clone())
-                .ok()
+            host.resolve_frame_font(
+                frame_id,
+                FrameFontRequest::from_face(requested_face.clone()),
+            )
+            .ok()
         })
         .flatten();
     let Some(realized) = realized else {
@@ -679,27 +685,6 @@ pub(crate) fn frame_device_designator_p(value: &Value) -> bool {
         ValueKind::Fixnum(id) => id >= FRAME_ID_BASE as i64,
         ValueKind::Veclike(VecLikeType::Frame) => value.as_frame_id().unwrap() >= FRAME_ID_BASE,
         _ => false,
-    }
-}
-
-pub(crate) fn live_frame_id_for_face_update(
-    eval: &mut super::eval::Context,
-    frame: Option<&Value>,
-) -> Result<Option<FrameId>, Flow> {
-    match frame {
-        None => Ok(Some(super::window_cmds::ensure_selected_frame_id(eval))),
-        Some(v) if v.is_nil() || v.as_fixnum() == Some(0) => {
-            Ok(Some(super::window_cmds::ensure_selected_frame_id(eval)))
-        }
-        Some(v) if v.is_t() => Ok(None),
-        Some(value) if live_frame_designator_in_state(&eval.frames, value) => Ok(Some(
-            frame_id_from_designator(value)
-                .expect("live frame designator should decode to frame id"),
-        )),
-        Some(other) => Err(signal(
-            LispCondition::WrongTypeArgument,
-            vec![Value::symbol("frame-live-p"), *other],
-        )),
     }
 }
 
@@ -936,7 +921,7 @@ pub(crate) fn is_font_object(val: &Value) -> bool {
 }
 
 /// Check whether a value is represented as a font-entity vector.
-fn is_font_entity(val: &Value) -> bool {
+pub(crate) fn is_font_entity(val: &Value) -> bool {
     is_tagged_font_vector(val, FONT_ENTITY_TAG)
 }
 
@@ -2464,7 +2449,7 @@ pub(crate) fn resolve_current_buffer_remapped_default_face_font(
     let remapped_default = face_table.resolve_with_remapping("default", &remapping);
     eval.display_host
         .as_mut()?
-        .resolve_frame_font(frame_id, remapped_default)
+        .resolve_frame_font(frame_id, FrameFontRequest::from_face(remapped_default))
         .ok()
         .flatten()
 }

--- a/neovm-core/src/emacs_core/display/font/tests/mod.rs
+++ b/neovm-core/src/emacs_core/display/font/tests/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::buffer::{Buffer, CharPos0};
-use crate::emacs_core::display_host::{AvailableFontFamilyName, FontResolveRequest};
+use crate::emacs_core::display_host::{AvailableFontFamilyName, FontResolveRequest, FrameFontSize};
 use crate::emacs_core::eval::{
     Context, DisplayHost, FontOtfCapability, FontPxProbeResult, FontSpecResolveRequest,
     GuiFrameHostRequest, ResolvedFontMatch, ResolvedFontSpecMatch,
@@ -83,37 +83,50 @@ fn raw_context_does_not_prebind_x_color_aliases() {
 
 #[test]
 fn named_font_string_parses_fractional_point_size() {
-    let face =
-        face_from_named_font_string("CaskaydiaCove NF-10.5").expect("font name should parse");
+    let request = frame_font_request_from_named_font_string("CaskaydiaCove NF-10.5")
+        .expect("font name should parse");
     assert_eq!(
-        face.family.as_ref().and_then(|family| family.as_utf8_str()),
+        request
+            .face()
+            .family
+            .as_ref()
+            .and_then(|family| family.as_utf8_str()),
         Some("CaskaydiaCove NF")
     );
-    assert_eq!(face.height, Some(FaceHeight::Absolute(105)));
+    assert_eq!(
+        request.size(),
+        FrameFontSize::points(10.5).expect("representable point size")
+    );
 }
 
 #[test]
 fn named_font_string_requires_a_representable_positive_point_size() {
     let below_precision =
-        face_from_named_font_string("Example-0.01").expect("font name should parse");
+        frame_font_request_from_named_font_string("Example-0.01").expect("font name should parse");
     assert_eq!(
         below_precision
+            .face()
             .family
             .as_ref()
             .and_then(|family| family.as_utf8_str()),
         Some("Example-0.01")
     );
-    assert_eq!(below_precision.height, None);
+    assert_eq!(below_precision.size(), FrameFontSize::Default);
 
-    let minimum = face_from_named_font_string("Example-0.1").expect("font name should parse");
+    let minimum =
+        frame_font_request_from_named_font_string("Example-0.1").expect("font name should parse");
     assert_eq!(
         minimum
+            .face()
             .family
             .as_ref()
             .and_then(|family| family.as_utf8_str()),
         Some("Example")
     );
-    assert_eq!(minimum.height, Some(FaceHeight::Absolute(1)));
+    assert_eq!(
+        minimum.size(),
+        FrameFontSize::points(0.1).expect("minimum point size")
+    );
 }
 
 #[test]

--- a/neovm-core/src/emacs_core/display/window_cmds/tests/mod.rs
+++ b/neovm-core/src/emacs_core/display/window_cmds/tests/mod.rs
@@ -307,7 +307,7 @@ impl DisplayHost for RecordingDisplayHost {
     fn resolve_frame_font(
         &mut self,
         _frame_id: crate::window::FrameId,
-        _face: crate::face::Face,
+        _request: crate::emacs_core::display_host::FrameFontRequest,
     ) -> Result<Option<ResolvedFrameFont>, String> {
         Ok(self.resolved_frame_font.clone())
     }

--- a/neovm-core/src/emacs_core/display/xfaces/mod.rs
+++ b/neovm-core/src/emacs_core/display/xfaces/mod.rs
@@ -2437,7 +2437,13 @@ fn is_reset_like_face_attr_value(value: &Value) -> bool {
 pub(crate) fn font_spec_size_to_face_height(size: Value) -> Option<Value> {
     match size.kind() {
         ValueKind::Float if size.xfloat() > 0.0 => Some(Value::fixnum(10 * (size.xfloat() as i64))),
-        ValueKind::Fixnum(px) if px > 0 => Some(Value::fixnum(px * 10)),
+        // GNU font-spec integer sizes are pixels, while face heights are
+        // tenths of a point.  Convert at the 96 DPI logical coordinate space
+        // used by graphical faces; 72.27 is GNU's PT_PER_INCH.
+        ValueKind::Fixnum(px) if px > 0 => px
+            .checked_mul(7_227)?
+            .checked_add(480)
+            .map(|scaled| Value::fixnum(scaled / 960)),
         _ => None,
     }
 }

--- a/neovm-core/src/emacs_core/display/xfaces/mod.rs
+++ b/neovm-core/src/emacs_core/display/xfaces/mod.rs
@@ -346,8 +346,8 @@ use super::font::{
     default_face_font_attr_affects_frame_font, face_remapping_for_current_buffer,
     font_name_for_face, font_name_value, font_string_text, font_value_fields, font_value_text,
     font_vector_get_flexible, frame_device_designator_p, frame_id_from_designator,
-    frame_parameter_for_face_attribute, is_font, is_font_spec, live_frame_designator_in_state,
-    live_frame_font_attribute_fallback, live_frame_id_for_face_update,
+    frame_parameter_for_face_attribute, is_font, is_font_entity, is_font_spec,
+    live_frame_designator_in_state, live_frame_font_attribute_fallback,
     opened_font_from_resolved_match, publish_face_attribute_to_frame_parameter, resolve_font_match,
     resolve_live_frame_font_request, sync_live_default_face_font_state, sync_live_frame_font_state,
 };
@@ -2256,97 +2256,94 @@ fn ensure_frame_lisp_face_vector_by_symbol(
     Some(vector)
 }
 
-fn apply_lisp_face_vector_update_for_frame_arg(
-    eval: &mut super::eval::Context,
-    face_name: &str,
-    attr: LFaceAttr,
-    attr_value: Value,
-    font_derivation_value: Value,
-    frame_arg: Option<&Value>,
-) -> Result<(), Flow> {
-    match frame_arg {
-        Some(frame) if frame.is_t() => {
-            if let Some(vector) = ensure_global_lisp_face_vector(eval, face_name) {
-                set_lisp_face_vector_attr_with_font_derivatives(
-                    face_name,
-                    vector,
-                    attr,
-                    attr_value,
-                    font_derivation_value,
-                )?;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FontFaceRealizationTarget {
+    NewFrameDefaults { reference_frame: FrameId },
+    LiveFrame(FrameId),
+}
+
+impl FontFaceRealizationTarget {
+    const fn reference_frame(self) -> FrameId {
+        match self {
+            Self::NewFrameDefaults { reference_frame } | Self::LiveFrame(reference_frame) => {
+                reference_frame
             }
         }
+    }
+
+    const fn defaults_frame(self) -> bool {
+        matches!(self, Self::NewFrameDefaults { .. })
+    }
+}
+
+/// Mirror GNU's recursive `FRAME == 0` handling as an explicit target list.
+/// Each live frame retains its own realization because its display metrics may
+/// differ; new-frame defaults use the selected graphical frame as GNU does.
+fn font_face_realization_targets(
+    eval: &mut super::eval::Context,
+    frame_arg: Option<&Value>,
+) -> Vec<FontFaceRealizationTarget> {
+    let selected = super::window_cmds::ensure_selected_frame_id(eval);
+    match frame_arg {
+        Some(frame) if frame.is_t() => vec![FontFaceRealizationTarget::NewFrameDefaults {
+            reference_frame: selected,
+        }],
         Some(frame) if frame.as_fixnum() == Some(0) => {
-            if let Some(vector) = ensure_global_lisp_face_vector(eval, face_name) {
-                set_lisp_face_vector_attr_with_font_derivatives(
-                    face_name,
-                    vector,
-                    attr,
-                    attr_value,
-                    font_derivation_value,
-                )?;
+            let mut live_frames = eval.frames.frame_list();
+            if let Some(index) = live_frames
+                .iter()
+                .position(|frame_id| *frame_id == selected)
+            {
+                live_frames.swap(0, index);
             }
-            for frame_id in eval.frames.frame_list() {
-                if let Some(vector) = ensure_frame_lisp_face_vector(
-                    eval,
-                    frame_id,
-                    face_name,
-                    FrameFaceInitial::Empty,
-                ) {
-                    set_lisp_face_vector_attr_with_font_derivatives(
-                        face_name,
-                        vector,
-                        attr,
-                        attr_value,
-                        font_derivation_value,
-                    )?;
-                }
-            }
+            let mut targets = Vec::with_capacity(live_frames.len() + 1);
+            targets.push(FontFaceRealizationTarget::NewFrameDefaults {
+                reference_frame: selected,
+            });
+            targets.extend(
+                live_frames
+                    .into_iter()
+                    .map(FontFaceRealizationTarget::LiveFrame),
+            );
+            targets
         }
         Some(frame) if live_frame_designator_in_state(&eval.frames, frame) => {
             let frame_id =
                 frame_id_from_designator(frame).expect("live frame designator should decode");
-            if let Some(vector) =
-                ensure_frame_lisp_face_vector(eval, frame_id, face_name, FrameFaceInitial::Empty)
-            {
-                set_lisp_face_vector_attr_with_font_derivatives(
-                    face_name,
-                    vector,
-                    attr,
-                    attr_value,
-                    font_derivation_value,
-                )?;
-            }
+            vec![FontFaceRealizationTarget::LiveFrame(frame_id)]
         }
-        None => {
-            let frame_id = super::window_cmds::ensure_selected_frame_id(eval);
-            if let Some(vector) =
-                ensure_frame_lisp_face_vector(eval, frame_id, face_name, FrameFaceInitial::Empty)
-            {
-                set_lisp_face_vector_attr_with_font_derivatives(
-                    face_name,
-                    vector,
-                    attr,
-                    attr_value,
-                    font_derivation_value,
-                )?;
-            }
+        None | Some(_) => vec![FontFaceRealizationTarget::LiveFrame(selected)],
+    }
+}
+
+fn set_realized_font_for_target(
+    eval: &mut super::eval::Context,
+    target: FontFaceRealizationTarget,
+    face_symbol: Value,
+    face_name: &str,
+    font_value: Value,
+) -> Result<(), Flow> {
+    let vector = match target {
+        FontFaceRealizationTarget::NewFrameDefaults { .. } => {
+            ensure_global_lisp_face_vector(eval, face_name)
         }
-        Some(frame) if frame.is_nil() => {
-            let frame_id = super::window_cmds::ensure_selected_frame_id(eval);
-            if let Some(vector) =
-                ensure_frame_lisp_face_vector(eval, frame_id, face_name, FrameFaceInitial::Empty)
-            {
-                set_lisp_face_vector_attr_with_font_derivatives(
-                    face_name,
-                    vector,
-                    attr,
-                    attr_value,
-                    font_derivation_value,
-                )?;
-            }
+        FontFaceRealizationTarget::LiveFrame(frame_id) => {
+            let initial = if is_known_lisp_face_name(face_name) {
+                FrameFaceInitial::SelectedBase
+            } else {
+                FrameFaceInitial::Empty
+            };
+            ensure_frame_lisp_face_vector_by_symbol(eval, frame_id, face_symbol, face_name, initial)
         }
-        _ => {}
+    };
+    if let Some(vector) = vector {
+        set_lisp_face_vector_attr_with_font_derivatives(
+            face_name,
+            vector,
+            LFaceAttr::Font,
+            font_value,
+            font_value,
+        )?;
     }
     Ok(())
 }
@@ -2434,26 +2431,12 @@ fn is_reset_like_face_attr_value(value: &Value) -> bool {
     })
 }
 
-pub(crate) fn font_spec_size_to_face_height(size: Value) -> Option<Value> {
-    match size.kind() {
-        ValueKind::Float if size.xfloat() > 0.0 => Some(Value::fixnum(10 * (size.xfloat() as i64))),
-        // GNU font-spec integer sizes are pixels, while face heights are
-        // tenths of a point.  Convert at the 96 DPI logical coordinate space
-        // used by graphical faces; 72.27 is GNU's PT_PER_INCH.
-        ValueKind::Fixnum(px) if px > 0 => px
-            .checked_mul(7_227)?
-            .checked_add(480)
-            .map(|scaled| Value::fixnum(scaled / 960)),
-        _ => None,
-    }
-}
-
 pub(crate) fn derived_face_attrs_from_font_value(value: &Value) -> Vec<(LFaceAttr, Value)> {
     if !is_font(value) {
         return Vec::new();
     }
 
-    let font_spec = is_font_spec(value);
+    let unresolved_pixel_sized_font = is_font_spec(value) || is_font_entity(value);
     let Some(elems) = font_value_fields(value) else {
         return Vec::new();
     };
@@ -2483,12 +2466,17 @@ pub(crate) fn derived_face_attrs_from_font_value(value: &Value) -> Vec<(LFaceAtt
     if let Some(v) = font_vector_get_flexible(&elems, "height") {
         derived.push((LFaceAttr::Height, v));
     } else if let Some(v) = font_vector_get_flexible(&elems, "size") {
-        if font_spec {
-            if let Some(height) = font_spec_size_to_face_height(v) {
-                derived.push((LFaceAttr::Height, height));
+        match v.kind() {
+            // An integer selector size is still in pixels. It has no
+            // frame-independent face height; the opened font object supplies
+            // that after resolution against the target frame.
+            ValueKind::Fixnum(_) if unresolved_pixel_sized_font => {}
+            // GNU floating selector sizes are points. The xfaces path stores
+            // the whole-point value as tenths of a point.
+            ValueKind::Float if unresolved_pixel_sized_font && v.xfloat() > 0.0 => {
+                derived.push((LFaceAttr::Height, Value::fixnum(10 * (v.xfloat() as i64))));
             }
-        } else {
-            derived.push((LFaceAttr::Height, v));
+            _ => derived.push((LFaceAttr::Height, v)),
         }
     }
 
@@ -3243,56 +3231,68 @@ pub(crate) fn builtin_internal_set_lisp_face_attribute(
         if let Ok(attr_name) = normalize_set_face_attribute_name(&args[1]) {
             let (canonical_attr, canonical_value) =
                 normalize_face_attr_for_set_with_eval(Some(eval), &face_name, attr_name, value)?;
-            let live_frame_id = live_frame_id_for_face_update(eval, args.get(3))?;
-            let font_resolution = if canonical_attr == LFaceAttr::Font {
-                live_frame_id
-                    .map(|frame_id| resolve_live_frame_font_request(eval, frame_id, &value))
-            } else {
-                None
-            };
-            let effective_value = font_resolution
-                .as_ref()
-                .map_or(canonical_value, |resolution| resolution.font_value);
-            // GNU stores the opened font object in a live graphical lface.
-            // The original Lisp designator remains the frame's `font`
-            // parameter; collapsing these two representations here breaks
-            // consumers which require a realized font (notably startup font
-            // rescaling).
-            let public_effective_value = effective_value;
-
-            if canonical_attr == LFaceAttr::Font && effective_value != value {
-                set_face_override(&face_name, canonical_attr, public_effective_value, false);
-            }
+            let mut public_effective_value = canonical_value;
             if canonical_attr == LFaceAttr::Font {
-                apply_lisp_face_vector_update_for_frame_arg(
-                    eval,
-                    &face_name,
-                    canonical_attr,
-                    public_effective_value,
-                    effective_value,
-                    args.get(3),
-                )?;
-            }
+                let targets = font_face_realization_targets(eval, args.get(3));
+                let mut published_live_override = false;
+                for target in targets {
+                    let frame_id = target.reference_frame();
+                    let resolution = resolve_live_frame_font_request(eval, frame_id, &value);
+                    let effective_value = resolution.font_value;
+                    set_realized_font_for_target(
+                        eval,
+                        target,
+                        face_symbol,
+                        &face_name,
+                        effective_value,
+                    )?;
 
-            if canonical_attr == LFaceAttr::Font {
-                for (derived_attr, derived_value) in
-                    derived_face_attrs_from_font_value(&effective_value)
-                {
-                    set_face_override(&face_name, derived_attr, derived_value, false);
-                }
-            }
+                    // FACE_ATTR_STATE has one new-frame-default domain and one
+                    // live-frame compatibility domain. Publish the selected
+                    // frame first for FRAME=0; authoritative per-frame vectors
+                    // above retain every distinct opened object and height.
+                    let publish_override = target.defaults_frame() || !published_live_override;
+                    if publish_override {
+                        let defaults_frame = target.defaults_frame();
+                        if effective_value != value {
+                            set_face_override(
+                                &face_name,
+                                canonical_attr,
+                                effective_value,
+                                defaults_frame,
+                            );
+                        }
+                        for (derived_attr, derived_value) in
+                            derived_face_attrs_from_font_value(&effective_value)
+                        {
+                            set_face_override(
+                                &face_name,
+                                derived_attr,
+                                derived_value,
+                                defaults_frame,
+                            );
+                        }
+                        if !defaults_frame {
+                            published_live_override = true;
+                        }
+                        public_effective_value = effective_value;
+                    }
 
-            if canonical_attr == LFaceAttr::Font && face_name == "default" {
-                if let (Some(frame_id), Some(resolution)) =
-                    (live_frame_id, font_resolution.as_ref())
-                {
-                    sync_live_frame_font_state(eval, frame_id, &value, resolution);
+                    if face_name == "default"
+                        && let FontFaceRealizationTarget::LiveFrame(frame_id) = target
+                    {
+                        sync_live_frame_font_state(eval, frame_id, &value, &resolution);
+                    }
                 }
             } else if face_name == "default"
                 && default_face_font_attr_affects_frame_font(canonical_attr)
-                && let Some(frame_id) = live_frame_id
             {
-                sync_live_default_face_font_state(eval, frame_id);
+                // GNU handles FRAME=0 recursively, so each frame reopens the
+                // font against its own display metrics after a family, height,
+                // weight, slant, or width change.
+                for frame_id in changed_live_frames.iter().copied() {
+                    sync_live_default_face_font_state(eval, frame_id);
+                }
             }
 
             if let Some(parameter) = frame_parameter_for_face_attribute(&face_name, canonical_attr)
@@ -4695,3 +4695,7 @@ mod tests;
 #[cfg(test)]
 #[path = "tests/builtins.rs"]
 mod builtins_test;
+
+#[cfg(test)]
+#[path = "tests/font_size_test.rs"]
+mod font_size_test;

--- a/neovm-core/src/emacs_core/display/xfaces/tests/builtins.rs
+++ b/neovm-core/src/emacs_core/display/xfaces/tests/builtins.rs
@@ -1151,6 +1151,35 @@ fn internal_set_lisp_face_attribute_font_object_derives_font_related_attrs() {
 }
 
 #[test]
+fn internal_set_lisp_face_attribute_default_font_spec_integer_size_converts_pixels_to_points() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = Context::new();
+    let font_spec = font_spec(vec![
+        Value::keyword("family"),
+        Value::string("Monospace"),
+        Value::keyword("size"),
+        Value::fixnum(15),
+    ])
+    .expect("create font spec");
+
+    builtin_internal_set_lisp_face_attribute(
+        &mut eval,
+        vec![Value::symbol("default"), Value::keyword("font"), font_spec],
+    )
+    .expect("font-spec integer :size should be interpreted as pixels");
+
+    assert_eq!(
+        builtin_internal_get_lisp_face_attribute(
+            &mut eval,
+            vec![Value::symbol("default"), Value::keyword(":height"),]
+        )
+        .expect("default face height")
+        .as_int(),
+        Some(113)
+    );
+}
+
+#[test]
 fn internal_set_lisp_face_attribute_default_font_spec_float_size_derives_absolute_height() {
     crate::test_utils::init_test_tracing();
     let mut eval = Context::new();

--- a/neovm-core/src/emacs_core/display/xfaces/tests/builtins.rs
+++ b/neovm-core/src/emacs_core/display/xfaces/tests/builtins.rs
@@ -74,7 +74,7 @@ impl DisplayHost for LiveFrameFontDisplayHost {
     fn resolve_frame_font(
         &mut self,
         _frame_id: crate::window::FrameId,
-        _face: crate::face::Face,
+        _request: crate::emacs_core::display_host::FrameFontRequest,
     ) -> Result<Option<ResolvedFrameFont>, String> {
         Ok(self.realized.clone())
     }
@@ -1147,35 +1147,6 @@ fn internal_set_lisp_face_attribute_font_object_derives_font_related_attrs() {
         .unwrap()
         .as_int(),
         Some(102)
-    );
-}
-
-#[test]
-fn internal_set_lisp_face_attribute_default_font_spec_integer_size_converts_pixels_to_points() {
-    crate::test_utils::init_test_tracing();
-    let mut eval = Context::new();
-    let font_spec = font_spec(vec![
-        Value::keyword("family"),
-        Value::string("Monospace"),
-        Value::keyword("size"),
-        Value::fixnum(15),
-    ])
-    .expect("create font spec");
-
-    builtin_internal_set_lisp_face_attribute(
-        &mut eval,
-        vec![Value::symbol("default"), Value::keyword("font"), font_spec],
-    )
-    .expect("font-spec integer :size should be interpreted as pixels");
-
-    assert_eq!(
-        builtin_internal_get_lisp_face_attribute(
-            &mut eval,
-            vec![Value::symbol("default"), Value::keyword(":height"),]
-        )
-        .expect("default face height")
-        .as_int(),
-        Some(113)
     );
 }
 

--- a/neovm-core/src/emacs_core/display/xfaces/tests/font_size_test.rs
+++ b/neovm-core/src/emacs_core/display/xfaces/tests/font_size_test.rs
@@ -1,0 +1,242 @@
+use super::*;
+use crate::emacs_core::display_host::{FrameFontRequest, FrameFontSize};
+use crate::emacs_core::eval::{
+    Context, DisplayHost, FontPxProbeResult, GuiFrameHostRequest, ResolvedFrameFont,
+};
+use crate::emacs_core::font::font_spec;
+use crate::emacs_core::value::Value;
+use crate::face::{FontSlant, FontWeight, FontWidth};
+use crate::window::FrameId;
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+fn resolved_frame_font(height_tenths: i32) -> ResolvedFrameFont {
+    ResolvedFrameFont {
+        font: crate::emacs_core::eval::test_resolved_opened_font(
+            "Monospace",
+            None,
+            None,
+            FontWeight::NORMAL,
+            FontSlant::Normal,
+            FontWidth::Normal,
+            Some("Monospace-Regular"),
+            FontPxProbeResult {
+                pixel_size: 15,
+                height: 18,
+                ascent: 14,
+                descent: 4,
+                max_width: 9,
+                space_width: 8,
+                average_width: 8,
+            },
+            None,
+        ),
+        height_tenths,
+    }
+}
+
+struct CapturingFrameFontDisplayHost {
+    requested_size: Rc<Cell<FrameFontSize>>,
+    realized: ResolvedFrameFont,
+}
+
+struct FrameSpecificFontDisplayHost {
+    selected_frame: FrameId,
+    requests: Rc<RefCell<Vec<FrameId>>>,
+}
+
+impl DisplayHost for FrameSpecificFontDisplayHost {
+    fn realize_gui_frame(&mut self, _request: GuiFrameHostRequest) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn resize_gui_frame(&mut self, _request: GuiFrameHostRequest) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn resolve_frame_font(
+        &mut self,
+        frame_id: FrameId,
+        request: FrameFontRequest,
+    ) -> Result<Option<ResolvedFrameFont>, String> {
+        assert_eq!(
+            request.size(),
+            FrameFontSize::pixels(15).expect("positive pixel size")
+        );
+        self.requests.borrow_mut().push(frame_id);
+        let height_tenths = if frame_id == self.selected_frame {
+            // Cocoa-like logical coordinates.
+            150
+        } else {
+            // Windows/Wayland-like logical coordinates.
+            113
+        };
+        Ok(Some(resolved_frame_font(height_tenths)))
+    }
+}
+
+fn integer_font_spec() -> Value {
+    font_spec(vec![
+        Value::keyword("family"),
+        Value::string("Monospace"),
+        Value::keyword("size"),
+        Value::fixnum(15),
+    ])
+    .expect("create font spec")
+}
+
+impl DisplayHost for CapturingFrameFontDisplayHost {
+    fn realize_gui_frame(&mut self, _request: GuiFrameHostRequest) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn resize_gui_frame(&mut self, _request: GuiFrameHostRequest) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn resolve_frame_font(
+        &mut self,
+        _frame_id: FrameId,
+        request: FrameFontRequest,
+    ) -> Result<Option<ResolvedFrameFont>, String> {
+        self.requested_size.set(request.size());
+        Ok(Some(self.realized.clone()))
+    }
+}
+
+#[test]
+fn live_font_spec_keeps_integer_size_in_pixels_until_frame_realization() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = Context::new();
+    let frame_id = crate::emacs_core::window_cmds::ensure_selected_frame_id(&mut eval);
+    let frame = eval
+        .frame_manager_mut()
+        .get_mut(frame_id)
+        .expect("selected frame");
+    frame.set_window_system(Some(Value::symbol("neo")));
+
+    let requested_size = Rc::new(Cell::new(FrameFontSize::Default));
+    eval.set_display_host(Box::new(CapturingFrameFontDisplayHost {
+        requested_size: Rc::clone(&requested_size),
+        // The host models GNU Cocoa: 15 logical pixels are 150 tenths of a
+        // point at FRAME_RES == PT_PER_INCH.
+        realized: resolved_frame_font(150),
+    }));
+    let spec = integer_font_spec();
+
+    builtin_internal_set_lisp_face_attribute(
+        &mut eval,
+        vec![
+            Value::symbol("default"),
+            Value::keyword("font"),
+            spec,
+            Value::make_frame(frame_id.0),
+        ],
+    )
+    .expect("realize integer font-spec size");
+
+    assert_eq!(
+        requested_size.get(),
+        FrameFontSize::pixels(15).expect("positive pixel size")
+    );
+    assert_eq!(
+        builtin_internal_get_lisp_face_attribute(
+            &mut eval,
+            vec![
+                Value::symbol("default"),
+                Value::keyword(":height"),
+                Value::make_frame(frame_id.0),
+            ],
+        )
+        .expect("realized default face height")
+        .as_int(),
+        Some(150)
+    );
+}
+
+#[test]
+fn frame_zero_realizes_integer_font_size_for_each_live_frame() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = Context::new();
+    let selected_frame = crate::emacs_core::window_cmds::ensure_selected_frame_id(&mut eval);
+    let buffer_id = eval.buffers.current_buffer_id().expect("current buffer");
+    let other_frame = eval.frames.create_frame("other", 800, 600, buffer_id);
+    for frame_id in [selected_frame, other_frame] {
+        eval.frame_manager_mut()
+            .get_mut(frame_id)
+            .expect("live frame")
+            .set_window_system(Some(Value::symbol("neo")));
+    }
+
+    let requests = Rc::new(RefCell::new(Vec::new()));
+    eval.set_display_host(Box::new(FrameSpecificFontDisplayHost {
+        selected_frame,
+        requests: Rc::clone(&requests),
+    }));
+
+    builtin_internal_set_lisp_face_attribute(
+        &mut eval,
+        vec![
+            Value::symbol("default"),
+            Value::keyword("font"),
+            integer_font_spec(),
+            Value::fixnum(0),
+        ],
+    )
+    .expect("realize font on every frame");
+
+    for (frame_id, expected_height) in [(selected_frame, 150), (other_frame, 113)] {
+        assert_eq!(
+            builtin_internal_get_lisp_face_attribute(
+                &mut eval,
+                vec![
+                    Value::symbol("default"),
+                    Value::keyword(":height"),
+                    Value::make_frame(frame_id.0),
+                ],
+            )
+            .expect("frame-local default face height")
+            .as_int(),
+            Some(expected_height)
+        );
+    }
+    let requests = requests.borrow();
+    assert!(requests.contains(&selected_frame));
+    assert!(requests.contains(&other_frame));
+}
+
+#[test]
+fn frame_t_realizes_new_frame_defaults_against_selected_gui_frame() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = Context::new();
+    let selected_frame = crate::emacs_core::window_cmds::ensure_selected_frame_id(&mut eval);
+    eval.frame_manager_mut()
+        .get_mut(selected_frame)
+        .expect("selected frame")
+        .set_window_system(Some(Value::symbol("neo")));
+
+    let requests = Rc::new(RefCell::new(Vec::new()));
+    eval.set_display_host(Box::new(FrameSpecificFontDisplayHost {
+        selected_frame,
+        requests: Rc::clone(&requests),
+    }));
+
+    builtin_internal_set_lisp_face_attribute(
+        &mut eval,
+        vec![
+            Value::symbol("default"),
+            Value::keyword("font"),
+            integer_font_spec(),
+            Value::T,
+        ],
+    )
+    .expect("realize new-frame defaults");
+
+    let defaults = lookup_face_new_frame_defaults_vector(&eval, Value::symbol("default"))
+        .expect("new-frame default face vector");
+    assert_eq!(
+        lisp_face_vector_attr(defaults, LFaceAttr::Height).and_then(|height| height.as_int()),
+        Some(150)
+    );
+    assert_eq!(requests.borrow().as_slice(), &[selected_frame]);
+}

--- a/neovm-core/src/emacs_core/runtime/eval/mod.rs
+++ b/neovm-core/src/emacs_core/runtime/eval/mod.rs
@@ -23,8 +23,8 @@ use super::command_observation::{
 use super::custom::CustomManager;
 use super::debug_on_call::DebugOnCallCode;
 pub use super::display_host::{
-    DisplayHost, TerminalCreateRequest, TerminalDisplayTarget, TerminalFloatPlacement,
-    TerminalGridSize, TerminalId, XwidgetScriptRequestId,
+    DisplayHost, FrameFontRequest, FrameFontSize, TerminalCreateRequest, TerminalDisplayTarget,
+    TerminalFloatPlacement, TerminalGridSize, TerminalId, XwidgetScriptRequestId,
 };
 use super::error::*;
 use super::interactive::InteractiveRegistry;


### PR DESCRIPTION
## Problem

GNU Emacs interprets an integer `font-spec :size` as pixels, while Neomacs treated it as points. Configurations such as Doom's `:size 15` therefore rendered roughly one third larger in Neomacs.

## Solution

Convert integer font-spec sizes from pixels to face heights in tenths of a point at the graphical face coordinate space. Floating-point sizes continue to represent points.
