### PR TITLE
fix(renderer): recognize vertical glyph overhang

### DIFF
--- a/neomacs-renderer-wgpu/src/renderer/glyphs.rs
+++ b/neomacs-renderer-wgpu/src/renderer/glyphs.rs
@@ -33,50 +33,111 @@ const CHAR_OVERLAP_LOG_LIMIT: usize = 32;
 #[derive(Debug, Clone)]
 pub(super) struct RenderedCharBounds {
     pub(super) glyph_index: usize,
-    pub(super) window_id: i64,
     pub(super) row_role: GlyphRowRole,
     pub(super) slot_id: DisplaySlotId,
     pub(super) label: String,
     pub(super) face_id: FaceId,
     pub(super) font_size: f32,
-    pub(super) cell_x: f32,
-    pub(super) cell_y: f32,
-    pub(super) cell_w: f32,
-    pub(super) cell_h: f32,
-    pub(super) glyph_x: f32,
-    pub(super) glyph_y: f32,
-    pub(super) glyph_w: f32,
-    pub(super) glyph_h: f32,
-    pub(super) left_overhang: f32,
-    pub(super) right_overhang: f32,
-    pub(super) top_overhang: f32,
-    pub(super) bottom_overhang: f32,
+    pub(super) geometry: RenderedGlyphGeometry,
 }
 
-impl RenderedCharBounds {
-    fn right(&self) -> f32 {
-        self.glyph_x + self.glyph_w
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct RenderedGlyphGeometry {
+    /// The layout-owned advance cell.
+    cell: Rect,
+    /// The clipped bitmap rectangle actually submitted for rendering.
+    bitmap: Rect,
+}
+
+impl RenderedGlyphGeometry {
+    pub(super) const fn new(cell: Rect, bitmap: Rect) -> Self {
+        Self { cell, bitmap }
     }
 
-    fn bottom(&self) -> f32 {
-        self.glyph_y + self.glyph_h
+    #[cfg(test)]
+    pub(super) const fn cell(self) -> Rect {
+        self.cell
+    }
+
+    #[cfg(test)]
+    pub(super) const fn bitmap(self) -> Rect {
+        self.bitmap
+    }
+
+    pub(super) fn translated_y(mut self, dy: f32) -> Self {
+        self.cell.y += dy;
+        self.bitmap.y += dy;
+        self
+    }
+
+    fn overhang(self) -> GlyphOverhang {
+        GlyphOverhang {
+            left: (self.cell.x - self.bitmap.x).max(0.0),
+            right: (self.bitmap.right() - self.cell.right()).max(0.0),
+            top: (self.cell.y - self.bitmap.y).max(0.0),
+            bottom: (self.bitmap.bottom() - self.cell.bottom()).max(0.0),
+        }
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+struct GlyphOverhang {
+    left: f32,
+    right: f32,
+    top: f32,
+    bottom: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OverlapAxis {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct AxisSpan {
+    start: f32,
+    end: f32,
+}
+
+impl OverlapAxis {
+    fn project(self, rect: Rect) -> AxisSpan {
+        match self {
+            Self::Horizontal => AxisSpan {
+                start: rect.x,
+                end: rect.right(),
+            },
+            Self::Vertical => AxisSpan {
+                start: rect.y,
+                end: rect.bottom(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExpectedCharOverlap {
+    HorizontalOverhang,
+    VerticalOverhang,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CharOverlapClassification {
+    Expected(ExpectedCharOverlap),
+    Unexpected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
 struct CharOverlap {
-    x: f32,
-    y: f32,
-    width: f32,
-    height: f32,
-    expected_by_overhang: bool,
+    bounds: Rect,
+    classification: CharOverlapClassification,
 }
 
 fn char_overlap(a: &RenderedCharBounds, b: &RenderedCharBounds) -> Option<CharOverlap> {
-    let x0 = a.glyph_x.max(b.glyph_x);
-    let y0 = a.glyph_y.max(b.glyph_y);
-    let x1 = a.right().min(b.right());
-    let y1 = a.bottom().min(b.bottom());
+    let x0 = a.geometry.bitmap.x.max(b.geometry.bitmap.x);
+    let y0 = a.geometry.bitmap.y.max(b.geometry.bitmap.y);
+    let x1 = a.geometry.bitmap.right().min(b.geometry.bitmap.right());
+    let y1 = a.geometry.bitmap.bottom().min(b.geometry.bitmap.bottom());
     let width = x1 - x0;
     let height = y1 - y0;
     if width <= CHAR_OVERLAP_MIN_AXIS
@@ -85,123 +146,93 @@ fn char_overlap(a: &RenderedCharBounds, b: &RenderedCharBounds) -> Option<CharOv
     {
         return None;
     }
-    let expected_by_overhang = overlap_is_expected_by_overhang(a, b, x0, x1, y0, y1);
+    let bounds = Rect::new(x0, y0, width, height);
+    let classification = classify_char_overlap(a, b, bounds);
     Some(CharOverlap {
-        x: x0,
-        y: y0,
-        width,
-        height,
-        expected_by_overhang,
+        bounds,
+        classification,
     })
 }
 
-fn overlap_is_expected_by_overhang(
+fn classify_char_overlap(
     a: &RenderedCharBounds,
     b: &RenderedCharBounds,
-    overlap_left: f32,
-    overlap_right: f32,
-    overlap_top: f32,
-    overlap_bottom: f32,
-) -> bool {
-    let a_cell_right = a.cell_x + a.cell_w;
-    let b_cell_right = b.cell_x + b.cell_w;
-
-    let a_explains = a.right_overhang > 0.0
-        && overlap_left >= a_cell_right - CHAR_OVERLAP_MIN_AXIS
-        && overlap_right <= a.right() + CHAR_OVERLAP_MIN_AXIS;
-    let b_explains = b.left_overhang > 0.0
-        && overlap_right <= b.cell_x + CHAR_OVERLAP_MIN_AXIS
-        && overlap_left >= b.glyph_x - CHAR_OVERLAP_MIN_AXIS;
-
-    let b_right_explains = b.right_overhang > 0.0
-        && overlap_left >= b_cell_right - CHAR_OVERLAP_MIN_AXIS
-        && overlap_right <= b.right() + CHAR_OVERLAP_MIN_AXIS;
-    let a_left_explains = a.left_overhang > 0.0
-        && overlap_right <= a.cell_x + CHAR_OVERLAP_MIN_AXIS
-        && overlap_left >= a.glyph_x - CHAR_OVERLAP_MIN_AXIS;
-
-    let a_right_b_left_explain = a.right_overhang > 0.0
-        && b.left_overhang > 0.0
-        && (a_cell_right - b.cell_x).abs() <= CHAR_OVERLAP_MIN_AXIS
-        && overlap_left >= b.glyph_x - CHAR_OVERLAP_MIN_AXIS
-        && overlap_right <= a.right() + CHAR_OVERLAP_MIN_AXIS
-        && overlap_left <= a_cell_right + CHAR_OVERLAP_MIN_AXIS
-        && overlap_right >= a_cell_right - CHAR_OVERLAP_MIN_AXIS;
-    let b_right_a_left_explain = b.right_overhang > 0.0
-        && a.left_overhang > 0.0
-        && (b_cell_right - a.cell_x).abs() <= CHAR_OVERLAP_MIN_AXIS
-        && overlap_left >= a.glyph_x - CHAR_OVERLAP_MIN_AXIS
-        && overlap_right <= b.right() + CHAR_OVERLAP_MIN_AXIS
-        && overlap_left <= b_cell_right + CHAR_OVERLAP_MIN_AXIS
-        && overlap_right >= b_cell_right - CHAR_OVERLAP_MIN_AXIS;
-
-    let a_cell_bottom = a.cell_y + a.cell_h;
-    let b_cell_bottom = b.cell_y + b.cell_h;
-
-    let a_bottom_explains = a.bottom_overhang > 0.0
-        && overlap_top >= a_cell_bottom - CHAR_OVERLAP_MIN_AXIS
-        && overlap_bottom <= a.bottom() + CHAR_OVERLAP_MIN_AXIS;
-    let b_top_explains = b.top_overhang > 0.0
-        && overlap_bottom <= b.cell_y + CHAR_OVERLAP_MIN_AXIS
-        && overlap_top >= b.glyph_y - CHAR_OVERLAP_MIN_AXIS;
-
-    let b_bottom_explains = b.bottom_overhang > 0.0
-        && overlap_top >= b_cell_bottom - CHAR_OVERLAP_MIN_AXIS
-        && overlap_bottom <= b.bottom() + CHAR_OVERLAP_MIN_AXIS;
-    let a_top_explains = a.top_overhang > 0.0
-        && overlap_bottom <= a.cell_y + CHAR_OVERLAP_MIN_AXIS
-        && overlap_top >= a.glyph_y - CHAR_OVERLAP_MIN_AXIS;
-
-    let a_bottom_b_top_explain = a.bottom_overhang > 0.0
-        && b.top_overhang > 0.0
-        && (a_cell_bottom - b.cell_y).abs() <= CHAR_OVERLAP_MIN_AXIS
-        && overlap_top >= b.glyph_y - CHAR_OVERLAP_MIN_AXIS
-        && overlap_bottom <= a.bottom() + CHAR_OVERLAP_MIN_AXIS
-        && overlap_top <= a_cell_bottom + CHAR_OVERLAP_MIN_AXIS
-        && overlap_bottom >= a_cell_bottom - CHAR_OVERLAP_MIN_AXIS;
-    let b_bottom_a_top_explain = b.bottom_overhang > 0.0
-        && a.top_overhang > 0.0
-        && (b_cell_bottom - a.cell_y).abs() <= CHAR_OVERLAP_MIN_AXIS
-        && overlap_top >= a.glyph_y - CHAR_OVERLAP_MIN_AXIS
-        && overlap_bottom <= b.bottom() + CHAR_OVERLAP_MIN_AXIS
-        && overlap_top <= b_cell_bottom + CHAR_OVERLAP_MIN_AXIS
-        && overlap_bottom >= b_cell_bottom - CHAR_OVERLAP_MIN_AXIS;
-
-    // Adjacent cells in the same grid column may use deliberately intersecting
-    // bitmaps. Box-drawing corners are a common case: the corner reaches below
-    // its cell while the following vertical stroke reaches above its cell.
-    // Classify the actual bitmap intersection as overhang even when rasterizer
-    // rounding makes one of the independently calculated overhangs vanish.
-    let same_vertical_grid_run = a.window_id == b.window_id
-        && a.row_role == b.row_role
-        && a.slot_id.col == b.slot_id.col
-        && a.slot_id.row.abs_diff(b.slot_id.row) == 1;
-    let adjacent_cell_boundary = if (a_cell_bottom - b.cell_y).abs() <= CHAR_OVERLAP_MIN_AXIS {
-        Some(a_cell_bottom)
-    } else if (b_cell_bottom - a.cell_y).abs() <= CHAR_OVERLAP_MIN_AXIS {
-        Some(b_cell_bottom)
+    overlap: Rect,
+) -> CharOverlapClassification {
+    if overlap_is_expected_on_axis(a, b, overlap, OverlapAxis::Horizontal) {
+        CharOverlapClassification::Expected(ExpectedCharOverlap::HorizontalOverhang)
+    } else if overlap_is_expected_on_axis(a, b, overlap, OverlapAxis::Vertical) {
+        CharOverlapClassification::Expected(ExpectedCharOverlap::VerticalOverhang)
     } else {
-        None
-    };
-    let adjacent_vertical_overhang = same_vertical_grid_run
-        && adjacent_cell_boundary.is_some_and(|boundary| {
-            overlap_top <= boundary + CHAR_OVERLAP_MIN_AXIS
-                && overlap_bottom >= boundary - CHAR_OVERLAP_MIN_AXIS
-        });
+        CharOverlapClassification::Unexpected
+    }
+}
 
-    a_explains
-        || b_explains
-        || b_right_explains
-        || a_left_explains
-        || a_right_b_left_explain
-        || b_right_a_left_explain
-        || a_bottom_explains
-        || b_top_explains
-        || b_bottom_explains
-        || a_top_explains
-        || a_bottom_b_top_explain
-        || b_bottom_a_top_explain
-        || adjacent_vertical_overhang
+fn overlap_is_expected_on_axis(
+    a: &RenderedCharBounds,
+    b: &RenderedCharBounds,
+    overlap: Rect,
+    axis: OverlapAxis,
+) -> bool {
+    // Match GNU redisplay's ownership discipline: horizontal bearings belong
+    // to one glyph row, while vertical overlap belongs to adjacent rows. A
+    // geometric intersection alone must never erase that logical boundary.
+    let same_render_run = a.slot_id.window_id == b.slot_id.window_id && a.row_role == b.row_role;
+    let grid_neighbors = same_render_run
+        && match axis {
+            OverlapAxis::Horizontal => a.slot_id.row == b.slot_id.row,
+            OverlapAxis::Vertical => {
+                a.slot_id.col == b.slot_id.col && a.slot_id.row.abs_diff(b.slot_id.row) == 1
+            }
+        };
+    if !grid_neighbors {
+        return false;
+    }
+
+    let a_cell = axis.project(a.geometry.cell);
+    let b_cell = axis.project(b.geometry.cell);
+    let a_bitmap = axis.project(a.geometry.bitmap);
+    let b_bitmap = axis.project(b.geometry.bitmap);
+    let overlap = axis.project(overlap);
+    let (before_cell, before_bitmap, after_cell, after_bitmap) =
+        if a_cell.start.total_cmp(&b_cell.start).is_le() {
+            (a_cell, a_bitmap, b_cell, b_bitmap)
+        } else {
+            (b_cell, b_bitmap, a_cell, a_bitmap)
+        };
+
+    if !approx_eq(before_cell.end, after_cell.start, CHAR_OVERLAP_MIN_AXIS) {
+        return false;
+    }
+    let shared_cell_boundary = before_cell.end;
+    if axis == OverlapAxis::Vertical
+        && (overlap.start > shared_cell_boundary + CHAR_OVERLAP_MIN_AXIS
+            || overlap.end < shared_cell_boundary - CHAR_OVERLAP_MIN_AXIS)
+    {
+        return false;
+    }
+
+    // Overhang is derived from the two rectangles. Keeping it out of stored
+    // state makes a bitmap/cell pair with contradictory overhang impossible.
+    let before_extends_after_cell = before_bitmap.end > before_cell.end;
+    let after_extends_before_cell = after_bitmap.start < after_cell.start;
+    if !before_extends_after_cell && !after_extends_before_cell {
+        return false;
+    }
+
+    let expected_start = if after_extends_before_cell {
+        after_bitmap.start
+    } else {
+        before_cell.end
+    };
+    let expected_end = if before_extends_after_cell {
+        before_bitmap.end
+    } else {
+        after_cell.start
+    };
+
+    overlap.start >= expected_start - CHAR_OVERLAP_MIN_AXIS
+        && overlap.end <= expected_end + CHAR_OVERLAP_MIN_AXIS
 }
 
 pub(super) fn log_rendered_char_overlaps(
@@ -211,9 +242,11 @@ pub(super) fn log_rendered_char_overlaps(
 ) -> usize {
     let mut sorted: Vec<&RenderedCharBounds> = chars.iter().collect();
     sorted.sort_by(|a, b| {
-        a.glyph_x
-            .total_cmp(&b.glyph_x)
-            .then(a.glyph_y.total_cmp(&b.glyph_y))
+        a.geometry
+            .bitmap
+            .x
+            .total_cmp(&b.geometry.bitmap.x)
+            .then(a.geometry.bitmap.y.total_cmp(&b.geometry.bitmap.y))
             .then(a.glyph_index.cmp(&b.glyph_index))
     });
 
@@ -221,106 +254,112 @@ pub(super) fn log_rendered_char_overlaps(
     let mut overhang_total = 0usize;
     for (i, a) in sorted.iter().enumerate() {
         for b in sorted.iter().skip(i + 1) {
-            if b.glyph_x >= a.right() {
+            if b.geometry.bitmap.x >= a.geometry.bitmap.right() {
                 break;
             }
             let Some(overlap) = char_overlap(a, b) else {
                 continue;
             };
-            if overlap.expected_by_overhang {
-                overhang_total += 1;
-                tracing::debug!(
-                    "char_overhang frame_id={} pass={} overlap=({:.1},{:.1},{:.1}x{:.1}) \
+            match overlap.classification {
+                CharOverlapClassification::Expected(reason) => {
+                    overhang_total += 1;
+                    let a_overhang = a.geometry.overhang();
+                    let b_overhang = b.geometry.overhang();
+                    tracing::debug!(
+                        "char_overhang frame_id={} pass={} reason={:?} overlap=({:.1},{:.1},{:.1}x{:.1}) \
                      a[glyph={} label={:?} face={} cell=({:.1},{:.1},{:.1}x{:.1}) \
                      bitmap=({:.1},{:.1},{:.1}x{:.1}) overhang=({:.1},{:.1},{:.1},{:.1})] \
                      b[glyph={} label={:?} face={} cell=({:.1},{:.1},{:.1}x{:.1}) \
                      bitmap=({:.1},{:.1},{:.1}x{:.1}) overhang=({:.1},{:.1},{:.1},{:.1})]",
-                    frame_id,
-                    pass_name,
-                    overlap.x,
-                    overlap.y,
-                    overlap.width,
-                    overlap.height,
-                    a.glyph_index,
-                    a.label,
-                    a.face_id,
-                    a.cell_x,
-                    a.cell_y,
-                    a.cell_w,
-                    a.cell_h,
-                    a.glyph_x,
-                    a.glyph_y,
-                    a.glyph_w,
-                    a.glyph_h,
-                    a.left_overhang,
-                    a.right_overhang,
-                    a.top_overhang,
-                    a.bottom_overhang,
-                    b.glyph_index,
-                    b.label,
-                    b.face_id,
-                    b.cell_x,
-                    b.cell_y,
-                    b.cell_w,
-                    b.cell_h,
-                    b.glyph_x,
-                    b.glyph_y,
-                    b.glyph_w,
-                    b.glyph_h,
-                    b.left_overhang,
-                    b.right_overhang,
-                    b.top_overhang,
-                    b.bottom_overhang,
-                );
-                continue;
-            }
-            unexpected_total += 1;
-            if unexpected_total <= CHAR_OVERLAP_LOG_LIMIT {
-                tracing::error!(
-                    "char_overlap frame_id={} pass={} overlap=({:.1},{:.1},{:.1}x{:.1}) \
+                        frame_id,
+                        pass_name,
+                        reason,
+                        overlap.bounds.x,
+                        overlap.bounds.y,
+                        overlap.bounds.width,
+                        overlap.bounds.height,
+                        a.glyph_index,
+                        a.label,
+                        a.face_id,
+                        a.geometry.cell.x,
+                        a.geometry.cell.y,
+                        a.geometry.cell.width,
+                        a.geometry.cell.height,
+                        a.geometry.bitmap.x,
+                        a.geometry.bitmap.y,
+                        a.geometry.bitmap.width,
+                        a.geometry.bitmap.height,
+                        a_overhang.left,
+                        a_overhang.right,
+                        a_overhang.top,
+                        a_overhang.bottom,
+                        b.glyph_index,
+                        b.label,
+                        b.face_id,
+                        b.geometry.cell.x,
+                        b.geometry.cell.y,
+                        b.geometry.cell.width,
+                        b.geometry.cell.height,
+                        b.geometry.bitmap.x,
+                        b.geometry.bitmap.y,
+                        b.geometry.bitmap.width,
+                        b.geometry.bitmap.height,
+                        b_overhang.left,
+                        b_overhang.right,
+                        b_overhang.top,
+                        b_overhang.bottom,
+                    );
+                }
+                CharOverlapClassification::Unexpected => {
+                    unexpected_total += 1;
+                    if unexpected_total <= CHAR_OVERLAP_LOG_LIMIT {
+                        tracing::error!(
+                            "char_overlap frame_id={} pass={} overlap=({:.1},{:.1},{:.1}x{:.1}) \
                      a[glyph={} window={} role={:?} slot=({}, {}) label={:?} face={} font={:.1} \
                      cell=({:.1},{:.1},{:.1}x{:.1}) bitmap=({:.1},{:.1},{:.1}x{:.1})] \
                      b[glyph={} window={} role={:?} slot=({}, {}) label={:?} face={} font={:.1} \
                      cell=({:.1},{:.1},{:.1}x{:.1}) bitmap=({:.1},{:.1},{:.1}x{:.1})]",
-                    frame_id,
-                    pass_name,
-                    overlap.x,
-                    overlap.y,
-                    overlap.width,
-                    overlap.height,
-                    a.glyph_index,
-                    a.window_id,
-                    a.row_role,
-                    a.slot_id.row,
-                    a.slot_id.col,
-                    a.label,
-                    a.face_id,
-                    a.font_size,
-                    a.cell_x,
-                    a.cell_y,
-                    a.cell_w,
-                    a.cell_h,
-                    a.glyph_x,
-                    a.glyph_y,
-                    a.glyph_w,
-                    a.glyph_h,
-                    b.glyph_index,
-                    b.window_id,
-                    b.row_role,
-                    b.slot_id.row,
-                    b.slot_id.col,
-                    b.label,
-                    b.face_id,
-                    b.font_size,
-                    b.cell_x,
-                    b.cell_y,
-                    b.cell_w,
-                    b.cell_h,
-                    b.glyph_x,
-                    b.glyph_y,
-                    b.glyph_w,
-                    b.glyph_h,
-                );
+                            frame_id,
+                            pass_name,
+                            overlap.bounds.x,
+                            overlap.bounds.y,
+                            overlap.bounds.width,
+                            overlap.bounds.height,
+                            a.glyph_index,
+                            a.slot_id.window_id.get(),
+                            a.row_role,
+                            a.slot_id.row,
+                            a.slot_id.col,
+                            a.label,
+                            a.face_id,
+                            a.font_size,
+                            a.geometry.cell.x,
+                            a.geometry.cell.y,
+                            a.geometry.cell.width,
+                            a.geometry.cell.height,
+                            a.geometry.bitmap.x,
+                            a.geometry.bitmap.y,
+                            a.geometry.bitmap.width,
+                            a.geometry.bitmap.height,
+                            b.glyph_index,
+                            b.slot_id.window_id.get(),
+                            b.row_role,
+                            b.slot_id.row,
+                            b.slot_id.col,
+                            b.label,
+                            b.face_id,
+                            b.font_size,
+                            b.geometry.cell.x,
+                            b.geometry.cell.y,
+                            b.geometry.cell.width,
+                            b.geometry.cell.height,
+                            b.geometry.bitmap.x,
+                            b.geometry.bitmap.y,
+                            b.geometry.bitmap.width,
+                            b.geometry.bitmap.height,
+                        );
+                    }
+                }
             }
         }
     }
@@ -478,12 +517,7 @@ pub(super) fn log_cursor_glyph_alignment(
     let (cx, cy, cw, ch) = cursor_glyph_slot_rect(frame_glyphs, cursor);
     let tol = 1.0_f32;
     let cursor_rect = ResolvedCursorRect(Rect::new(cx, cy, cw, ch));
-    let cell_rect = GlyphCellRect(Rect::new(
-        glyph.cell_x,
-        glyph.cell_y,
-        glyph.cell_w,
-        glyph.cell_h,
-    ));
+    let cell_rect = GlyphCellRect(glyph.geometry.cell);
     let direction = CursorInlineDirection::from_bidi_level(
         frame_glyphs
             .slot_glyph(cursor.slot_id)
@@ -511,14 +545,14 @@ pub(super) fn log_cursor_glyph_alignment(
         cy,
         cw,
         ch,
-        glyph.cell_x,
-        glyph.cell_y,
-        glyph.cell_w,
-        glyph.cell_h,
-        glyph.glyph_x,
-        glyph.glyph_y,
-        glyph.glyph_w,
-        glyph.glyph_h,
+        glyph.geometry.cell.x,
+        glyph.geometry.cell.y,
+        glyph.geometry.cell.width,
+        glyph.geometry.cell.height,
+        glyph.geometry.bitmap.x,
+        glyph.geometry.bitmap.y,
+        glyph.geometry.bitmap.width,
+        glyph.geometry.bitmap.height,
         glyph.label,
         glyph.face_id,
         glyph.font_size,

--- a/neomacs-renderer-wgpu/src/renderer/glyphs.rs
+++ b/neomacs-renderer-wgpu/src/renderer/glyphs.rs
@@ -49,6 +49,8 @@ pub(super) struct RenderedCharBounds {
     pub(super) glyph_h: f32,
     pub(super) left_overhang: f32,
     pub(super) right_overhang: f32,
+    pub(super) top_overhang: f32,
+    pub(super) bottom_overhang: f32,
 }
 
 impl RenderedCharBounds {
@@ -83,7 +85,7 @@ fn char_overlap(a: &RenderedCharBounds, b: &RenderedCharBounds) -> Option<CharOv
     {
         return None;
     }
-    let expected_by_overhang = overlap_is_expected_by_overhang(a, b, x0, x1);
+    let expected_by_overhang = overlap_is_expected_by_overhang(a, b, x0, x1, y0, y1);
     Some(CharOverlap {
         x: x0,
         y: y0,
@@ -98,6 +100,8 @@ fn overlap_is_expected_by_overhang(
     b: &RenderedCharBounds,
     overlap_left: f32,
     overlap_right: f32,
+    overlap_top: f32,
+    overlap_bottom: f32,
 ) -> bool {
     let a_cell_right = a.cell_x + a.cell_w;
     let b_cell_right = b.cell_x + b.cell_w;
@@ -131,12 +135,73 @@ fn overlap_is_expected_by_overhang(
         && overlap_left <= b_cell_right + CHAR_OVERLAP_MIN_AXIS
         && overlap_right >= b_cell_right - CHAR_OVERLAP_MIN_AXIS;
 
+    let a_cell_bottom = a.cell_y + a.cell_h;
+    let b_cell_bottom = b.cell_y + b.cell_h;
+
+    let a_bottom_explains = a.bottom_overhang > 0.0
+        && overlap_top >= a_cell_bottom - CHAR_OVERLAP_MIN_AXIS
+        && overlap_bottom <= a.bottom() + CHAR_OVERLAP_MIN_AXIS;
+    let b_top_explains = b.top_overhang > 0.0
+        && overlap_bottom <= b.cell_y + CHAR_OVERLAP_MIN_AXIS
+        && overlap_top >= b.glyph_y - CHAR_OVERLAP_MIN_AXIS;
+
+    let b_bottom_explains = b.bottom_overhang > 0.0
+        && overlap_top >= b_cell_bottom - CHAR_OVERLAP_MIN_AXIS
+        && overlap_bottom <= b.bottom() + CHAR_OVERLAP_MIN_AXIS;
+    let a_top_explains = a.top_overhang > 0.0
+        && overlap_bottom <= a.cell_y + CHAR_OVERLAP_MIN_AXIS
+        && overlap_top >= a.glyph_y - CHAR_OVERLAP_MIN_AXIS;
+
+    let a_bottom_b_top_explain = a.bottom_overhang > 0.0
+        && b.top_overhang > 0.0
+        && (a_cell_bottom - b.cell_y).abs() <= CHAR_OVERLAP_MIN_AXIS
+        && overlap_top >= b.glyph_y - CHAR_OVERLAP_MIN_AXIS
+        && overlap_bottom <= a.bottom() + CHAR_OVERLAP_MIN_AXIS
+        && overlap_top <= a_cell_bottom + CHAR_OVERLAP_MIN_AXIS
+        && overlap_bottom >= a_cell_bottom - CHAR_OVERLAP_MIN_AXIS;
+    let b_bottom_a_top_explain = b.bottom_overhang > 0.0
+        && a.top_overhang > 0.0
+        && (b_cell_bottom - a.cell_y).abs() <= CHAR_OVERLAP_MIN_AXIS
+        && overlap_top >= a.glyph_y - CHAR_OVERLAP_MIN_AXIS
+        && overlap_bottom <= b.bottom() + CHAR_OVERLAP_MIN_AXIS
+        && overlap_top <= b_cell_bottom + CHAR_OVERLAP_MIN_AXIS
+        && overlap_bottom >= b_cell_bottom - CHAR_OVERLAP_MIN_AXIS;
+
+    // Adjacent cells in the same grid column may use deliberately intersecting
+    // bitmaps. Box-drawing corners are a common case: the corner reaches below
+    // its cell while the following vertical stroke reaches above its cell.
+    // Classify the actual bitmap intersection as overhang even when rasterizer
+    // rounding makes one of the independently calculated overhangs vanish.
+    let same_vertical_grid_run = a.window_id == b.window_id
+        && a.row_role == b.row_role
+        && a.slot_id.col == b.slot_id.col
+        && a.slot_id.row.abs_diff(b.slot_id.row) == 1;
+    let adjacent_cell_boundary = if (a_cell_bottom - b.cell_y).abs() <= CHAR_OVERLAP_MIN_AXIS {
+        Some(a_cell_bottom)
+    } else if (b_cell_bottom - a.cell_y).abs() <= CHAR_OVERLAP_MIN_AXIS {
+        Some(b_cell_bottom)
+    } else {
+        None
+    };
+    let adjacent_vertical_overhang = same_vertical_grid_run
+        && adjacent_cell_boundary.is_some_and(|boundary| {
+            overlap_top <= boundary + CHAR_OVERLAP_MIN_AXIS
+                && overlap_bottom >= boundary - CHAR_OVERLAP_MIN_AXIS
+        });
+
     a_explains
         || b_explains
         || b_right_explains
         || a_left_explains
         || a_right_b_left_explain
         || b_right_a_left_explain
+        || a_bottom_explains
+        || b_top_explains
+        || b_bottom_explains
+        || a_top_explains
+        || a_bottom_b_top_explain
+        || b_bottom_a_top_explain
+        || adjacent_vertical_overhang
 }
 
 pub(super) fn log_rendered_char_overlaps(
@@ -167,9 +232,9 @@ pub(super) fn log_rendered_char_overlaps(
                 tracing::debug!(
                     "char_overhang frame_id={} pass={} overlap=({:.1},{:.1},{:.1}x{:.1}) \
                      a[glyph={} label={:?} face={} cell=({:.1},{:.1},{:.1}x{:.1}) \
-                     bitmap=({:.1},{:.1},{:.1}x{:.1}) overhang=({:.1},{:.1})] \
+                     bitmap=({:.1},{:.1},{:.1}x{:.1}) overhang=({:.1},{:.1},{:.1},{:.1})] \
                      b[glyph={} label={:?} face={} cell=({:.1},{:.1},{:.1}x{:.1}) \
-                     bitmap=({:.1},{:.1},{:.1}x{:.1}) overhang=({:.1},{:.1})]",
+                     bitmap=({:.1},{:.1},{:.1}x{:.1}) overhang=({:.1},{:.1},{:.1},{:.1})]",
                     frame_id,
                     pass_name,
                     overlap.x,
@@ -189,6 +254,8 @@ pub(super) fn log_rendered_char_overlaps(
                     a.glyph_h,
                     a.left_overhang,
                     a.right_overhang,
+                    a.top_overhang,
+                    a.bottom_overhang,
                     b.glyph_index,
                     b.label,
                     b.face_id,
@@ -202,6 +269,8 @@ pub(super) fn log_rendered_char_overlaps(
                     b.glyph_h,
                     b.left_overhang,
                     b.right_overhang,
+                    b.top_overhang,
+                    b.bottom_overhang,
                 );
                 continue;
             }

--- a/neomacs-renderer-wgpu/src/renderer/glyphs_test.rs
+++ b/neomacs-renderer-wgpu/src/renderer/glyphs_test.rs
@@ -1,7 +1,8 @@
 use super::{
-    CursorCellAlignment, CursorCellContract, CursorInlineDirection, GlyphCellRect,
-    RenderedCharBounds, ResolvedCursorRect, char_overlap, cursor_cell_alignment,
-    cursor_glyph_slot_rect, frame_default_glyph_metrics, log_cursor_glyph_alignment,
+    CharOverlapClassification, CursorCellAlignment, CursorCellContract, CursorInlineDirection,
+    ExpectedCharOverlap, GlyphCellRect, RenderedCharBounds, RenderedGlyphGeometry,
+    ResolvedCursorRect, char_overlap, cursor_cell_alignment, cursor_glyph_slot_rect,
+    frame_default_glyph_metrics, log_cursor_glyph_alignment,
 };
 use neomacs_display_protocol::face::BoxVerticalEdges;
 use neomacs_display_protocol::frame_glyphs::{
@@ -576,24 +577,15 @@ fn vertical_bar_cursor_aligned_to_its_glyph_cell_is_not_a_mismatch() {
 
     let chars = [RenderedCharBounds {
         glyph_index: 0,
-        window_id: window_id.get(),
         row_role: GlyphRowRole::Text,
         slot_id,
         label: "葭".to_owned(),
         face_id: FaceId::new(25),
         font_size: 13.0,
-        cell_x: 233.0,
-        cell_y: 123.0,
-        cell_w: 13.0,
-        cell_h: 18.0,
-        glyph_x: 233.5,
-        glyph_y: 125.5,
-        glyph_w: 12.5,
-        glyph_h: 13.0,
-        left_overhang: 0.0,
-        right_overhang: 0.0,
-        top_overhang: 0.0,
-        bottom_overhang: 0.0,
+        geometry: RenderedGlyphGeometry::new(
+            Rect::new(233.0, 123.0, 13.0, 18.0),
+            Rect::new(233.5, 125.5, 12.5, 13.0),
+        ),
     }];
 
     log_cursor_glyph_alignment(4_294_967_296, "text", &frame, &chars);
@@ -765,7 +757,6 @@ fn frame_default_glyph_metrics_derive_line_height_from_font_size() {
 fn char_bounds(label: &str, x: f32, y: f32, width: f32, height: f32) -> RenderedCharBounds {
     RenderedCharBounds {
         glyph_index: 0,
-        window_id: 1,
         row_role: GlyphRowRole::Text,
         slot_id: DisplaySlotId {
             window_id: neomacs_display_protocol::types::DisplayWindowId::new(1),
@@ -775,19 +766,16 @@ fn char_bounds(label: &str, x: f32, y: f32, width: f32, height: f32) -> Rendered
         label: label.to_string(),
         face_id: FaceId::new(0),
         font_size: 14.0,
-        cell_x: x,
-        cell_y: y,
-        cell_w: width,
-        cell_h: height,
-        glyph_x: x,
-        glyph_y: y,
-        glyph_w: width,
-        glyph_h: height,
-        left_overhang: 0.0,
-        right_overhang: 0.0,
-        top_overhang: 0.0,
-        bottom_overhang: 0.0,
+        geometry: RenderedGlyphGeometry::new(
+            Rect::new(x, y, width, height),
+            Rect::new(x, y, width, height),
+        ),
     }
+}
+
+fn with_bitmap(mut bounds: RenderedCharBounds, bitmap: Rect) -> RenderedCharBounds {
+    bounds.geometry = RenderedGlyphGeometry::new(bounds.geometry.cell, bitmap);
+    bounds
 }
 
 #[test]
@@ -796,11 +784,11 @@ fn char_overlap_detects_intersecting_rendered_bitmaps() {
     let b = char_bounds("B", 9.0, 4.0, 10.0, 12.0);
 
     let overlap = char_overlap(&a, &b).expect("overlap");
-    assert_eq!(overlap.x, 9.0);
-    assert_eq!(overlap.y, 4.0);
-    assert_eq!(overlap.width, 1.0);
-    assert_eq!(overlap.height, 8.0);
-    assert!(!overlap.expected_by_overhang);
+    assert_eq!(overlap.bounds, Rect::new(9.0, 4.0, 1.0, 8.0));
+    assert_eq!(
+        overlap.classification,
+        CharOverlapClassification::Unexpected
+    );
 }
 
 #[test]
@@ -815,107 +803,189 @@ fn char_overlap_ignores_touching_edges_and_subpixel_noise() {
 
 #[test]
 fn char_overlap_classifies_font_overhang_separately() {
-    let mut f = char_bounds("f", 0.0, 0.0, 9.0, 12.0);
-    f.glyph_w = 11.0;
-    f.right_overhang = 2.0;
+    let f = with_bitmap(
+        char_bounds("f", 0.0, 0.0, 9.0, 12.0),
+        Rect::new(0.0, 0.0, 11.0, 12.0),
+    );
     let next = char_bounds("a", 9.0, 0.0, 12.0, 12.0);
 
     let overlap = char_overlap(&f, &next).expect("overhang overlap");
-    assert_eq!(overlap.x, 9.0);
-    assert_eq!(overlap.width, 2.0);
-    assert!(overlap.expected_by_overhang);
+    assert_eq!(overlap.bounds.x, 9.0);
+    assert_eq!(overlap.bounds.width, 2.0);
+    assert_eq!(
+        overlap.classification,
+        CharOverlapClassification::Expected(ExpectedCharOverlap::HorizontalOverhang)
+    );
+}
+
+#[test]
+fn char_overlap_horizontal_overhang_requires_one_logical_row() {
+    let first = with_bitmap(
+        char_bounds("f", 0.0, 0.0, 9.0, 12.0),
+        Rect::new(0.0, 0.0, 11.0, 12.0),
+    );
+    let next = char_bounds("a", 9.0, 0.0, 12.0, 12.0);
+    let mut other_window = next.clone();
+    other_window.slot_id.window_id = DisplayWindowId::new(2);
+    let mut other_role = next.clone();
+    other_role.row_role = GlyphRowRole::ModeLine;
+    let mut other_row = next;
+    other_row.slot_id.row = 1;
+
+    for (case, next) in [
+        ("different window", other_window),
+        ("different row role", other_role),
+        ("different row", other_row),
+    ] {
+        let overlap = char_overlap(&first, &next).expect("horizontal bitmap collision");
+        assert_eq!(
+            overlap.classification,
+            CharOverlapClassification::Unexpected,
+            "{case} must not suppress a genuine collision"
+        );
+    }
 }
 
 #[test]
 fn char_overlap_classifies_subpixel_boundary_overhang_separately() {
-    let mut slash = char_bounds("/", 775.8, 698.0, 14.0, 31.0);
-    slash.glyph_x = 776.0;
-    slash.glyph_y = 701.7;
-    slash.glyph_w = 14.3;
-    slash.glyph_h = 22.3;
-    slash.right_overhang = (slash.glyph_x + slash.glyph_w - (slash.cell_x + slash.cell_w)).max(0.0);
-
-    let mut m = char_bounds("m", 789.8, 698.0, 14.0, 31.0);
-    m.glyph_x = 789.7;
-    m.glyph_y = 708.0;
-    m.glyph_w = 13.7;
-    m.glyph_h = 13.7;
-    m.left_overhang = (m.cell_x - m.glyph_x).max(0.0);
+    let slash = with_bitmap(
+        char_bounds("/", 775.8, 698.0, 14.0, 31.0),
+        Rect::new(776.0, 701.7, 14.3, 22.3),
+    );
+    let m = with_bitmap(
+        char_bounds("m", 789.8, 698.0, 14.0, 31.0),
+        Rect::new(789.7, 708.0, 13.7, 13.7),
+    );
 
     let overlap = char_overlap(&slash, &m).expect("subpixel boundary overhang");
-    assert!(overlap.expected_by_overhang);
+    assert_eq!(
+        overlap.classification,
+        CharOverlapClassification::Expected(ExpectedCharOverlap::HorizontalOverhang)
+    );
 }
 
 #[test]
 fn char_overlap_classifies_adjacent_vertical_overhang_separately() {
-    let mut upper = char_bounds("│", 861.0, 76.0, 9.0, 19.0);
-    upper.glyph_x = 865.0;
-    upper.glyph_y = 75.0;
-    upper.glyph_w = 2.0;
-    upper.glyph_h = 23.0;
-    upper.top_overhang = 1.0;
-    upper.bottom_overhang = 3.0;
-
-    let mut lower = char_bounds("│", 861.0, 95.0, 9.0, 19.0);
-    lower.glyph_x = 865.0;
-    lower.glyph_y = 94.0;
-    lower.glyph_w = 2.0;
-    lower.glyph_h = 23.0;
-    lower.top_overhang = 1.0;
-    lower.bottom_overhang = 3.0;
+    let (upper, lower) = adjacent_vertical_overhang_bounds();
 
     let overlap = char_overlap(&upper, &lower).expect("vertical overhang overlap");
-    assert_eq!(overlap.y, 94.0);
-    assert_eq!(overlap.height, 4.0);
-    assert!(overlap.expected_by_overhang);
+    assert_eq!(overlap.bounds.y, 94.0);
+    assert_eq!(overlap.bounds.height, 4.0);
+    assert_eq!(
+        overlap.classification,
+        CharOverlapClassification::Expected(ExpectedCharOverlap::VerticalOverhang)
+    );
+}
+
+fn adjacent_vertical_overhang_bounds() -> (RenderedCharBounds, RenderedCharBounds) {
+    let mut upper = with_bitmap(
+        char_bounds("│", 861.0, 76.0, 9.0, 19.0),
+        Rect::new(865.0, 75.0, 2.0, 23.0),
+    );
+    upper.slot_id.row = 5;
+    upper.slot_id.col = 2;
+
+    let mut lower = with_bitmap(
+        char_bounds("│", 861.0, 95.0, 9.0, 19.0),
+        Rect::new(865.0, 94.0, 2.0, 23.0),
+    );
+    lower.slot_id.row = 6;
+    lower.slot_id.col = 2;
+    (upper, lower)
+}
+
+#[test]
+fn char_overlap_vertical_overhang_requires_one_logical_grid_run() {
+    let (upper, lower) = adjacent_vertical_overhang_bounds();
+    let mut other_window = lower.clone();
+    other_window.slot_id.window_id = DisplayWindowId::new(2);
+    let mut other_role = lower.clone();
+    other_role.row_role = GlyphRowRole::ModeLine;
+    let mut other_column = lower.clone();
+    other_column.slot_id.col = 3;
+    let mut nonadjacent_row = lower;
+    nonadjacent_row.slot_id.row = 7;
+
+    for (case, lower) in [
+        ("different window", other_window),
+        ("different row role", other_role),
+        ("different column", other_column),
+        ("nonadjacent row", nonadjacent_row),
+    ] {
+        let overlap = char_overlap(&upper, &lower).expect("vertical bitmap collision");
+        assert_eq!(
+            overlap.classification,
+            CharOverlapClassification::Unexpected,
+            "{case} must not suppress a genuine collision"
+        );
+    }
+}
+
+#[test]
+fn char_overlap_vertical_overhang_must_intersect_the_shared_row_boundary() {
+    let mut upper = with_bitmap(
+        char_bounds("upper", 0.0, 0.0, 10.0, 10.0),
+        Rect::new(4.0, 0.0, 2.0, 18.0),
+    );
+    upper.slot_id.row = 5;
+    upper.slot_id.col = 2;
+
+    let mut lower = with_bitmap(
+        char_bounds("lower", 0.0, 10.0, 10.0, 10.0),
+        Rect::new(4.0, 14.0, 2.0, 4.0),
+    );
+    lower.slot_id.row = 6;
+    lower.slot_id.col = 2;
+
+    let overlap = char_overlap(&upper, &lower).expect("deep vertical bitmap collision");
+    assert_eq!(overlap.bounds, Rect::new(4.0, 14.0, 2.0, 4.0));
+    assert_eq!(
+        overlap.classification,
+        CharOverlapClassification::Unexpected,
+        "vertical ink that collides away from the shared row boundary is not a joining overhang"
+    );
 }
 
 #[test]
 fn char_overlap_classifies_box_drawing_corner_join_separately() {
-    let mut corner = char_bounds("╮", 1734.0, 95.0, 9.0, 19.0);
+    let mut corner = with_bitmap(
+        char_bounds("╮", 1734.0, 95.0, 9.0, 19.0),
+        Rect::new(1733.0, 103.0, 7.0, 14.0),
+    );
     corner.slot_id.row = 5;
     corner.slot_id.col = 2;
-    corner.glyph_x = 1733.0;
-    corner.glyph_y = 103.0;
-    corner.glyph_w = 7.0;
-    corner.glyph_h = 14.0;
-    corner.left_overhang = 1.0;
 
-    let mut stem = char_bounds("│", 1734.0, 114.0, 9.0, 19.0);
+    let mut stem = with_bitmap(
+        char_bounds("│", 1734.0, 114.0, 9.0, 19.0),
+        Rect::new(1738.0, 113.0, 2.0, 23.0),
+    );
     stem.slot_id.row = 6;
     stem.slot_id.col = 2;
-    stem.glyph_x = 1738.0;
-    stem.glyph_y = 113.0;
-    stem.glyph_w = 2.0;
-    stem.glyph_h = 23.0;
 
     let overlap = char_overlap(&corner, &stem).expect("box-drawing join overlap");
-    assert_eq!(overlap.x, 1738.0);
-    assert_eq!(overlap.y, 113.0);
-    assert_eq!(overlap.width, 2.0);
-    assert_eq!(overlap.height, 4.0);
-    assert!(overlap.expected_by_overhang);
+    assert_eq!(overlap.bounds, Rect::new(1738.0, 113.0, 2.0, 4.0));
+    assert_eq!(
+        overlap.classification,
+        CharOverlapClassification::Expected(ExpectedCharOverlap::VerticalOverhang)
+    );
 }
 
 #[test]
 fn char_overlap_classifies_adjacent_dual_bearing_overhang_separately() {
-    let mut w = char_bounds("w", 888.0, 384.0, 16.0, 33.0);
-    w.glyph_x = 889.0;
-    w.glyph_y = 395.0;
-    w.glyph_w = 17.0;
-    w.glyph_h = 15.0;
-    w.right_overhang = 2.0;
-
-    let mut x = char_bounds("x", 904.0, 384.0, 16.0, 33.0);
-    x.glyph_x = 903.0;
-    x.glyph_y = 395.0;
-    x.glyph_w = 18.0;
-    x.glyph_h = 15.0;
-    x.left_overhang = 1.0;
-    x.right_overhang = 1.0;
+    let w = with_bitmap(
+        char_bounds("w", 888.0, 384.0, 16.0, 33.0),
+        Rect::new(889.0, 395.0, 17.0, 15.0),
+    );
+    let x = with_bitmap(
+        char_bounds("x", 904.0, 384.0, 16.0, 33.0),
+        Rect::new(903.0, 395.0, 18.0, 15.0),
+    );
 
     let overlap = char_overlap(&w, &x).expect("dual-bearing overhang overlap");
-    assert_eq!(overlap.x, 903.0);
-    assert_eq!(overlap.width, 3.0);
-    assert!(overlap.expected_by_overhang);
+    assert_eq!(overlap.bounds.x, 903.0);
+    assert_eq!(overlap.bounds.width, 3.0);
+    assert_eq!(
+        overlap.classification,
+        CharOverlapClassification::Expected(ExpectedCharOverlap::HorizontalOverhang)
+    );
 }

--- a/neomacs-renderer-wgpu/src/renderer/glyphs_test.rs
+++ b/neomacs-renderer-wgpu/src/renderer/glyphs_test.rs
@@ -592,6 +592,8 @@ fn vertical_bar_cursor_aligned_to_its_glyph_cell_is_not_a_mismatch() {
         glyph_h: 13.0,
         left_overhang: 0.0,
         right_overhang: 0.0,
+        top_overhang: 0.0,
+        bottom_overhang: 0.0,
     }];
 
     log_cursor_glyph_alignment(4_294_967_296, "text", &frame, &chars);
@@ -783,6 +785,8 @@ fn char_bounds(label: &str, x: f32, y: f32, width: f32, height: f32) -> Rendered
         glyph_h: height,
         left_overhang: 0.0,
         right_overhang: 0.0,
+        top_overhang: 0.0,
+        bottom_overhang: 0.0,
     }
 }
 
@@ -839,6 +843,57 @@ fn char_overlap_classifies_subpixel_boundary_overhang_separately() {
     m.left_overhang = (m.cell_x - m.glyph_x).max(0.0);
 
     let overlap = char_overlap(&slash, &m).expect("subpixel boundary overhang");
+    assert!(overlap.expected_by_overhang);
+}
+
+#[test]
+fn char_overlap_classifies_adjacent_vertical_overhang_separately() {
+    let mut upper = char_bounds("│", 861.0, 76.0, 9.0, 19.0);
+    upper.glyph_x = 865.0;
+    upper.glyph_y = 75.0;
+    upper.glyph_w = 2.0;
+    upper.glyph_h = 23.0;
+    upper.top_overhang = 1.0;
+    upper.bottom_overhang = 3.0;
+
+    let mut lower = char_bounds("│", 861.0, 95.0, 9.0, 19.0);
+    lower.glyph_x = 865.0;
+    lower.glyph_y = 94.0;
+    lower.glyph_w = 2.0;
+    lower.glyph_h = 23.0;
+    lower.top_overhang = 1.0;
+    lower.bottom_overhang = 3.0;
+
+    let overlap = char_overlap(&upper, &lower).expect("vertical overhang overlap");
+    assert_eq!(overlap.y, 94.0);
+    assert_eq!(overlap.height, 4.0);
+    assert!(overlap.expected_by_overhang);
+}
+
+#[test]
+fn char_overlap_classifies_box_drawing_corner_join_separately() {
+    let mut corner = char_bounds("╮", 1734.0, 95.0, 9.0, 19.0);
+    corner.slot_id.row = 5;
+    corner.slot_id.col = 2;
+    corner.glyph_x = 1733.0;
+    corner.glyph_y = 103.0;
+    corner.glyph_w = 7.0;
+    corner.glyph_h = 14.0;
+    corner.left_overhang = 1.0;
+
+    let mut stem = char_bounds("│", 1734.0, 114.0, 9.0, 19.0);
+    stem.slot_id.row = 6;
+    stem.slot_id.col = 2;
+    stem.glyph_x = 1738.0;
+    stem.glyph_y = 113.0;
+    stem.glyph_w = 2.0;
+    stem.glyph_h = 23.0;
+
+    let overlap = char_overlap(&corner, &stem).expect("box-drawing join overlap");
+    assert_eq!(overlap.x, 1738.0);
+    assert_eq!(overlap.y, 113.0);
+    assert_eq!(overlap.width, 2.0);
+    assert_eq!(overlap.height, 4.0);
     assert!(overlap.expected_by_overhang);
 }
 

--- a/neomacs-renderer-wgpu/src/renderer/layer_text.rs
+++ b/neomacs-renderer-wgpu/src/renderer/layer_text.rs
@@ -460,6 +460,8 @@ impl row_reuse::RowTessellator for LiveRowTessellator<'_, '_> {
                                 glyph_h,
                                 left_overhang: (*x - glyph_x).max(0.0),
                                 right_overhang: (glyph_right - cell_right).max(0.0),
+                                top_overhang: (*y - glyph_y).max(0.0),
+                                bottom_overhang: (glyph_y + glyph_h - (*y + *height)).max(0.0),
                             });
                         }
 

--- a/neomacs-renderer-wgpu/src/renderer/layer_text.rs
+++ b/neomacs-renderer-wgpu/src/renderer/layer_text.rs
@@ -15,9 +15,9 @@ use super::super::glyph_atlas::{
 use super::super::vertex::{GlyphVertex, RectVertex, RoundedRectVertex, SubpixelGlyphVertex};
 use super::frame_pass::{BoxSpanSet, FrameParams, FramePassCtx};
 use super::glyphs::{
-    CHAR_OVERLAP_MIN_AXIS, RenderedCharBounds, build_subpixel_vertices, color_is_grayscale,
-    log_cursor_glyph_alignment, log_rendered_char_overlaps, subpixel_background_color,
-    subpixel_foreground_color, trace_face_debug_enabled,
+    CHAR_OVERLAP_MIN_AXIS, RenderedCharBounds, RenderedGlyphGeometry, build_subpixel_vertices,
+    color_is_grayscale, log_cursor_glyph_alignment, log_rendered_char_overlaps,
+    subpixel_background_color, subpixel_foreground_color, trace_face_debug_enabled,
 };
 use super::row_reuse;
 use super::{GlyphRenderStats, WgpuRenderer};
@@ -214,7 +214,6 @@ impl row_reuse::RowTessellator for LiveRowTessellator<'_, '_> {
         for glyph_index in chunk.glyphs.clone() {
             let glyph = &frame_glyphs.glyphs[glyph_index];
             if let FrameGlyph::Char {
-                window_id,
                 slot_id,
                 char,
                 composed,
@@ -437,11 +436,8 @@ impl row_reuse::RowTessellator for LiveRowTessellator<'_, '_> {
                             };
 
                         if glyph_w > CHAR_OVERLAP_MIN_AXIS && glyph_h > CHAR_OVERLAP_MIN_AXIS {
-                            let cell_right = *x + *width;
-                            let glyph_right = glyph_x + glyph_w;
                             out.bounds.push(RenderedCharBounds {
                                 glyph_index,
-                                window_id: window_id.get(),
                                 row_role: *row_role,
                                 slot_id: *slot_id,
                                 label: composed
@@ -450,18 +446,10 @@ impl row_reuse::RowTessellator for LiveRowTessellator<'_, '_> {
                                     .unwrap_or_else(|| char.to_string()),
                                 face_id,
                                 font_size,
-                                cell_x: *x,
-                                cell_y: *y,
-                                cell_w: *width,
-                                cell_h: *height,
-                                glyph_x,
-                                glyph_y,
-                                glyph_w,
-                                glyph_h,
-                                left_overhang: (*x - glyph_x).max(0.0),
-                                right_overhang: (glyph_right - cell_right).max(0.0),
-                                top_overhang: (*y - glyph_y).max(0.0),
-                                bottom_overhang: (glyph_y + glyph_h - (*y + *height)).max(0.0),
+                                geometry: RenderedGlyphGeometry::new(
+                                    Rect::new(*x, *y, *width, *height),
+                                    Rect::new(glyph_x, glyph_y, glyph_w, glyph_h),
+                                ),
                             });
                         }
 

--- a/neomacs-renderer-wgpu/src/renderer/row_reuse.rs
+++ b/neomacs-renderer-wgpu/src/renderer/row_reuse.rs
@@ -269,8 +269,7 @@ impl RowStreams {
         }
         for bounds in &row.bounds {
             let mut shifted = bounds.clone();
-            shifted.cell_y += dy;
-            shifted.glyph_y += dy;
+            shifted.geometry = shifted.geometry.translated_y(dy);
             self.bounds.push(shifted);
         }
     }

--- a/neomacs-renderer-wgpu/src/renderer/row_reuse_test.rs
+++ b/neomacs-renderer-wgpu/src/renderer/row_reuse_test.rs
@@ -15,7 +15,7 @@ use std::num::NonZeroU32;
 
 use neomacs_display_protocol::frame_glyphs::{DisplaySlotId, FrameGlyph, GlyphRowRole};
 use neomacs_display_protocol::glyph_matrix::RowDamage;
-use neomacs_display_protocol::types::DisplayWindowId;
+use neomacs_display_protocol::types::{DisplayWindowId, Rect};
 
 use super::super::super::glyph_atlas::FrameFontBindingsIdentity;
 use super::super::super::glyph_atlas::types::{
@@ -23,7 +23,7 @@ use super::super::super::glyph_atlas::types::{
     GlyphMetrics, PageId, SubpixelMask, UvRect,
 };
 use super::super::super::vertex::{GlyphVertex, SubpixelGlyphVertex};
-use super::super::glyphs::RenderedCharBounds;
+use super::super::glyphs::{RenderedCharBounds, RenderedGlyphGeometry};
 use super::*;
 
 const FRAME: u64 = 7;
@@ -214,7 +214,6 @@ impl RowTessellator for FakeTessellator<'_> {
         let mut tessellation = RowTessellation::default();
         for glyph_index in chunk.glyphs.clone() {
             let FrameGlyph::Char {
-                window_id,
                 row_role,
                 slot_id,
                 char: c,
@@ -261,24 +260,15 @@ impl RowTessellator for FakeTessellator<'_> {
             }
             out.bounds.push(RenderedCharBounds {
                 glyph_index,
-                window_id: window_id.get(),
                 row_role: *row_role,
                 slot_id: *slot_id,
                 label: c.to_string(),
                 face_id: *face_id,
                 font_size: 14.0,
-                cell_x: *x,
-                cell_y: *y,
-                cell_w: *width,
-                cell_h: *height,
-                glyph_x: *x,
-                glyph_y: *y,
-                glyph_w: 8.0,
-                glyph_h: 12.0,
-                left_overhang: 0.0,
-                right_overhang: 0.0,
-                top_overhang: 0.0,
-                bottom_overhang: 0.0,
+                geometry: RenderedGlyphGeometry::new(
+                    Rect::new(*x, *y, *width, *height),
+                    Rect::new(*x, *y, 8.0, 12.0),
+                ),
             });
         }
         tessellation
@@ -538,7 +528,13 @@ fn fingerprint(streams: &RowStreams) -> Fingerprint {
     let bounds = streams
         .bounds
         .iter()
-        .map(|b| (b.glyph_index, b.cell_y.to_bits(), b.glyph_y.to_bits()))
+        .map(|b| {
+            (
+                b.glyph_index,
+                b.geometry.cell().y.to_bits(),
+                b.geometry.bitmap().y.to_bits(),
+            )
+        })
         .collect();
     (mask, subpixel, color, entries, bounds)
 }

--- a/neomacs-renderer-wgpu/src/renderer/row_reuse_test.rs
+++ b/neomacs-renderer-wgpu/src/renderer/row_reuse_test.rs
@@ -277,6 +277,8 @@ impl RowTessellator for FakeTessellator<'_> {
                 glyph_h: 12.0,
                 left_overhang: 0.0,
                 right_overhang: 0.0,
+                top_overhang: 0.0,
+                bottom_overhang: 0.0,
             });
         }
         tessellation


### PR DESCRIPTION
## Problem

Box-drawing fonts deliberately extend glyphs above and below their cells so adjacent strokes join without gaps. The renderer's overlap diagnostic only understood horizontal overhang, so vertical graph characters such as `│` and `╮` followed by `│` were repeatedly reported as unexpected collisions.

## Solution

Track top and bottom bitmap overhang and classify intersections across adjacent rows in the same grid column as expected font overhang. Genuine unexpected glyph collisions remain error diagnostics.
