### PR TITLE
fix(neoterm): preserve terminal render state

### DIFF
--- a/neomacs-display-protocol/src/frame_glyphs.rs
+++ b/neomacs-display-protocol/src/frame_glyphs.rs
@@ -668,6 +668,24 @@ impl FrameGlyph {
             _ => None,
         }
     }
+
+    /// Mutable counterpart to [`Self::face_id`] for scene-layer identity
+    /// remapping.
+    ///
+    /// Keeping the exhaustive set of inline face-bearing variants beside the
+    /// protocol enum avoids renderer-owned layers each carrying a partial,
+    /// silently divergent copy of this knowledge.
+    pub fn face_id_mut(&mut self) -> Option<&mut FaceId> {
+        match self {
+            FrameGlyph::Char { face_id, .. }
+            | FrameGlyph::Stretch { face_id, .. }
+            | FrameGlyph::Image { face_id, .. }
+            | FrameGlyph::Video { face_id, .. }
+            | FrameGlyph::Xwidget { face_id, .. }
+            | FrameGlyph::Surface { face_id, .. } => Some(face_id),
+            _ => None,
+        }
+    }
 }
 
 /// Authoritative physical cursor snapshot for a frame.

--- a/neomacs-display-protocol/src/frame_glyphs.rs
+++ b/neomacs-display-protocol/src/frame_glyphs.rs
@@ -6,7 +6,7 @@
 
 use crate::effect_config::EffectsConfig;
 use crate::face::{
-    BoxBorderStyle, BoxType, BoxVerticalEdges, Face, FaceAttributes, UnderlineStyle,
+    BasicFaceId, BoxBorderStyle, BoxType, BoxVerticalEdges, Face, FaceAttributes, UnderlineStyle,
 };
 use crate::types::{
     Color, DisplayFrameId, DisplayWindowId, FaceId, ImageId, Px, Rect, SurfaceId, VideoId,
@@ -1317,6 +1317,20 @@ pub fn derive_window_transition_hint(
 }
 
 impl FrameGlyphBuffer {
+    /// Resolve the default face's concrete font from this frame's matching
+    /// font table.
+    ///
+    /// Keeping this lookup on the snapshot prevents consumers from repeating
+    /// the face-id/table join and accidentally treating a stale font id as a
+    /// usable partial binding.
+    #[must_use]
+    pub fn default_resolved_font(&self) -> Option<&crate::font::ResolvedFont> {
+        self.faces
+            .get(&BasicFaceId::Default.into())
+            .and_then(|face| face.default_resolved_font_id)
+            .and_then(|font_id| self.fonts.get(&font_id))
+    }
+
     /// Borrow every font binding for this exact frame as one coherent value.
     #[must_use]
     pub fn font_bindings(&self) -> crate::font::FrameFontBindings<'_> {

--- a/neomacs-display-protocol/src/frame_glyphs_test.rs
+++ b/neomacs-display-protocol/src/frame_glyphs_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::BasicFaceId;
 use crate::TransitionDirection;
 use crate::WebViewId;
 
@@ -14,6 +15,57 @@ fn assert_color_eq(actual: &Color, expected: &Color) {
         "Colors differ: actual {:?} vs expected {:?}",
         actual,
         expected,
+    );
+}
+
+#[test]
+fn frame_default_resolved_font_is_one_coherent_binding_lookup() {
+    use crate::font::{
+        FontFileAsset, FontOutlineAsset, FontReplay, FontResolutionSource, FontSlantKind,
+        ResolvedFont, ResolvedFontAdvance, ResolvedFontId, ResolvedFontIdentity,
+    };
+
+    let mut frame = FrameGlyphBuffer::with_size(120.0, 80.0);
+    let font_id = ResolvedFontId(42);
+    let mut default_face = Face::new(BasicFaceId::Default.into());
+    default_face.default_resolved_font_id = Some(font_id);
+    frame.faces.insert(default_face.id, default_face);
+    frame.fonts.insert(
+        font_id,
+        ResolvedFont {
+            id: font_id,
+            identity: ResolvedFontIdentity::from_file("/test-fixtures/default-font.ttf", 0, None),
+            replay: FontReplay::Swash {
+                asset: FontOutlineAsset::File(
+                    FontFileAsset::new("/test-fixtures/default-font.ttf", 0)
+                        .expect("valid test font asset"),
+                ),
+            },
+            family: "Default Font".to_string(),
+            full_name: None,
+            postscript_name: None,
+            weight: 400,
+            slant: FontSlantKind::Normal,
+            width: 5,
+            pixel_size: 18.0,
+            ascent_px: 14.0,
+            descent_px: 4.0,
+            space_advance_px: 10.0,
+            glyph_advance: ResolvedFontAdvance::fixed_cell(10.0),
+            source: FontResolutionSource::FacePrimary,
+        },
+    );
+
+    let resolved = frame
+        .default_resolved_font()
+        .expect("default face and font table should resolve together");
+    assert_eq!(resolved.id, font_id);
+    assert_eq!(resolved.family, "Default Font");
+
+    frame.fonts.remove(&font_id);
+    assert!(
+        frame.default_resolved_font().is_none(),
+        "a stale face id must not escape as a partial binding"
     );
 }
 

--- a/neomacs-display-runtime/src/render_thread/child_frames.rs
+++ b/neomacs-display-runtime/src/render_thread/child_frames.rs
@@ -129,7 +129,7 @@ impl ChildFrameManager {
                 clip_in_root: placed.clip_in_root(),
                 z_path: placed.z_path().to_vec(),
                 last_updated: self.frame_counter,
-                ingest_seq: super::frame_state::next_faces_ingest_seq(),
+                ingest_seq: super::frame_state::next_scene_generation(),
             },
         );
 

--- a/neomacs-display-runtime/src/render_thread/frame_state.rs
+++ b/neomacs-display-runtime/src/render_thread/frame_state.rs
@@ -6,11 +6,11 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 const FACE_DIFF_SAMPLE_LIMIT: usize = 10;
 
-/// Next unique frame-install stamp for the face aggregation signature.
-pub(super) fn next_faces_ingest_seq() -> u64 {
+/// Next unique generation for a frame scene and its derived render state.
+pub(super) fn next_scene_generation() -> u64 {
     use std::sync::atomic::{AtomicU64, Ordering};
-    static SEQ: AtomicU64 = AtomicU64::new(1);
-    SEQ.fetch_add(1, Ordering::Relaxed)
+    static GENERATION: AtomicU64 = AtomicU64::new(1);
+    GENERATION.fetch_add(1, Ordering::Relaxed)
 }
 
 /// Diagnostic classification of a face-table update. Purely observational:
@@ -323,27 +323,37 @@ impl RenderApp {
         }
     }
 
-    fn for_each_face_source(&self, mut visit: impl FnMut(u64, u64, &HashMap<FaceId, Face>)) {
+    fn for_each_face_source(
+        &self,
+        mut visit: impl FnMut(u64, u64, &HashMap<FaceId, Face>, Option<&HashMap<FaceId, Face>>),
+    ) {
         self.frame_windows
             .for_each_top_level_window(|window_state| {
                 let compositor = &window_state.render.compositor;
                 if let Some(frame) = compositor.current_frame.as_ref() {
                     visit(
                         frame.frame_placement.frame().get(),
-                        compositor.current_frame_ingest_seq,
+                        compositor.current_scene_generation,
                         &frame.faces,
+                        #[cfg(feature = "neo-term")]
+                        Some(compositor.terminal_expansion.faces()),
+                        #[cfg(not(feature = "neo-term"))]
+                        None,
                     );
                 }
                 for entry in compositor.child_frames.frames.values() {
-                    visit(entry.frame_id, entry.ingest_seq, &entry.frame.faces);
+                    visit(entry.frame_id, entry.ingest_seq, &entry.frame.faces, None);
                 }
             });
     }
 
     fn collect_face_id_conflicts(&self, limit: usize) -> FaceConflictDetails {
         let mut occurrences = Vec::new();
-        self.for_each_face_source(|frame_id, _ingest_seq, frame_faces| {
-            for (face_id, face) in frame_faces {
+        self.for_each_face_source(|frame_id, _generation, frame_faces, terminal_faces| {
+            for (face_id, face) in frame_faces
+                .iter()
+                .chain(terminal_faces.into_iter().flat_map(HashMap::iter))
+            {
                 occurrences.push(FaceOccurrence {
                     face_id: *face_id,
                     frame_id,
@@ -356,16 +366,16 @@ impl RenderApp {
     }
 
     fn refresh_faces_from_frames(&mut self) {
-        // Cheap change detection first: every frame install stamps a unique
-        // ingest sequence, so the sorted (frame_id, seq) signature of the
-        // contributing frames identifies the exact face-source set. An
-        // unchanged signature means the aggregate face map cannot have
-        // changed - the common case for cursor-blink and animation renders,
-        // which used to rebuild and clone the whole map on every rendered
-        // window.
+        // Cheap change detection first: every editor/terminal scene change and
+        // child-frame install stamps a unique generation. The sorted
+        // (frame_id, generation) signature therefore identifies the exact
+        // face-source set. An unchanged signature means the aggregate face map
+        // cannot have changed—the common case for cursor-blink and animation
+        // renders, which used to rebuild and clone the whole map on every
+        // rendered window.
         let mut signature: Vec<(u64, u64)> = Vec::new();
-        self.for_each_face_source(|frame_id, ingest_seq, _faces| {
-            signature.push((frame_id, ingest_seq));
+        self.for_each_face_source(|frame_id, generation, _faces, _terminal_faces| {
+            signature.push((frame_id, generation));
         });
         signature.sort_unstable();
         if signature == self.faces_signature {
@@ -377,8 +387,11 @@ impl RenderApp {
         // former second primary-window pass was pure duplication - and
         // panicked when no primary window existed.
         let mut faces = std::collections::HashMap::new();
-        self.for_each_face_source(|_frame_id, _ingest_seq, frame_faces| {
-            for (face_id, face) in frame_faces {
+        self.for_each_face_source(|_frame_id, _generation, frame_faces, terminal_faces| {
+            for (face_id, face) in frame_faces
+                .iter()
+                .chain(terminal_faces.into_iter().flat_map(HashMap::iter))
+            {
                 faces.entry(*face_id).or_insert_with(|| face.clone());
             }
         });

--- a/neomacs-display-runtime/src/render_thread/frame_windows.rs
+++ b/neomacs-display-runtime/src/render_thread/frame_windows.rs
@@ -21,9 +21,10 @@ use super::state::{
     PointerAppearanceState, PresentedInteractionKey, PresentedPointerHit, PresentedPressCapture,
     TypingSpeedState, WindowChrome, effective_window_scale_factor, window_size_from_emacs_pixels,
 };
+#[cfg(feature = "neo-term")]
+use super::terminal_expansion::{TerminalExpansion, TerminalExpansionUpdate};
 use super::transitions::{TransitionState, clear_frame_transition_textures};
 use super::x11_hints::apply_window_geometry_hints;
-use crate::core::frame_glyphs::FrameGlyph;
 use crate::core::frame_glyphs::FrameGlyphBuffer;
 use neomacs_display_protocol::effect_config::IdleDimConfig;
 #[cfg(feature = "video")]
@@ -219,18 +220,14 @@ pub(crate) struct FrameCompositor {
     /// decoder wakeups do not rescan every glyph at video frame rate.
     #[cfg(feature = "video")]
     visible_videos: HashSet<VideoId>,
-    /// Unique per-install stamp for `current_frame`; the face aggregation
-    /// signature uses it to detect frame replacement without hashing faces.
-    pub current_frame_ingest_seq: u64,
-    /// Glyph count before the current NeoTerm expansion. Rewinding to this
-    /// boundary makes render preparation idempotent while the editor frame is
-    /// retained across terminal updates.
+    /// Unique generation of the composed editor scene. Frame replacement and
+    /// renderer-owned terminal replacement both advance it, so face
+    /// aggregation and retained-static rendering cannot observe stale state.
+    pub current_scene_generation: u64,
+    /// Renderer-owned terminal contribution, kept out of the immutable editor
+    /// frame and composed only into render clones.
     #[cfg(feature = "neo-term")]
-    terminal_expansion_base_glyph_len: Option<usize>,
-    /// Synthesized terminal faces appended after
-    /// `terminal_expansion_base_glyph_len` was captured.
-    #[cfg(feature = "neo-term")]
-    terminal_expansion_face_ids: HashSet<neomacs_display_protocol::types::FaceId>,
+    pub(super) terminal_expansion: TerminalExpansion,
     /// Row damage paired with `current_frame` (built from the same
     /// FrameDisplayState that frame was materialized from). Set only
     /// together with the frame via `set_current_frame` so a summary can
@@ -265,7 +262,7 @@ pub(crate) struct RetainedStatic {
     pub(super) view: wgpu::TextureView,
     /// Image-pipeline bind group for blitting the texture to the surface.
     pub(super) bind_group: wgpu::BindGroup,
-    /// `current_frame_ingest_seq` this was built from; a new scene commit
+    /// `current_scene_generation` this was built from; a new scene commit
     /// bumps that stamp and invalidates this.
     pub(super) generation: u64,
     pub(super) width: u32,
@@ -424,11 +421,9 @@ impl GuiFrameRenderState {
                 current_frame: None,
                 #[cfg(feature = "video")]
                 visible_videos: HashSet::new(),
-                current_frame_ingest_seq: 0,
+                current_scene_generation: 0,
                 #[cfg(feature = "neo-term")]
-                terminal_expansion_base_glyph_len: None,
-                #[cfg(feature = "neo-term")]
-                terminal_expansion_face_ids: HashSet::new(),
+                terminal_expansion: TerminalExpansion::default(),
                 current_row_damage: None,
                 child_frames: ChildFrameManager::new(),
                 hidden_child_frames: HashSet::new(),
@@ -475,11 +470,9 @@ impl GuiFrameRenderState {
                 current_frame: None,
                 #[cfg(feature = "video")]
                 visible_videos: HashSet::new(),
-                current_frame_ingest_seq: 0,
+                current_scene_generation: 0,
                 #[cfg(feature = "neo-term")]
-                terminal_expansion_base_glyph_len: None,
-                #[cfg(feature = "neo-term")]
-                terminal_expansion_face_ids: HashSet::new(),
+                terminal_expansion: TerminalExpansion::default(),
                 current_row_damage: None,
                 child_frames: ChildFrameManager::new(),
                 hidden_child_frames: HashSet::new(),
@@ -581,7 +574,10 @@ impl GuiFrameRenderState {
     // retained frame through narrower accessors.
     #[allow(dead_code)]
     pub(super) fn current_frame_clone(&self) -> Option<FrameGlyphBuffer> {
-        self.compositor.current_frame.clone()
+        let mut frame = self.compositor.current_frame.clone()?;
+        #[cfg(feature = "neo-term")]
+        self.compositor.terminal_expansion.compose_into(&mut frame);
+        Some(frame)
     }
 
     /// Whether the retained frame carries a theme-transition effect hint —
@@ -907,57 +903,40 @@ impl GuiFrameRenderState {
         self.compositor.dirty = true;
     }
 
-    /// Remove the previous terminal expansion and capture the immutable editor
-    /// glyph boundary for this render-preparation cycle.
-    #[cfg(feature = "neo-term")]
-    pub(super) fn begin_terminal_expansion(&mut self) {
-        let Some(frame) = self.compositor.current_frame.as_mut() else {
-            self.compositor.terminal_expansion_base_glyph_len = None;
-            self.compositor.terminal_expansion_face_ids.clear();
-            return;
-        };
-
-        if let Some(base_len) = self.compositor.terminal_expansion_base_glyph_len.take() {
-            frame.glyphs.truncate(base_len.min(frame.glyphs.len()));
-        }
-        for face_id in self.compositor.terminal_expansion_face_ids.drain() {
-            frame.faces.remove(&face_id);
-        }
-        self.compositor.terminal_expansion_base_glyph_len = Some(frame.glyphs.len());
-    }
-
-    /// Append glyphs together with the faces they reference.
+    /// Atomically replace the complete renderer-owned terminal contribution.
     ///
-    /// Producers that emit `FrameGlyph::Char` with synthesized face ids (the
-    /// terminal-cell expansion) must register those faces so
-    /// `FrameGlyphBuffer::resolved_face` can resolve the glyph's colors and
-    /// decorations at draw time.
+    /// The editor frame is never mutated. A real change advances the scene
+    /// generation, disables row reuse, and requests a full repaint; an
+    /// identical replacement has no side effects.
     #[cfg(feature = "neo-term")]
-    pub(super) fn extend_current_frame_glyphs_and_faces(
+    pub(super) fn replace_terminal_expansion(
         &mut self,
-        glyphs: Vec<FrameGlyph>,
-        faces: HashMap<crate::core::types::FaceId, crate::core::face::Face>,
-    ) -> bool {
-        if glyphs.is_empty() {
-            return false;
-        }
-        let Some(frame) = self.compositor.current_frame.as_mut() else {
-            return false;
+        next: TerminalExpansion,
+    ) -> TerminalExpansionUpdate {
+        let Some(frame) = self.compositor.current_frame.as_ref() else {
+            self.compositor.terminal_expansion = TerminalExpansion::default();
+            return TerminalExpansionUpdate::NoFrame;
         };
-        self.compositor
-            .terminal_expansion_face_ids
-            .extend(faces.keys().copied());
-        frame.glyphs.extend(glyphs);
-        frame.faces.extend(faces);
-        // The frame no longer matches the layout state its row-damage summary
-        // was built from, so drop the pairing — the renderer then tessellates
-        // this frame fully instead of splicing cached rows. (Today the
-        // appended terminal glyphs use the sentinel DisplayWindowId 0, which
-        // never appears in damage summaries, but that is an accident of the
-        // terminal expansion, not a guarantee worth betting reuse on.)
+        if let Some(face_id) = next
+            .faces()
+            .keys()
+            .find(|face_id| frame.faces.contains_key(face_id))
+            .copied()
+        {
+            tracing::error!(
+                face_id = face_id.get(),
+                "terminal expansion attempted to replace an editor-owned face"
+            );
+            return TerminalExpansionUpdate::FaceIdCollision(face_id);
+        }
+        if self.compositor.terminal_expansion == next {
+            return TerminalExpansionUpdate::Unchanged;
+        }
+        self.compositor.terminal_expansion = next;
+        self.compositor.current_scene_generation = super::frame_state::next_scene_generation();
         self.compositor.current_row_damage = None;
         self.compositor.dirty = true;
-        true
+        TerminalExpansionUpdate::Replaced
     }
 
     pub(super) fn set_visual_bell_start(&mut self, start: Option<Instant>) {
@@ -1114,8 +1093,7 @@ impl GuiFrameRenderState {
         self.compositor.current_frame = frame;
         #[cfg(feature = "neo-term")]
         {
-            self.compositor.terminal_expansion_base_glyph_len = None;
-            self.compositor.terminal_expansion_face_ids.clear();
+            self.compositor.terminal_expansion = TerminalExpansion::default();
         }
         #[cfg(feature = "video")]
         self.refresh_visible_videos();
@@ -1127,7 +1105,7 @@ impl GuiFrameRenderState {
         } else {
             false
         };
-        self.compositor.current_frame_ingest_seq = super::frame_state::next_faces_ingest_seq();
+        self.compositor.current_scene_generation = super::frame_state::next_scene_generation();
         self.compositor.current_row_damage = row_damage;
         if appearance_changed {
             self.record_pointer_paint_transition(before);
@@ -1200,10 +1178,11 @@ impl GuiFrameRenderState {
     }
 
     pub(super) fn take_current_frame_for_render(&mut self) -> Option<FrameGlyphBuffer> {
-        self.compositor
-            .current_frame
-            .as_mut()
-            .map(Self::take_frame_for_render)
+        let current_frame = self.compositor.current_frame.as_mut()?;
+        let mut frame = Self::take_frame_for_render(current_frame);
+        #[cfg(feature = "neo-term")]
+        self.compositor.terminal_expansion.compose_into(&mut frame);
+        Some(frame)
     }
 
     pub(super) fn take_frame_for_render(current_frame: &mut FrameGlyphBuffer) -> FrameGlyphBuffer {

--- a/neomacs-display-runtime/src/render_thread/frame_windows.rs
+++ b/neomacs-display-runtime/src/render_thread/frame_windows.rs
@@ -25,6 +25,8 @@ use super::state::{
 use super::terminal_expansion::{TerminalExpansion, TerminalExpansionUpdate};
 use super::transitions::{TransitionState, clear_frame_transition_textures};
 use super::x11_hints::apply_window_geometry_hints;
+#[cfg(feature = "video")]
+use crate::core::frame_glyphs::FrameGlyph;
 use crate::core::frame_glyphs::FrameGlyphBuffer;
 use neomacs_display_protocol::effect_config::IdleDimConfig;
 #[cfg(feature = "video")]

--- a/neomacs-display-runtime/src/render_thread/frame_windows.rs
+++ b/neomacs-display-runtime/src/render_thread/frame_windows.rs
@@ -222,6 +222,15 @@ pub(crate) struct FrameCompositor {
     /// Unique per-install stamp for `current_frame`; the face aggregation
     /// signature uses it to detect frame replacement without hashing faces.
     pub current_frame_ingest_seq: u64,
+    /// Glyph count before the current NeoTerm expansion. Rewinding to this
+    /// boundary makes render preparation idempotent while the editor frame is
+    /// retained across terminal updates.
+    #[cfg(feature = "neo-term")]
+    terminal_expansion_base_glyph_len: Option<usize>,
+    /// Synthesized terminal faces appended after
+    /// `terminal_expansion_base_glyph_len` was captured.
+    #[cfg(feature = "neo-term")]
+    terminal_expansion_face_ids: HashSet<neomacs_display_protocol::types::FaceId>,
     /// Row damage paired with `current_frame` (built from the same
     /// FrameDisplayState that frame was materialized from). Set only
     /// together with the frame via `set_current_frame` so a summary can
@@ -416,6 +425,10 @@ impl GuiFrameRenderState {
                 #[cfg(feature = "video")]
                 visible_videos: HashSet::new(),
                 current_frame_ingest_seq: 0,
+                #[cfg(feature = "neo-term")]
+                terminal_expansion_base_glyph_len: None,
+                #[cfg(feature = "neo-term")]
+                terminal_expansion_face_ids: HashSet::new(),
                 current_row_damage: None,
                 child_frames: ChildFrameManager::new(),
                 hidden_child_frames: HashSet::new(),
@@ -463,6 +476,10 @@ impl GuiFrameRenderState {
                 #[cfg(feature = "video")]
                 visible_videos: HashSet::new(),
                 current_frame_ingest_seq: 0,
+                #[cfg(feature = "neo-term")]
+                terminal_expansion_base_glyph_len: None,
+                #[cfg(feature = "neo-term")]
+                terminal_expansion_face_ids: HashSet::new(),
                 current_row_damage: None,
                 child_frames: ChildFrameManager::new(),
                 hidden_child_frames: HashSet::new(),
@@ -890,6 +907,25 @@ impl GuiFrameRenderState {
         self.compositor.dirty = true;
     }
 
+    /// Remove the previous terminal expansion and capture the immutable editor
+    /// glyph boundary for this render-preparation cycle.
+    #[cfg(feature = "neo-term")]
+    pub(super) fn begin_terminal_expansion(&mut self) {
+        let Some(frame) = self.compositor.current_frame.as_mut() else {
+            self.compositor.terminal_expansion_base_glyph_len = None;
+            self.compositor.terminal_expansion_face_ids.clear();
+            return;
+        };
+
+        if let Some(base_len) = self.compositor.terminal_expansion_base_glyph_len.take() {
+            frame.glyphs.truncate(base_len.min(frame.glyphs.len()));
+        }
+        for face_id in self.compositor.terminal_expansion_face_ids.drain() {
+            frame.faces.remove(&face_id);
+        }
+        self.compositor.terminal_expansion_base_glyph_len = Some(frame.glyphs.len());
+    }
+
     /// Append glyphs together with the faces they reference.
     ///
     /// Producers that emit `FrameGlyph::Char` with synthesized face ids (the
@@ -908,6 +944,9 @@ impl GuiFrameRenderState {
         let Some(frame) = self.compositor.current_frame.as_mut() else {
             return false;
         };
+        self.compositor
+            .terminal_expansion_face_ids
+            .extend(faces.keys().copied());
         frame.glyphs.extend(glyphs);
         frame.faces.extend(faces);
         // The frame no longer matches the layout state its row-damage summary
@@ -1073,6 +1112,11 @@ impl GuiFrameRenderState {
         });
         self.compositor.child_frames.set_root_frame(frame.as_ref());
         self.compositor.current_frame = frame;
+        #[cfg(feature = "neo-term")]
+        {
+            self.compositor.terminal_expansion_base_glyph_len = None;
+            self.compositor.terminal_expansion_face_ids.clear();
+        }
         #[cfg(feature = "video")]
         self.refresh_visible_videos();
         self.refresh_present_mapping();

--- a/neomacs-display-runtime/src/render_thread/frame_windows_test.rs
+++ b/neomacs-display-runtime/src/render_thread/frame_windows_test.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::core::frame_glyphs::{
-    BufferTransitionTarget, ContentTransitionHint, CursorStyle, DisplaySlotId, FrameGlyphBuffer,
-    PresentedWindowRegions, WindowCursor, WindowEffectHint,
+    BufferTransitionTarget, ContentTransitionHint, CursorStyle, DisplaySlotId, FrameGlyph,
+    FrameGlyphBuffer, PresentedWindowRegions, WindowCursor, WindowEffectHint,
 };
 use crate::render_thread::cursor::CursorTarget;
 use neomacs_display_protocol::types::Color;
@@ -40,9 +40,21 @@ fn gui_text_input_policy_enables_native_ime_on_window_creation() {
 
 #[cfg(feature = "neo-term")]
 #[test]
-fn terminal_expansion_replaces_previous_runtime_glyphs() {
+fn terminal_expansion_replacement_is_atomic_and_invalidates_the_scene() {
     let mut render = GuiFrameRenderState::new_without_device(0x42, false);
-    render.set_current_frame(Some(make_frame(0x42, 0)), None);
+    let mut editor_frame = make_frame(0x42, 0);
+    let editor_glyph = FrameGlyph::Border {
+        window_id: neomacs_display_protocol::types::DisplayWindowId::new(1),
+        row_role: neomacs_display_protocol::frame_glyphs::GlyphRowRole::Text,
+        clip_rect: None,
+        x: 0.0,
+        y: 0.0,
+        width: 8.0,
+        height: 19.0,
+        color: Color::WHITE,
+    };
+    editor_frame.glyphs.push(editor_glyph.clone());
+    render.set_current_frame(Some(editor_frame), None);
     let face_id = neomacs_display_protocol::types::FaceId::new(0xffff_fff0);
     let generated_glyph = FrameGlyph::Border {
         window_id: neomacs_display_protocol::types::DisplayWindowId::new(1),
@@ -56,12 +68,20 @@ fn terminal_expansion_replaces_previous_runtime_glyphs() {
     };
     let generated_faces =
         HashMap::from([(face_id, neomacs_display_protocol::face::Face::new(face_id))]);
+    let expansion = TerminalExpansion::new(vec![generated_glyph], generated_faces);
+    let initial_generation = render.compositor.current_scene_generation;
 
-    render.begin_terminal_expansion();
-    assert!(render.extend_current_frame_glyphs_and_faces(
-        vec![generated_glyph.clone()],
-        generated_faces.clone(),
-    ));
+    assert_eq!(
+        render.replace_terminal_expansion(expansion.clone()),
+        TerminalExpansionUpdate::Replaced
+    );
+    assert!(render.compositor.dirty);
+    assert_ne!(
+        render.compositor.current_scene_generation,
+        initial_generation
+    );
+    // The editor snapshot remains immutable; terminal state is composed only
+    // into the frame exposed for rendering.
     assert_eq!(
         render
             .compositor
@@ -72,32 +92,84 @@ fn terminal_expansion_replaces_previous_runtime_glyphs() {
             .len(),
         1
     );
-    assert!(
-        render
-            .compositor
-            .current_frame
-            .as_ref()
-            .unwrap()
-            .faces
-            .contains_key(&face_id)
-    );
-
-    render.begin_terminal_expansion();
-    let frame = render.compositor.current_frame.as_ref().unwrap();
-    assert!(frame.glyphs.is_empty());
-    assert!(!frame.faces.contains_key(&face_id));
-
-    assert!(render.extend_current_frame_glyphs_and_faces(vec![generated_glyph], generated_faces,));
+    let composed = render.current_frame_clone().expect("composed frame");
     assert_eq!(
-        render
-            .compositor
-            .current_frame
-            .as_ref()
-            .unwrap()
-            .glyphs
-            .len(),
-        1
+        composed.glyphs,
+        vec![editor_glyph.clone(), expansion.glyphs()[0].clone()]
     );
+    assert!(composed.faces.contains_key(&face_id));
+
+    render.begin_presentable_render();
+    let installed_generation = render.compositor.current_scene_generation;
+    assert_eq!(
+        render.replace_terminal_expansion(expansion),
+        TerminalExpansionUpdate::Unchanged
+    );
+    assert!(!render.compositor.dirty);
+    assert_eq!(
+        render.compositor.current_scene_generation,
+        installed_generation
+    );
+
+    assert_eq!(
+        render.replace_terminal_expansion(TerminalExpansion::default()),
+        TerminalExpansionUpdate::Replaced
+    );
+    assert!(render.compositor.dirty);
+    assert_ne!(
+        render.compositor.current_scene_generation,
+        installed_generation
+    );
+    let composed = render.current_frame_clone().expect("editor-only frame");
+    assert_eq!(composed.glyphs, vec![editor_glyph]);
+    assert!(!composed.faces.contains_key(&face_id));
+}
+
+#[cfg(feature = "neo-term")]
+#[test]
+fn terminal_expansion_rejects_editor_face_collisions_without_partial_installation() {
+    let mut render = GuiFrameRenderState::new_without_device(0x42, false);
+    let editor_face_id = neomacs_display_protocol::types::FaceId::new(0xffff_fff0);
+    let retained_face_id = neomacs_display_protocol::types::FaceId::new(0xffff_fff1);
+    let mut editor_frame = make_frame(0x42, 0);
+    editor_frame.faces.insert(
+        editor_face_id,
+        neomacs_display_protocol::face::Face::new(editor_face_id),
+    );
+    render.set_current_frame(Some(editor_frame), None);
+    let retained = TerminalExpansion::new(
+        Vec::new(),
+        HashMap::from([(
+            retained_face_id,
+            neomacs_display_protocol::face::Face::new(retained_face_id),
+        )]),
+    );
+    assert_eq!(
+        render.replace_terminal_expansion(retained),
+        TerminalExpansionUpdate::Replaced
+    );
+    render.begin_presentable_render();
+    let installed_generation = render.compositor.current_scene_generation;
+
+    let collision = TerminalExpansion::new(
+        Vec::new(),
+        HashMap::from([(
+            editor_face_id,
+            neomacs_display_protocol::face::Face::new(editor_face_id),
+        )]),
+    );
+    assert_eq!(
+        render.replace_terminal_expansion(collision),
+        TerminalExpansionUpdate::FaceIdCollision(editor_face_id)
+    );
+    assert!(!render.compositor.dirty);
+    assert_eq!(
+        render.compositor.current_scene_generation,
+        installed_generation
+    );
+    let composed = render.current_frame_clone().expect("composed frame");
+    assert!(composed.faces.contains_key(&editor_face_id));
+    assert!(composed.faces.contains_key(&retained_face_id));
 }
 
 fn make_frame(frame_id: u64, parent_id: u64) -> FrameGlyphBuffer {

--- a/neomacs-display-runtime/src/render_thread/frame_windows_test.rs
+++ b/neomacs-display-runtime/src/render_thread/frame_windows_test.rs
@@ -38,6 +38,68 @@ fn gui_text_input_policy_enables_native_ime_on_window_creation() {
     );
 }
 
+#[cfg(feature = "neo-term")]
+#[test]
+fn terminal_expansion_replaces_previous_runtime_glyphs() {
+    let mut render = GuiFrameRenderState::new_without_device(0x42, false);
+    render.set_current_frame(Some(make_frame(0x42, 0)), None);
+    let face_id = neomacs_display_protocol::types::FaceId::new(0xffff_fff0);
+    let generated_glyph = FrameGlyph::Border {
+        window_id: neomacs_display_protocol::types::DisplayWindowId::new(1),
+        row_role: neomacs_display_protocol::frame_glyphs::GlyphRowRole::Text,
+        clip_rect: None,
+        x: 8.0,
+        y: 0.0,
+        width: 9.0,
+        height: 19.0,
+        color: Color::WHITE,
+    };
+    let generated_faces =
+        HashMap::from([(face_id, neomacs_display_protocol::face::Face::new(face_id))]);
+
+    render.begin_terminal_expansion();
+    assert!(render.extend_current_frame_glyphs_and_faces(
+        vec![generated_glyph.clone()],
+        generated_faces.clone(),
+    ));
+    assert_eq!(
+        render
+            .compositor
+            .current_frame
+            .as_ref()
+            .unwrap()
+            .glyphs
+            .len(),
+        1
+    );
+    assert!(
+        render
+            .compositor
+            .current_frame
+            .as_ref()
+            .unwrap()
+            .faces
+            .contains_key(&face_id)
+    );
+
+    render.begin_terminal_expansion();
+    let frame = render.compositor.current_frame.as_ref().unwrap();
+    assert!(frame.glyphs.is_empty());
+    assert!(!frame.faces.contains_key(&face_id));
+
+    assert!(render.extend_current_frame_glyphs_and_faces(vec![generated_glyph], generated_faces,));
+    assert_eq!(
+        render
+            .compositor
+            .current_frame
+            .as_ref()
+            .unwrap()
+            .glyphs
+            .len(),
+        1
+    );
+}
+
 fn make_frame(frame_id: u64, parent_id: u64) -> FrameGlyphBuffer {
     let mut buf = FrameGlyphBuffer::with_size(800.0, 600.0);
     buf.set_frame_identity(

--- a/neomacs-display-runtime/src/render_thread/media.rs
+++ b/neomacs-display-runtime/src/render_thread/media.rs
@@ -663,6 +663,7 @@ impl RenderApp {
 
         self.frame_windows
             .for_each_top_level_window_mut(|window_state| {
+                window_state.render.begin_terminal_expansion();
                 Self::expand_terminal_glyphs_for_render_state(
                     &mut window_state.render,
                     &terminal_contents,
@@ -1094,8 +1095,8 @@ mod tests {
     #[test]
     fn terminal_glyph_expansion_inherits_frame_font_identity() {
         use neomacs_display_protocol::font::{
-            FontReplay, FontResolutionSource, FontSlantKind, ResolvedFont, ResolvedFontAdvance,
-            ResolvedFontId, ResolvedFontIdentity,
+            FontFileAsset, FontOutlineAsset, FontReplay, FontResolutionSource, FontSlantKind,
+            ResolvedFont, ResolvedFontAdvance, ResolvedFontId, ResolvedFontIdentity,
         };
 
         let mut frame = FrameGlyphBuffer::with_size(120.0, 80.0);
@@ -1110,7 +1111,12 @@ mod tests {
                 0,
                 Some("TerminalFont".to_string()),
             ),
-            replay: FontReplay::Swash,
+            replay: FontReplay::Swash {
+                asset: FontOutlineAsset::File(
+                    FontFileAsset::new("/tmp/terminal-font.ttf", 0)
+                        .expect("valid terminal font asset"),
+                ),
+            },
             family: "Terminal Font".to_string(),
             full_name: Some("Terminal Font Regular".to_string()),
             postscript_name: Some("TerminalFont".to_string()),

--- a/neomacs-display-runtime/src/render_thread/media.rs
+++ b/neomacs-display-runtime/src/render_thread/media.rs
@@ -2,7 +2,9 @@ use super::RenderApp;
 #[cfg(feature = "video")]
 use super::frame_sched::{NativeWindowId, PacingAction};
 #[cfg(feature = "neo-term")]
-use super::frame_windows::GuiFrameRenderState;
+use super::terminal_expansion::{
+    TERMINAL_FACE_ID_BASE, TERMINAL_FACE_ID_MASK, TerminalExpansion, next_terminal_face_id,
+};
 #[cfg(feature = "neo-term")]
 use crate::core::face::{BoxType, Face, FaceAttributes, UnderlineStyle};
 #[cfg(feature = "neo-term")]
@@ -14,7 +16,7 @@ use crate::core::types::{Color, FaceId, Px, Rect};
 #[cfg(any(feature = "neo-term", feature = "webview"))]
 use crate::thread_comm::InputEvent;
 #[cfg(feature = "neo-term")]
-use neomacs_display_protocol::font::ResolvedFont;
+use neomacs_display_protocol::font::{FontSlantKind, ResolvedFont, ResolvedFontId};
 #[cfg(feature = "neo-term")]
 use std::collections::HashMap;
 
@@ -94,15 +96,6 @@ impl RenderApp {
     }
 
     #[cfg(feature = "neo-term")]
-    fn frame_default_resolved_font(frame: &FrameGlyphBuffer) -> Option<&ResolvedFont> {
-        frame
-            .faces
-            .get(&FaceId::new(0))
-            .and_then(|face| face.default_resolved_font_id)
-            .and_then(|font_id| frame.fonts.get(&font_id))
-    }
-
-    #[cfg(feature = "neo-term")]
     fn expanded_terminal_glyphs_for_frame(
         frame: &FrameGlyphBuffer,
         terminal_contents: &HashMap<crate::terminal::TerminalId, crate::terminal::TerminalContent>,
@@ -111,7 +104,7 @@ impl RenderApp {
         let cell_h = frame.char_height;
         let font_size = frame.font_pixel_size;
         let ascent = cell_h * 0.8;
-        let default_font = Self::frame_default_resolved_font(frame);
+        let default_font = frame.default_resolved_font();
         let mut extra_glyphs = Vec::new();
         let mut extra_faces = HashMap::new();
 
@@ -174,24 +167,21 @@ impl RenderApp {
     }
 
     #[cfg(feature = "neo-term")]
-    fn expand_terminal_glyphs_for_render_state(
-        render: &mut GuiFrameRenderState,
+    fn terminal_expansion_for_frame(
+        frame: &FrameGlyphBuffer,
         terminal_contents: &HashMap<crate::terminal::TerminalId, crate::terminal::TerminalContent>,
         terminal_targets: &HashMap<
             crate::terminal::TerminalId,
             crate::terminal::TerminalDisplayTarget,
         >,
-    ) {
-        let Some(frame) = render.compositor.current_frame.as_ref() else {
-            return;
-        };
-        let (mut extra_glyphs, mut extra_faces) =
+    ) -> TerminalExpansion {
+        let (extra_glyphs, extra_faces) =
             Self::expanded_terminal_glyphs_for_frame(frame, terminal_contents);
         let (window_glyphs, window_faces) =
             Self::expanded_window_terminals_for_frame(frame, terminal_contents, terminal_targets);
-        extra_glyphs.extend(window_glyphs);
-        extra_faces.extend(window_faces);
-        render.extend_current_frame_glyphs_and_faces(extra_glyphs, extra_faces);
+        let mut expansion = TerminalExpansion::new(extra_glyphs, extra_faces);
+        expansion.merge(TerminalExpansion::new(window_glyphs, window_faces));
+        expansion
     }
 
     #[cfg(feature = "neo-term")]
@@ -227,9 +217,11 @@ impl RenderApp {
         let cell_w = frame.char_width;
         let cell_h = frame.char_height;
         let ascent = cell_h * 0.8;
-        let default_font = Self::frame_default_resolved_font(frame);
+        let default_font = frame.default_resolved_font();
 
-        for (id, target) in terminal_targets {
+        let mut ordered_targets: Vec<_> = terminal_targets.iter().collect();
+        ordered_targets.sort_unstable_by_key(|(id, _)| id.get());
+        for (id, target) in ordered_targets {
             let crate::terminal::TerminalDisplayTarget::Window { buffer } = target else {
                 continue;
             };
@@ -562,7 +554,7 @@ impl RenderApp {
                 frame.char_width,
                 frame.char_height,
                 frame.font_pixel_size,
-                Self::frame_default_resolved_font(frame).cloned(),
+                frame.default_resolved_font().cloned(),
             )
         } else {
             (8.0, 16.0, 14.0, None)
@@ -661,16 +653,6 @@ impl RenderApp {
             .filter_map(|id| self.terminal_manager.get(id).map(|view| (id, view.target)))
             .collect();
 
-        self.frame_windows
-            .for_each_top_level_window_mut(|window_state| {
-                window_state.render.begin_terminal_expansion();
-                Self::expand_terminal_glyphs_for_render_state(
-                    &mut window_state.render,
-                    &terminal_contents,
-                    &terminal_targets,
-                );
-            });
-
         // Render floating terminals
         let mut float_glyphs = Vec::new();
         let mut float_faces = HashMap::new();
@@ -726,13 +708,28 @@ impl RenderApp {
             }
         }
 
-        if let Some(primary_frame) = self
-            .frame_windows
-            .primary_window_mut()
-            .map(|ws| &mut ws.render)
-        {
-            primary_frame.extend_current_frame_glyphs_and_faces(float_glyphs, float_faces);
-        }
+        let primary_frame_id = self.frame_windows.primary_frame_id();
+        let mut floating_expansion = Some(TerminalExpansion::new(float_glyphs, float_faces));
+        self.frame_windows
+            .for_each_top_level_window_mut(|window_state| {
+                let mut expansion = window_state
+                    .render
+                    .compositor
+                    .current_frame
+                    .as_ref()
+                    .map(|frame| {
+                        Self::terminal_expansion_for_frame(
+                            frame,
+                            &terminal_contents,
+                            &terminal_targets,
+                        )
+                    })
+                    .unwrap_or_default();
+                if primary_frame_id == Some(window_state.render.emacs_frame_id) {
+                    expansion.merge(floating_expansion.take().unwrap_or_default());
+                }
+                let _ = window_state.render.replace_terminal_expansion(expansion);
+            });
     }
 
     /// Expand terminal content cells into FrameGlyph entries.
@@ -746,7 +743,8 @@ impl RenderApp {
     /// per-cell stretch above and the terminal's default-background stretch
     /// supply the background, exactly as when `Char.bg` was `None`). Because
     /// terminal cell geometry uses the frame's default font metrics, synthesized
-    /// faces also inherit that font's exact render identity.
+    /// faces inherit its family/file provenance. Exact identity is retained only
+    /// when it already satisfies the cell's requested bold/italic style.
     #[cfg(feature = "neo-term")]
     fn expand_terminal_cells(
         content: &crate::terminal::content::TerminalContent,
@@ -762,8 +760,6 @@ impl RenderApp {
         out: &mut Vec<FrameGlyph>,
         faces: &mut HashMap<FaceId, Face>,
     ) {
-        use rio_vt::crosswords::style::StyleFlags as CellFlags;
-
         for cell in &content.cells {
             let cx = origin_x + cell.col as f32 * cell_w;
             let cy = origin_y + cell.row as f32 * cell_h;
@@ -796,23 +792,8 @@ impl RenderApp {
             if cell.c != ' ' && cell.c != '\0' {
                 let mut fg = cell.fg;
                 fg.a *= opacity;
-                let bold = cell.flags.contains(CellFlags::BOLD);
-                let italic = cell.flags.contains(CellFlags::ITALIC);
-                let underline = cell.flags.contains(CellFlags::UNDERLINE);
-                let strikeout = cell.flags.contains(CellFlags::STRIKEOUT);
-                let face_id = terminal_cell_face_id(fg, bold, italic, underline, strikeout);
-                faces.entry(face_id).or_insert_with(|| {
-                    terminal_cell_face(
-                        face_id,
-                        fg,
-                        bold,
-                        italic,
-                        underline,
-                        strikeout,
-                        font_size,
-                        default_font,
-                    )
-                });
+                let style = TerminalCellStyle::from_flags(cell.flags);
+                let face_id = intern_terminal_cell_face(faces, fg, style, font_size, default_font);
                 out.push(FrameGlyph::Char {
                     window_id: paint.window_id,
                     row_role: paint.row_role,
@@ -859,30 +840,132 @@ impl RenderApp {
     }
 }
 
-/// Base for synthesized terminal-cell face ids. Kept far above any real GNU
-/// face id so terminal faces never collide with faces published by layout.
-#[cfg(feature = "neo-term")]
-const TERMINAL_FACE_ID_BASE: u32 = 0xF000_0000;
-
-/// Deterministic face id for a terminal cell's visual style.
+/// The SGR style dimensions that affect one synthesized terminal face.
 ///
-/// Encodes the 8-bit-per-channel foreground plus the four SGR flags into the
-/// low 28 bits below [`TERMINAL_FACE_ID_BASE`]. Identical styles map to the
-/// same id, so equally styled cells share one synthesized face and one glyph
-/// atlas cache entry; distinct colors/flags never collide.
+/// Carrying them as one value keeps face interning, face attributes, and exact
+/// font replay on the same policy instead of letting independent booleans
+/// drift between those operations.
 #[cfg(feature = "neo-term")]
-fn terminal_cell_face_id(
-    fg: Color,
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TerminalCellStyle {
     bold: bool,
     italic: bool,
     underline: bool,
     strike: bool,
+}
+
+#[cfg(feature = "neo-term")]
+impl TerminalCellStyle {
+    fn from_flags(flags: rio_vt::crosswords::style::StyleFlags) -> Self {
+        use rio_vt::crosswords::style::StyleFlags as CellFlags;
+
+        Self {
+            bold: flags.contains(CellFlags::BOLD),
+            italic: flags.contains(CellFlags::ITALIC),
+            underline: flags.contains(CellFlags::UNDERLINE),
+            strike: flags.contains(CellFlags::STRIKEOUT),
+        }
+    }
+
+    fn packed_bits(self) -> u32 {
+        (self.bold as u32)
+            | ((self.italic as u32) << 1)
+            | ((self.underline as u32) << 2)
+            | ((self.strike as u32) << 3)
+    }
+
+    fn face_attributes(self) -> FaceAttributes {
+        let mut attributes = FaceAttributes::empty();
+        if self.bold {
+            attributes |= FaceAttributes::BOLD;
+        }
+        if self.italic {
+            attributes |= FaceAttributes::ITALIC;
+        }
+        if self.underline {
+            attributes |= FaceAttributes::UNDERLINE;
+        }
+        if self.strike {
+            attributes |= FaceAttributes::STRIKE_THROUGH;
+        }
+        attributes
+    }
+
+    fn font_binding(self, default_font: Option<&ResolvedFont>) -> TerminalFontBinding {
+        let Some(default_font) = default_font else {
+            return TerminalFontBinding::ResolveFromInheritedFamily;
+        };
+        let has_requested_weight = !self.bold || default_font.weight >= 700;
+        let has_requested_slant =
+            !self.italic || !matches!(default_font.slant, FontSlantKind::Normal);
+        if has_requested_weight && has_requested_slant {
+            TerminalFontBinding::Exact(default_font.id)
+        } else {
+            TerminalFontBinding::ResolveFromInheritedFamily
+        }
+    }
+}
+
+/// Whether the renderer may replay the frame's default font identity exactly,
+/// or must resolve the terminal cell's requested style within that family.
+#[cfg(feature = "neo-term")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TerminalFontBinding {
+    Exact(ResolvedFontId),
+    ResolveFromInheritedFamily,
+}
+
+#[cfg(feature = "neo-term")]
+impl TerminalFontBinding {
+    fn exact_id(self) -> Option<ResolvedFontId> {
+        match self {
+            Self::Exact(font_id) => Some(font_id),
+            Self::ResolveFromInheritedFamily => None,
+        }
+    }
+}
+
+/// Deterministic candidate face id for a terminal cell's complete paint key.
+/// Exact float bits include opacity; the expansion's interner resolves the
+/// unavoidable collision risk of fitting that key into the reserved 28 bits.
+#[cfg(feature = "neo-term")]
+fn terminal_cell_face_candidate_id(fg: Color, style: TerminalCellStyle) -> FaceId {
+    let mut hash = 0x811c_9dc5_u32;
+    for word in [
+        fg.r.to_bits(),
+        fg.g.to_bits(),
+        fg.b.to_bits(),
+        fg.a.to_bits(),
+        style.packed_bits(),
+    ] {
+        for byte in word.to_le_bytes() {
+            hash ^= u32::from(byte);
+            hash = hash.wrapping_mul(0x0100_0193);
+        }
+    }
+    FaceId::new(TERMINAL_FACE_ID_BASE | (hash & TERMINAL_FACE_ID_MASK))
+}
+
+#[cfg(feature = "neo-term")]
+fn intern_terminal_cell_face(
+    faces: &mut HashMap<FaceId, Face>,
+    fg: Color,
+    style: TerminalCellStyle,
+    font_size: f32,
+    default_font: Option<&ResolvedFont>,
 ) -> FaceId {
-    let to_u8 = |c: f32| (c.clamp(0.0, 1.0) * 255.0).round() as u32;
-    let rgb = (to_u8(fg.r) << 16) | (to_u8(fg.g) << 8) | to_u8(fg.b);
-    let flags =
-        (bold as u32) | ((italic as u32) << 1) | ((underline as u32) << 2) | ((strike as u32) << 3);
-    FaceId::new(TERMINAL_FACE_ID_BASE | ((rgb << 4) | flags))
+    let mut face_id = terminal_cell_face_candidate_id(fg, style);
+    loop {
+        let face = terminal_cell_face(face_id, fg, style, font_size, default_font);
+        match faces.get(&face_id) {
+            Some(existing) if existing == &face => return face_id,
+            Some(_) => face_id = next_terminal_face_id(face_id),
+            None => {
+                faces.insert(face_id, face);
+                return face_id;
+            }
+        }
+    }
 }
 
 /// Synthesize the `Face` for a terminal cell so that
@@ -894,31 +977,18 @@ fn terminal_cell_face_id(
 fn terminal_cell_face(
     face_id: FaceId,
     fg: Color,
-    bold: bool,
-    italic: bool,
-    underline: bool,
-    strike: bool,
+    style: TerminalCellStyle,
     font_size: f32,
     default_font: Option<&ResolvedFont>,
 ) -> Face {
-    let mut attrs = FaceAttributes::empty();
-    if bold {
-        attrs |= FaceAttributes::BOLD;
-    }
-    if italic {
-        attrs |= FaceAttributes::ITALIC;
-    }
-    if underline {
-        attrs |= FaceAttributes::UNDERLINE;
-    }
-    if strike {
-        attrs |= FaceAttributes::STRIKE_THROUGH;
-    }
-    let underline_style = if underline {
+    let underline_style = if style.underline {
         UnderlineStyle::from_gnu_code(1).unwrap_or_default()
     } else {
         UnderlineStyle::None
     };
+    let font_family = default_font
+        .map(|font| font.family.clone())
+        .unwrap_or_else(|| "monospace".to_string());
     Face {
         id: face_id,
         foreground: fg,
@@ -932,12 +1002,10 @@ fn terminal_cell_face(
         overline_color: None,
         strike_through_color: None,
         box_color: None,
-        font_family: default_font
-            .map(|font| font.family.clone())
-            .unwrap_or_else(|| "monospace".to_string()),
+        font_family: font_family.clone(),
         font_size,
-        font_weight: if bold { 700 } else { 400 },
-        attributes: attrs,
+        font_weight: if style.bold { 700 } else { 400 },
+        attributes: style.face_attributes(),
         underline_style,
         box_type: BoxType::None,
         box_line_width: Default::default(),
@@ -952,14 +1020,10 @@ fn terminal_cell_face(
         underline_thickness: 1,
         background_gradient: None,
         lisp_name: None,
-        default_resolved_font_id: default_font.map(|font| font.id),
+        default_resolved_font_id: style.font_binding(default_font).exact_id(),
         stipple: None,
         underline_placement: neomacs_display_protocol::face::UnderlinePosition::default(),
-        fontset_base_family: Some(
-            default_font
-                .map(|font| font.family.clone())
-                .unwrap_or_else(|| "monospace".to_string()),
-        ),
+        fontset_base_family: Some(font_family),
     }
 }
 
@@ -1107,13 +1171,13 @@ mod tests {
         let font = ResolvedFont {
             id: font_id,
             identity: ResolvedFontIdentity::from_file(
-                "/tmp/terminal-font.ttf",
+                "./target/test-fixtures/terminal-font.ttf",
                 0,
                 Some("TerminalFont".to_string()),
             ),
             replay: FontReplay::Swash {
                 asset: FontOutlineAsset::File(
-                    FontFileAsset::new("/tmp/terminal-font.ttf", 0)
+                    FontFileAsset::new("./target/test-fixtures/terminal-font.ttf", 0)
                         .expect("valid terminal font asset"),
                 ),
             },
@@ -1178,7 +1242,7 @@ mod tests {
         assert_eq!(face.font_family, "Terminal Font");
         assert_eq!(
             face.font_file_path.as_deref(),
-            Some("/tmp/terminal-font.ttf")
+            Some("./target/test-fixtures/terminal-font.ttf")
         );
         assert_eq!((face.font_ascent, face.font_descent), (14, 4));
     }
@@ -1293,3 +1357,7 @@ mod tests {
         ));
     }
 }
+
+#[cfg(test)]
+#[path = "media_test.rs"]
+mod followup_tests;

--- a/neomacs-display-runtime/src/render_thread/media.rs
+++ b/neomacs-display-runtime/src/render_thread/media.rs
@@ -14,6 +14,8 @@ use crate::core::types::{Color, FaceId, Px, Rect};
 #[cfg(any(feature = "neo-term", feature = "webview"))]
 use crate::thread_comm::InputEvent;
 #[cfg(feature = "neo-term")]
+use neomacs_display_protocol::font::ResolvedFont;
+#[cfg(feature = "neo-term")]
 use std::collections::HashMap;
 
 #[cfg(feature = "neo-term")]
@@ -92,6 +94,15 @@ impl RenderApp {
     }
 
     #[cfg(feature = "neo-term")]
+    fn frame_default_resolved_font(frame: &FrameGlyphBuffer) -> Option<&ResolvedFont> {
+        frame
+            .faces
+            .get(&FaceId::new(0))
+            .and_then(|face| face.default_resolved_font_id)
+            .and_then(|font_id| frame.fonts.get(&font_id))
+    }
+
+    #[cfg(feature = "neo-term")]
     fn expanded_terminal_glyphs_for_frame(
         frame: &FrameGlyphBuffer,
         terminal_contents: &HashMap<crate::terminal::TerminalId, crate::terminal::TerminalContent>,
@@ -100,6 +111,7 @@ impl RenderApp {
         let cell_h = frame.char_height;
         let font_size = frame.font_pixel_size;
         let ascent = cell_h * 0.8;
+        let default_font = Self::frame_default_resolved_font(frame);
         let mut extra_glyphs = Vec::new();
         let mut extra_faces = HashMap::new();
 
@@ -150,6 +162,7 @@ impl RenderApp {
                 cell_h,
                 ascent,
                 font_size,
+                default_font,
                 TerminalPaintTarget::DETACHED_TEXT,
                 1.0,
                 &mut extra_glyphs,
@@ -214,6 +227,7 @@ impl RenderApp {
         let cell_w = frame.char_width;
         let cell_h = frame.char_height;
         let ascent = cell_h * 0.8;
+        let default_font = Self::frame_default_resolved_font(frame);
 
         for (id, target) in terminal_targets {
             let crate::terminal::TerminalDisplayTarget::Window { buffer } = target else {
@@ -261,6 +275,7 @@ impl RenderApp {
                     cell_h,
                     ascent,
                     frame.font_pixel_size,
+                    default_font,
                     paint,
                     1.0,
                     &mut glyphs,
@@ -538,14 +553,19 @@ impl RenderApp {
 
         // Get frame font metrics for terminal cell sizing.
         // These come from FRAME_COLUMN_WIDTH / FRAME_LINE_HEIGHT / FRAME_FONT->pixel_size.
-        let (cell_w, cell_h, font_size) = if let Some(frame) = self
+        let (cell_w, cell_h, font_size, default_font) = if let Some(frame) = self
             .frame_windows
             .primary_window()
             .and_then(|ws| ws.render.compositor.current_frame.as_ref())
         {
-            (frame.char_width, frame.char_height, frame.font_pixel_size)
+            (
+                frame.char_width,
+                frame.char_height,
+                frame.font_pixel_size,
+                Self::frame_default_resolved_font(frame).cloned(),
+            )
         } else {
-            (8.0, 16.0, 14.0)
+            (8.0, 16.0, 14.0, None)
         };
         let ascent = cell_h * 0.8;
 
@@ -695,6 +715,7 @@ impl RenderApp {
                         cell_h,
                         ascent,
                         font_size,
+                        default_font.as_ref(),
                         TerminalPaintTarget::FLOATING,
                         view.float_opacity,
                         &mut float_glyphs,
@@ -722,7 +743,9 @@ impl RenderApp {
     /// `faces`, and the glyph references it. The synthesized face uses a
     /// transparent background so no per-character background is painted (the
     /// per-cell stretch above and the terminal's default-background stretch
-    /// supply the background, exactly as when `Char.bg` was `None`).
+    /// supply the background, exactly as when `Char.bg` was `None`). Because
+    /// terminal cell geometry uses the frame's default font metrics, synthesized
+    /// faces also inherit that font's exact render identity.
     #[cfg(feature = "neo-term")]
     fn expand_terminal_cells(
         content: &crate::terminal::content::TerminalContent,
@@ -732,6 +755,7 @@ impl RenderApp {
         cell_h: f32,
         ascent: f32,
         font_size: f32,
+        default_font: Option<&ResolvedFont>,
         paint: TerminalPaintTarget,
         opacity: f32,
         out: &mut Vec<FrameGlyph>,
@@ -777,7 +801,16 @@ impl RenderApp {
                 let strikeout = cell.flags.contains(CellFlags::STRIKEOUT);
                 let face_id = terminal_cell_face_id(fg, bold, italic, underline, strikeout);
                 faces.entry(face_id).or_insert_with(|| {
-                    terminal_cell_face(face_id, fg, bold, italic, underline, strikeout, font_size)
+                    terminal_cell_face(
+                        face_id,
+                        fg,
+                        bold,
+                        italic,
+                        underline,
+                        strikeout,
+                        font_size,
+                        default_font,
+                    )
                 });
                 out.push(FrameGlyph::Char {
                     window_id: paint.window_id,
@@ -865,6 +898,7 @@ fn terminal_cell_face(
     underline: bool,
     strike: bool,
     font_size: f32,
+    default_font: Option<&ResolvedFont>,
 ) -> Face {
     let mut attrs = FaceAttributes::empty();
     if bold {
@@ -897,7 +931,9 @@ fn terminal_cell_face(
         overline_color: None,
         strike_through_color: None,
         box_color: None,
-        font_family: "monospace".to_string(),
+        font_family: default_font
+            .map(|font| font.family.clone())
+            .unwrap_or_else(|| "monospace".to_string()),
         font_size,
         font_weight: if bold { 700 } else { 400 },
         attributes: attrs,
@@ -908,17 +944,21 @@ fn terminal_cell_face(
         box_border_style: neomacs_display_protocol::face::BoxBorderStyle::Solid,
         box_border_speed: 1.0,
         box_color2: None,
-        font_file_path: None,
-        font_ascent: 0,
-        font_descent: 0,
+        font_file_path: default_font.and_then(|font| font.identity.file_path.clone()),
+        font_ascent: default_font.map_or(0, |font| font.ascent_px.round() as i32),
+        font_descent: default_font.map_or(0, |font| font.descent_px.round() as i32),
         underline_position: 1,
         underline_thickness: 1,
         background_gradient: None,
         lisp_name: None,
-        default_resolved_font_id: None,
+        default_resolved_font_id: default_font.map(|font| font.id),
         stipple: None,
         underline_placement: neomacs_display_protocol::face::UnderlinePosition::default(),
-        fontset_base_family: Some("monospace".to_string()),
+        fontset_base_family: Some(
+            default_font
+                .map(|font| font.family.clone())
+                .unwrap_or_else(|| "monospace".to_string()),
+        ),
     }
 }
 
@@ -1049,6 +1089,92 @@ mod tests {
         assert_eq!(*width, 10.0);
         assert_eq!(*height, 20.0);
         assert_eq!(faces.get(face_id).expect("terminal face").font_size, 18.0);
+    }
+
+    #[test]
+    fn terminal_glyph_expansion_inherits_frame_font_identity() {
+        use neomacs_display_protocol::font::{
+            FontReplay, FontResolutionSource, FontSlantKind, ResolvedFont, ResolvedFontAdvance,
+            ResolvedFontId, ResolvedFontIdentity,
+        };
+
+        let mut frame = FrameGlyphBuffer::with_size(120.0, 80.0);
+        frame.char_width = 10.0;
+        frame.char_height = 20.0;
+        frame.font_pixel_size = 18.0;
+        let font_id = ResolvedFontId(42);
+        let font = ResolvedFont {
+            id: font_id,
+            identity: ResolvedFontIdentity::from_file(
+                "/tmp/terminal-font.ttf",
+                0,
+                Some("TerminalFont".to_string()),
+            ),
+            replay: FontReplay::Swash,
+            family: "Terminal Font".to_string(),
+            full_name: Some("Terminal Font Regular".to_string()),
+            postscript_name: Some("TerminalFont".to_string()),
+            weight: 400,
+            slant: FontSlantKind::Normal,
+            width: 5,
+            pixel_size: 18.0,
+            ascent_px: 14.0,
+            descent_px: 4.0,
+            space_advance_px: 10.0,
+            glyph_advance: ResolvedFontAdvance::fixed_cell(10.0),
+            source: FontResolutionSource::FacePrimary,
+        };
+        let mut default_face = Face::new(FaceId::new(0));
+        default_face.default_resolved_font_id = Some(font_id);
+        frame.faces.insert(default_face.id, default_face);
+        frame.fonts.insert(font_id, font);
+        frame.glyphs.push(FrameGlyph::Terminal {
+            terminal_id: 7,
+            x: 30.0,
+            y: 40.0,
+            width: 50.0,
+            height: 20.0,
+        });
+        let contents = HashMap::from([(
+            crate::terminal::TerminalId::new(7).expect("nonzero terminal id"),
+            TerminalContent {
+                cells: vec![RenderCell {
+                    col: 0,
+                    row: 0,
+                    c: 'x',
+                    fg: Color::WHITE,
+                    bg: Color::BLACK,
+                    flags: CellFlags::empty(),
+                }],
+                cols: 1,
+                rows: 1,
+                cursor: RenderCursor {
+                    col: 0,
+                    row: 0,
+                    visible: false,
+                },
+                default_bg: Color::BLACK,
+                default_fg: Color::WHITE,
+            },
+        )]);
+
+        let (glyphs, faces) = RenderApp::expanded_terminal_glyphs_for_frame(&frame, &contents);
+        let face_id = glyphs
+            .iter()
+            .find_map(|glyph| match glyph {
+                FrameGlyph::Char { face_id, .. } => Some(*face_id),
+                _ => None,
+            })
+            .expect("terminal char face");
+        let face = faces.get(&face_id).expect("synthesized terminal face");
+
+        assert_eq!(face.default_resolved_font_id, Some(font_id));
+        assert_eq!(face.font_family, "Terminal Font");
+        assert_eq!(
+            face.font_file_path.as_deref(),
+            Some("/tmp/terminal-font.ttf")
+        );
+        assert_eq!((face.font_ascent, face.font_descent), (14, 4));
     }
 
     #[test]

--- a/neomacs-display-runtime/src/render_thread/media.rs
+++ b/neomacs-display-runtime/src/render_thread/media.rs
@@ -169,6 +169,7 @@ impl RenderApp {
     #[cfg(feature = "neo-term")]
     fn terminal_expansion_for_frame(
         frame: &FrameGlyphBuffer,
+        ordered_terminal_ids: &[crate::terminal::TerminalId],
         terminal_contents: &HashMap<crate::terminal::TerminalId, crate::terminal::TerminalContent>,
         terminal_targets: &HashMap<
             crate::terminal::TerminalId,
@@ -177,8 +178,12 @@ impl RenderApp {
     ) -> TerminalExpansion {
         let (extra_glyphs, extra_faces) =
             Self::expanded_terminal_glyphs_for_frame(frame, terminal_contents);
-        let (window_glyphs, window_faces) =
-            Self::expanded_window_terminals_for_frame(frame, terminal_contents, terminal_targets);
+        let (window_glyphs, window_faces) = Self::expanded_window_terminals_for_frame(
+            frame,
+            ordered_terminal_ids,
+            terminal_contents,
+            terminal_targets,
+        );
         let mut expansion = TerminalExpansion::new(extra_glyphs, extra_faces);
         expansion.merge(TerminalExpansion::new(window_glyphs, window_faces));
         expansion
@@ -206,6 +211,7 @@ impl RenderApp {
     #[cfg(feature = "neo-term")]
     fn expanded_window_terminals_for_frame(
         frame: &FrameGlyphBuffer,
+        ordered_terminal_ids: &[crate::terminal::TerminalId],
         terminal_contents: &HashMap<crate::terminal::TerminalId, crate::terminal::TerminalContent>,
         terminal_targets: &HashMap<
             crate::terminal::TerminalId,
@@ -219,9 +225,10 @@ impl RenderApp {
         let ascent = cell_h * 0.8;
         let default_font = frame.default_resolved_font();
 
-        let mut ordered_targets: Vec<_> = terminal_targets.iter().collect();
-        ordered_targets.sort_unstable_by_key(|(id, _)| id.get());
-        for (id, target) in ordered_targets {
+        for id in ordered_terminal_ids {
+            let Some(target) = terminal_targets.get(id) else {
+                continue;
+            };
             let crate::terminal::TerminalDisplayTarget::Window { buffer } = target else {
                 continue;
             };
@@ -587,7 +594,11 @@ impl RenderApp {
                         .or_insert(layout);
                 }
             });
-        for id in self.terminal_manager.ids() {
+        // One stable identity snapshot drives the complete update. This keeps
+        // independently-built terminal layers deterministic without allocating
+        // and sorting the manager's HashMap keys for every phase below.
+        let terminal_ids = self.terminal_manager.ids();
+        for &id in &terminal_ids {
             let Some(view) = self.terminal_manager.get_mut(id) else {
                 continue;
             };
@@ -616,7 +627,7 @@ impl RenderApp {
         self.terminal_manager.update_all();
 
         // Check for exited terminals and notify Emacs
-        for id in self.terminal_manager.ids() {
+        for &id in &terminal_ids {
             if let Some(view) = self.terminal_manager.get_mut(id)
                 && view.event_proxy.is_exited()
                 && !view.exit_notified
@@ -625,7 +636,7 @@ impl RenderApp {
                 self.comms.send_input(InputEvent::TerminalExited { id });
             }
         }
-        for id in self.terminal_manager.ids() {
+        for &id in &terminal_ids {
             if let Some(title) = self
                 .terminal_manager
                 .get(id)
@@ -636,27 +647,25 @@ impl RenderApp {
             }
         }
 
-        let terminal_contents: HashMap<_, _> = self
-            .terminal_manager
-            .ids()
-            .into_iter()
+        let terminal_contents: HashMap<_, _> = terminal_ids
+            .iter()
+            .copied()
             .filter_map(|id| {
                 self.terminal_manager
                     .get(id)
                     .and_then(|view| view.content().map(|content| (id, content.clone())))
             })
             .collect();
-        let terminal_targets: HashMap<_, _> = self
-            .terminal_manager
-            .ids()
-            .into_iter()
+        let terminal_targets: HashMap<_, _> = terminal_ids
+            .iter()
+            .copied()
             .filter_map(|id| self.terminal_manager.get(id).map(|view| (id, view.target)))
             .collect();
 
         // Render floating terminals
         let mut float_glyphs = Vec::new();
         let mut float_faces = HashMap::new();
-        for id in self.terminal_manager.ids() {
+        for &id in &terminal_ids {
             if let Some(view) = self.terminal_manager.get(id) {
                 if view.target != TerminalDisplayTarget::Floating {
                     continue;
@@ -720,6 +729,7 @@ impl RenderApp {
                     .map(|frame| {
                         Self::terminal_expansion_for_frame(
                             frame,
+                            &terminal_ids,
                             &terminal_contents,
                             &terminal_targets,
                         )
@@ -1157,97 +1167,6 @@ mod tests {
     }
 
     #[test]
-    fn terminal_glyph_expansion_inherits_frame_font_identity() {
-        use neomacs_display_protocol::font::{
-            FontFileAsset, FontOutlineAsset, FontReplay, FontResolutionSource, FontSlantKind,
-            ResolvedFont, ResolvedFontAdvance, ResolvedFontId, ResolvedFontIdentity,
-        };
-
-        let mut frame = FrameGlyphBuffer::with_size(120.0, 80.0);
-        frame.char_width = 10.0;
-        frame.char_height = 20.0;
-        frame.font_pixel_size = 18.0;
-        let font_id = ResolvedFontId(42);
-        let font = ResolvedFont {
-            id: font_id,
-            identity: ResolvedFontIdentity::from_file(
-                "./target/test-fixtures/terminal-font.ttf",
-                0,
-                Some("TerminalFont".to_string()),
-            ),
-            replay: FontReplay::Swash {
-                asset: FontOutlineAsset::File(
-                    FontFileAsset::new("./target/test-fixtures/terminal-font.ttf", 0)
-                        .expect("valid terminal font asset"),
-                ),
-            },
-            family: "Terminal Font".to_string(),
-            full_name: Some("Terminal Font Regular".to_string()),
-            postscript_name: Some("TerminalFont".to_string()),
-            weight: 400,
-            slant: FontSlantKind::Normal,
-            width: 5,
-            pixel_size: 18.0,
-            ascent_px: 14.0,
-            descent_px: 4.0,
-            space_advance_px: 10.0,
-            glyph_advance: ResolvedFontAdvance::fixed_cell(10.0),
-            source: FontResolutionSource::FacePrimary,
-        };
-        let mut default_face = Face::new(FaceId::new(0));
-        default_face.default_resolved_font_id = Some(font_id);
-        frame.faces.insert(default_face.id, default_face);
-        frame.fonts.insert(font_id, font);
-        frame.glyphs.push(FrameGlyph::Terminal {
-            terminal_id: 7,
-            x: 30.0,
-            y: 40.0,
-            width: 50.0,
-            height: 20.0,
-        });
-        let contents = HashMap::from([(
-            crate::terminal::TerminalId::new(7).expect("nonzero terminal id"),
-            TerminalContent {
-                cells: vec![RenderCell {
-                    col: 0,
-                    row: 0,
-                    c: 'x',
-                    fg: Color::WHITE,
-                    bg: Color::BLACK,
-                    flags: CellFlags::empty(),
-                }],
-                cols: 1,
-                rows: 1,
-                cursor: RenderCursor {
-                    col: 0,
-                    row: 0,
-                    visible: false,
-                },
-                default_bg: Color::BLACK,
-                default_fg: Color::WHITE,
-            },
-        )]);
-
-        let (glyphs, faces) = RenderApp::expanded_terminal_glyphs_for_frame(&frame, &contents);
-        let face_id = glyphs
-            .iter()
-            .find_map(|glyph| match glyph {
-                FrameGlyph::Char { face_id, .. } => Some(*face_id),
-                _ => None,
-            })
-            .expect("terminal char face");
-        let face = faces.get(&face_id).expect("synthesized terminal face");
-
-        assert_eq!(face.default_resolved_font_id, Some(font_id));
-        assert_eq!(face.font_family, "Terminal Font");
-        assert_eq!(
-            face.font_file_path.as_deref(),
-            Some("./target/test-fixtures/terminal-font.ttf")
-        );
-        assert_eq!((face.font_ascent, face.font_descent), (14, 4));
-    }
-
-    #[test]
     fn terminal_glyph_expansion_ignores_missing_terminal_content() {
         let mut frame = FrameGlyphBuffer::with_size(120.0, 80.0);
         frame.glyphs.push(FrameGlyph::Terminal {
@@ -1335,7 +1254,7 @@ mod tests {
         )]);
 
         let (glyphs, _) =
-            RenderApp::expanded_window_terminals_for_frame(&frame, &contents, &targets);
+            RenderApp::expanded_window_terminals_for_frame(&frame, &[id], &contents, &targets);
 
         assert_eq!(glyphs.len(), 1);
         assert!(matches!(

--- a/neomacs-display-runtime/src/render_thread/media_test.rs
+++ b/neomacs-display-runtime/src/render_thread/media_test.rs
@@ -141,6 +141,20 @@ fn terminal_cell_replays_an_exact_font_that_already_satisfies_its_style() {
 
 #[cfg(feature = "neo-term")]
 #[test]
+fn terminal_glyph_expansion_inherits_frame_font_identity() {
+    let face = terminal_face_for_flags(CellFlags::empty());
+
+    assert_eq!(face.default_resolved_font_id, Some(ResolvedFontId(42)));
+    assert_eq!(face.font_family, "Terminal Font");
+    assert_eq!(
+        face.font_file_path.as_deref(),
+        Some("/test-fixtures/terminal-font.ttf")
+    );
+    assert_eq!((face.font_ascent, face.font_descent), (14, 4));
+}
+
+#[cfg(feature = "neo-term")]
+#[test]
 fn terminal_face_interning_keeps_distinct_opacity_faces_distinct() {
     let content = TerminalContent {
         cells: vec![RenderCell {

--- a/neomacs-display-runtime/src/render_thread/media_test.rs
+++ b/neomacs-display-runtime/src/render_thread/media_test.rs
@@ -1,0 +1,205 @@
+use super::*;
+
+#[cfg(feature = "neo-term")]
+use crate::terminal::content::{RenderCell, RenderCursor, TerminalContent};
+#[cfg(feature = "neo-term")]
+use neomacs_display_protocol::font::{
+    FontFileAsset, FontOutlineAsset, FontReplay, FontResolutionSource, FontSlantKind, ResolvedFont,
+    ResolvedFontAdvance, ResolvedFontId, ResolvedFontIdentity,
+};
+#[cfg(feature = "neo-term")]
+use rio_vt::crosswords::style::StyleFlags as CellFlags;
+
+#[cfg(feature = "neo-term")]
+fn terminal_face_for_flags_and_font(
+    flags: CellFlags,
+    font_weight: u16,
+    font_slant: FontSlantKind,
+) -> Face {
+    let mut frame = FrameGlyphBuffer::with_size(120.0, 80.0);
+    frame.char_width = 10.0;
+    frame.char_height = 20.0;
+    frame.font_pixel_size = 18.0;
+    let font_id = ResolvedFontId(42);
+    let font_path = "/test-fixtures/terminal-font.ttf";
+    let font = ResolvedFont {
+        id: font_id,
+        identity: ResolvedFontIdentity::from_file(font_path, 0, Some("TerminalFont".to_string())),
+        replay: FontReplay::Swash {
+            asset: FontOutlineAsset::File(
+                FontFileAsset::new(font_path, 0).expect("valid terminal font asset"),
+            ),
+        },
+        family: "Terminal Font".to_string(),
+        full_name: Some("Terminal Font Regular".to_string()),
+        postscript_name: Some("TerminalFont".to_string()),
+        weight: font_weight,
+        slant: font_slant,
+        width: 5,
+        pixel_size: 18.0,
+        ascent_px: 14.0,
+        descent_px: 4.0,
+        space_advance_px: 10.0,
+        glyph_advance: ResolvedFontAdvance::fixed_cell(10.0),
+        source: FontResolutionSource::FacePrimary,
+    };
+    let mut default_face = Face::new(FaceId::new(0));
+    default_face.default_resolved_font_id = Some(font_id);
+    frame.faces.insert(default_face.id, default_face);
+    frame.fonts.insert(font_id, font);
+    frame.glyphs.push(FrameGlyph::Terminal {
+        terminal_id: 7,
+        x: 30.0,
+        y: 40.0,
+        width: 50.0,
+        height: 20.0,
+    });
+    let contents = HashMap::from([(
+        crate::terminal::TerminalId::new(7).expect("nonzero terminal id"),
+        TerminalContent {
+            cells: vec![RenderCell {
+                col: 0,
+                row: 0,
+                c: 'x',
+                fg: Color::WHITE,
+                bg: Color::BLACK,
+                flags,
+            }],
+            cols: 1,
+            rows: 1,
+            cursor: RenderCursor {
+                col: 0,
+                row: 0,
+                visible: false,
+            },
+            default_bg: Color::BLACK,
+            default_fg: Color::WHITE,
+        },
+    )]);
+
+    let (glyphs, faces) = RenderApp::expanded_terminal_glyphs_for_frame(&frame, &contents);
+    let face_id = glyphs
+        .iter()
+        .find_map(|glyph| match glyph {
+            FrameGlyph::Char { face_id, .. } => Some(*face_id),
+            _ => None,
+        })
+        .expect("terminal char face");
+    faces
+        .get(&face_id)
+        .expect("synthesized terminal face")
+        .clone()
+}
+
+#[cfg(feature = "neo-term")]
+fn terminal_face_for_flags(flags: CellFlags) -> Face {
+    terminal_face_for_flags_and_font(flags, 400, FontSlantKind::Normal)
+}
+
+#[cfg(feature = "neo-term")]
+#[test]
+fn bold_terminal_cell_does_not_replay_the_regular_font_as_exact() {
+    let face = terminal_face_for_flags(CellFlags::BOLD);
+
+    assert_eq!(face.default_resolved_font_id, None);
+    assert_eq!(face.font_weight, 700);
+    assert_eq!(face.font_family, "Terminal Font");
+    assert_eq!(
+        face.font_file_path.as_deref(),
+        Some("/test-fixtures/terminal-font.ttf")
+    );
+    assert_eq!((face.font_ascent, face.font_descent), (14, 4));
+}
+
+#[cfg(feature = "neo-term")]
+#[test]
+fn italic_terminal_cell_does_not_replay_the_upright_font_as_exact() {
+    let face = terminal_face_for_flags(CellFlags::ITALIC);
+
+    assert_eq!(face.default_resolved_font_id, None);
+    assert!(face.attributes.contains(FaceAttributes::ITALIC));
+    assert_eq!(face.font_family, "Terminal Font");
+    assert_eq!(
+        face.font_file_path.as_deref(),
+        Some("/test-fixtures/terminal-font.ttf")
+    );
+}
+
+#[cfg(feature = "neo-term")]
+#[test]
+fn terminal_cell_replays_an_exact_font_that_already_satisfies_its_style() {
+    let face = terminal_face_for_flags_and_font(
+        CellFlags::BOLD | CellFlags::ITALIC,
+        700,
+        FontSlantKind::Italic,
+    );
+
+    assert_eq!(face.default_resolved_font_id, Some(ResolvedFontId(42)));
+    assert_eq!(face.font_weight, 700);
+    assert!(face.attributes.contains(FaceAttributes::ITALIC));
+}
+
+#[cfg(feature = "neo-term")]
+#[test]
+fn terminal_face_interning_keeps_distinct_opacity_faces_distinct() {
+    let content = TerminalContent {
+        cells: vec![RenderCell {
+            col: 0,
+            row: 0,
+            c: 'x',
+            fg: Color::WHITE,
+            bg: Color::BLACK,
+            flags: CellFlags::empty(),
+        }],
+        cols: 1,
+        rows: 1,
+        cursor: RenderCursor {
+            col: 0,
+            row: 0,
+            visible: false,
+        },
+        default_bg: Color::BLACK,
+        default_fg: Color::WHITE,
+    };
+    let mut glyphs = Vec::new();
+    let mut faces = HashMap::new();
+
+    RenderApp::expand_terminal_cells(
+        &content,
+        0.0,
+        0.0,
+        10.0,
+        20.0,
+        14.0,
+        18.0,
+        None,
+        TerminalPaintTarget::DETACHED_TEXT,
+        1.0,
+        &mut glyphs,
+        &mut faces,
+    );
+    RenderApp::expand_terminal_cells(
+        &content,
+        20.0,
+        0.0,
+        10.0,
+        20.0,
+        14.0,
+        18.0,
+        None,
+        TerminalPaintTarget::DETACHED_TEXT,
+        0.5,
+        &mut glyphs,
+        &mut faces,
+    );
+
+    let face_ids: Vec<_> = glyphs
+        .iter()
+        .filter_map(FrameGlyph::face_id)
+        .filter(|face_id| face_id.get() >= TERMINAL_FACE_ID_BASE)
+        .collect();
+    assert_eq!(face_ids.len(), 2);
+    assert_ne!(face_ids[0], face_ids[1]);
+    assert_eq!(faces[&face_ids[0]].foreground.a, 1.0);
+    assert_eq!(faces[&face_ids[1]].foreground.a, 0.5);
+}

--- a/neomacs-display-runtime/src/render_thread/mod.rs
+++ b/neomacs-display-runtime/src/render_thread/mod.rs
@@ -24,6 +24,8 @@ mod render_quality;
 mod state;
 mod surface_readback;
 mod terminal_commands;
+#[cfg(feature = "neo-term")]
+mod terminal_expansion;
 #[cfg(test)]
 mod tests;
 mod thread_handle;

--- a/neomacs-display-runtime/src/render_thread/render_pass.rs
+++ b/neomacs-display-runtime/src/render_thread/render_pass.rs
@@ -653,7 +653,7 @@ impl RenderApp {
             && std::env::var_os("NEOMACS_DISABLE_RETAINED_STATIC").is_none()
         {
             let mouse_pos = render.mouse_pos;
-            let generation = render.compositor.current_frame_ingest_seq;
+            let generation = render.compositor.current_scene_generation;
             let retained_valid = matches!(
                 &render.compositor.retained_static,
                 Some(rs) if rs.generation == generation

--- a/neomacs-display-runtime/src/render_thread/terminal_commands.rs
+++ b/neomacs-display-runtime/src/render_thread/terminal_commands.rs
@@ -8,6 +8,15 @@ use crate::thread_comm::TerminalCommand;
 
 #[cfg(feature = "neo-term")]
 impl RenderApp {
+    /// Schedule one render-preparation pass for renderer-owned terminal state.
+    ///
+    /// PTY wakeups normally provide this demand through `has_terminal_activity`,
+    /// but commands which remove a view or only change its compositor placement
+    /// cannot rely on a view-local dirty bit: the view may already be gone.
+    fn invalidate_terminal_scene(&mut self) {
+        self.frame_windows.mark_top_level_dirty();
+    }
+
     pub(super) fn handle_terminal(&mut self, cmd: TerminalCommand) {
         match cmd {
             TerminalCommand::TerminalCreate {
@@ -53,28 +62,45 @@ impl RenderApp {
                     view.resize(size);
                 }
             }
-            TerminalCommand::TerminalDestroy { id } => match self.terminal_manager.destroy(id) {
-                Ok(true) => {
-                    self.shared_terminals.complete_destroy(id);
-                    tracing::info!("Terminal {} destroyed", id);
+            TerminalCommand::TerminalDestroy { id } => {
+                let was_present = self.terminal_manager.get(id).is_some();
+                let result = self.terminal_manager.destroy(id);
+                if was_present {
+                    // `destroy` removes the view before shutting its PTY down,
+                    // including on teardown failure. Ensure the retained scene
+                    // is rebuilt from the manager's new authoritative state.
+                    self.invalidate_terminal_scene();
                 }
-                Ok(false) => {
-                    self.shared_terminals.complete_destroy(id);
-                    tracing::debug!("Terminal {} was already absent", id);
+                match result {
+                    Ok(true) => {
+                        self.shared_terminals.complete_destroy(id);
+                        tracing::info!("Terminal {} destroyed", id);
+                    }
+                    Ok(false) => {
+                        self.shared_terminals.complete_destroy(id);
+                        tracing::debug!("Terminal {} was already absent", id);
+                    }
+                    Err(error) => {
+                        self.shared_terminals
+                            .mark_destroy_failed(id, format!("teardown failed: {error}"));
+                        tracing::error!("Terminal {} teardown failed: {}", id, error);
+                    }
                 }
-                Err(error) => {
-                    self.shared_terminals
-                        .mark_destroy_failed(id, format!("teardown failed: {error}"));
-                    tracing::error!("Terminal {} teardown failed: {}", id, error);
-                }
-            },
+            }
             TerminalCommand::TerminalSetFloat { id, placement } => {
                 if let Some(view) = self.terminal_manager.get_mut(id) {
-                    view.float_x = placement.x();
-                    view.float_y = placement.y();
-                    view.float_opacity = placement.opacity();
+                    let next = (placement.x(), placement.y(), placement.opacity());
+                    let changed = (view.float_x, view.float_y, view.float_opacity) != next;
+                    if changed {
+                        (view.float_x, view.float_y, view.float_opacity) = next;
+                        self.invalidate_terminal_scene();
+                    }
                 }
             }
         }
     }
 }
+
+#[cfg(all(test, feature = "neo-term"))]
+#[path = "terminal_commands_test.rs"]
+mod tests;

--- a/neomacs-display-runtime/src/render_thread/terminal_commands_test.rs
+++ b/neomacs-display-runtime/src/render_thread/terminal_commands_test.rs
@@ -1,0 +1,100 @@
+use super::*;
+use crate::core::frame_glyphs::{FrameGlyph, FrameGlyphBuffer, GlyphRowRole};
+use crate::core::types::{Color, DisplayWindowId};
+use crate::render_thread::terminal_expansion::TerminalExpansion;
+use crate::terminal::{
+    TerminalDisplayTarget, TerminalFloatPlacement, TerminalGridSize, TerminalId, TerminalView,
+};
+use crate::thread_comm::ThreadComms;
+use std::sync::{Arc, Mutex};
+
+fn make_test_app() -> RenderApp {
+    let comms = ThreadComms::new();
+    let (_emacs, render) = comms.split();
+    RenderApp::new(
+        render,
+        800,
+        600,
+        "test".to_owned(),
+        Arc::new(crate::render_thread::ImageRenderState::default()),
+        Arc::new((Mutex::new(Vec::new()), std::sync::Condvar::new())),
+        true,
+        crate::terminal::new_shared_terminals(),
+    )
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn terminal_scene_commands_schedule_repositioning_and_final_removal() {
+    let mut app = make_test_app();
+    let id = TerminalId::new(71).expect("nonzero terminal id");
+    let size = TerminalGridSize::new(20, 5).expect("positive terminal grid");
+    let view = TerminalView::new(id, size, TerminalDisplayTarget::Floating, Some("/bin/sh"))
+        .expect("create real PTY shell");
+    app.terminal_manager.terminals.insert(id, view);
+
+    let primary = app
+        .frame_windows
+        .primary_window_mut()
+        .expect("test app has a primary window");
+    primary
+        .render
+        .set_current_frame(Some(FrameGlyphBuffer::with_size(800.0, 600.0)), None);
+    let retained_terminal_glyph = FrameGlyph::Border {
+        window_id: DisplayWindowId::new(0),
+        row_role: GlyphRowRole::ModeLine,
+        clip_rect: None,
+        x: 10.0,
+        y: 10.0,
+        width: 100.0,
+        height: 50.0,
+        color: Color::WHITE,
+    };
+    let _ = primary
+        .render
+        .replace_terminal_expansion(TerminalExpansion::new(
+            vec![retained_terminal_glyph.clone()],
+            Default::default(),
+        ));
+    primary.render.begin_presentable_render();
+
+    app.handle_terminal(TerminalCommand::TerminalSetFloat {
+        id,
+        placement: TerminalFloatPlacement::new(24.0, 48.0, 0.75).expect("valid terminal placement"),
+    });
+    assert!(
+        app.frame_windows
+            .primary_window()
+            .expect("test app has a primary window")
+            .render
+            .compositor
+            .dirty,
+        "terminal placement changes must schedule their replacement scene"
+    );
+    app.frame_windows
+        .primary_window_mut()
+        .expect("test app has a primary window")
+        .render
+        .begin_presentable_render();
+
+    app.handle_terminal(TerminalCommand::TerminalDestroy { id });
+
+    assert!(
+        app.frame_windows
+            .primary_window()
+            .expect("test app has a primary window")
+            .render
+            .compositor
+            .dirty,
+        "terminal removal must request the repaint that clears its retained layer"
+    );
+    app.prepare_frame_state_for_render();
+    let composed = app
+        .frame_windows
+        .primary_window()
+        .expect("test app has a primary window")
+        .render
+        .current_frame_clone()
+        .expect("composed editor frame");
+    assert!(!composed.glyphs.contains(&retained_terminal_glyph));
+}

--- a/neomacs-display-runtime/src/render_thread/terminal_expansion.rs
+++ b/neomacs-display-runtime/src/render_thread/terminal_expansion.rs
@@ -95,9 +95,8 @@ pub(super) fn next_terminal_face_id(face_id: FaceId) -> FaceId {
 }
 
 fn remap_generated_glyph_face(glyph: &mut FrameGlyph, remapped: &HashMap<FaceId, FaceId>) {
-    let face_id = match glyph {
-        FrameGlyph::Char { face_id, .. } | FrameGlyph::Stretch { face_id, .. } => face_id,
-        _ => return,
+    let Some(face_id) = glyph.face_id_mut() else {
+        return;
     };
     if let Some(replacement) = remapped.get(face_id) {
         *face_id = *replacement;

--- a/neomacs-display-runtime/src/render_thread/terminal_expansion.rs
+++ b/neomacs-display-runtime/src/render_thread/terminal_expansion.rs
@@ -1,0 +1,123 @@
+//! Renderer-owned NeoTerm glyphs composed over an immutable editor frame.
+
+use crate::core::face::Face;
+use crate::core::frame_glyphs::{FrameGlyph, FrameGlyphBuffer};
+use crate::core::types::FaceId;
+use std::collections::HashMap;
+
+/// Renderer-owned face-id namespace reserved for synthesized terminal faces.
+pub(super) const TERMINAL_FACE_ID_BASE: u32 = 0xF000_0000;
+pub(super) const TERMINAL_FACE_ID_MASK: u32 = 0x0FFF_FFFF;
+
+/// One complete, replaceable NeoTerm contribution to a frame scene.
+///
+/// Keeping this separate from [`FrameGlyphBuffer`] means render preparation
+/// never needs to truncate an editor-owned glyph vector or remember which
+/// face-table entries it injected.  Callers build a complete value and replace
+/// it atomically; composition happens only on the cloned frame sent to wgpu.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(super) struct TerminalExpansion {
+    glyphs: Vec<FrameGlyph>,
+    faces: HashMap<FaceId, Face>,
+}
+
+impl TerminalExpansion {
+    pub(super) fn new(glyphs: Vec<FrameGlyph>, faces: HashMap<FaceId, Face>) -> Self {
+        Self { glyphs, faces }
+    }
+
+    /// Merge another generated layer while preserving a one-to-one mapping
+    /// between face ids and face values.
+    ///
+    /// Independently built layers may choose the same deterministic candidate
+    /// id for different face values. Resolve that collision here and rewrite
+    /// the incoming glyph references before the layers become one scene.
+    pub(super) fn merge(&mut self, mut other: Self) {
+        if self.faces.is_empty() {
+            self.glyphs.extend(other.glyphs);
+            self.faces = other.faces;
+            return;
+        }
+        if other.faces.is_empty() {
+            self.glyphs.extend(other.glyphs);
+            return;
+        }
+        let mut incoming_faces: Vec<_> = other.faces.drain().collect();
+        incoming_faces.sort_unstable_by_key(|(face_id, _)| face_id.get());
+        let mut remapped = HashMap::new();
+
+        for (source_id, mut face) in incoming_faces {
+            let mut target_id = source_id;
+            loop {
+                face.id = target_id;
+                match self.faces.get(&target_id) {
+                    Some(existing) if existing == &face => break,
+                    Some(_) => target_id = next_terminal_face_id(target_id),
+                    None => {
+                        self.faces.insert(target_id, face);
+                        break;
+                    }
+                }
+            }
+            if source_id != target_id {
+                remapped.insert(source_id, target_id);
+            }
+        }
+
+        if !remapped.is_empty() {
+            for glyph in &mut other.glyphs {
+                remap_generated_glyph_face(glyph, &remapped);
+            }
+        }
+        self.glyphs.extend(other.glyphs);
+    }
+
+    pub(super) fn faces(&self) -> &HashMap<FaceId, Face> {
+        &self.faces
+    }
+
+    #[cfg(test)]
+    pub(super) fn glyphs(&self) -> &[FrameGlyph] {
+        &self.glyphs
+    }
+
+    pub(super) fn compose_into(&self, frame: &mut FrameGlyphBuffer) {
+        frame.glyphs.extend(self.glyphs.iter().cloned());
+        frame
+            .faces
+            .extend(self.faces.iter().map(|(id, face)| (*id, face.clone())));
+    }
+}
+
+pub(super) fn next_terminal_face_id(face_id: FaceId) -> FaceId {
+    let offset = face_id.get().wrapping_add(1) & TERMINAL_FACE_ID_MASK;
+    FaceId::new(TERMINAL_FACE_ID_BASE | offset)
+}
+
+fn remap_generated_glyph_face(glyph: &mut FrameGlyph, remapped: &HashMap<FaceId, FaceId>) {
+    let face_id = match glyph {
+        FrameGlyph::Char { face_id, .. } | FrameGlyph::Stretch { face_id, .. } => face_id,
+        _ => return,
+    };
+    if let Some(replacement) = remapped.get(face_id) {
+        *face_id = *replacement;
+    }
+}
+
+/// Observable result of an atomic terminal-expansion replacement.
+#[must_use]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum TerminalExpansionUpdate {
+    /// No editor frame exists to receive the expansion.
+    NoFrame,
+    /// The complete generated contribution was byte-for-byte unchanged.
+    Unchanged,
+    /// The visible scene changed and all dependent render state was invalidated.
+    Replaced,
+    /// A generated face attempted to occupy an editor-owned face slot.
+    FaceIdCollision(FaceId),
+}
+
+#[cfg(test)]
+#[path = "terminal_expansion_test.rs"]
+mod tests;

--- a/neomacs-display-runtime/src/render_thread/terminal_expansion_test.rs
+++ b/neomacs-display-runtime/src/render_thread/terminal_expansion_test.rs
@@ -1,0 +1,52 @@
+use super::*;
+use crate::core::frame_glyphs::{DisplaySlotId, GlyphRowRole};
+use crate::core::types::{Color, DisplayWindowId, Px};
+
+fn generated_char(face_id: FaceId, x: f32) -> FrameGlyph {
+    let window_id = DisplayWindowId::new(1);
+    FrameGlyph::Char {
+        window_id,
+        row_role: GlyphRowRole::Text,
+        clip_rect: None,
+        slot_id: DisplaySlotId::from_pixels(window_id, Px(x), Px(0.0), Px(8.0), Px(16.0)),
+        bidi_level: 0,
+        char: 'x',
+        composed: None,
+        x,
+        y: 0.0,
+        baseline: 12.0,
+        width: 8.0,
+        height: 16.0,
+        ascent: 12.0,
+        face_id,
+        box_vertical_edges: Default::default(),
+    }
+}
+
+#[test]
+fn merge_remaps_a_conflicting_generated_face_and_its_glyphs_together() {
+    let original_id = FaceId::new(TERMINAL_FACE_ID_BASE | 7);
+    let mut opaque = Face::new(original_id);
+    opaque.foreground = Color::WHITE;
+    let mut translucent = Face::new(original_id);
+    translucent.foreground = Color::new(1.0, 1.0, 1.0, 0.5);
+    let mut expansion = TerminalExpansion::new(
+        vec![generated_char(original_id, 0.0)],
+        HashMap::from([(original_id, opaque)]),
+    );
+
+    expansion.merge(TerminalExpansion::new(
+        vec![generated_char(original_id, 8.0)],
+        HashMap::from([(original_id, translucent)]),
+    ));
+
+    let face_ids: Vec<_> = expansion
+        .glyphs()
+        .iter()
+        .filter_map(FrameGlyph::face_id)
+        .collect();
+    assert_eq!(face_ids.len(), 2);
+    assert_ne!(face_ids[0], face_ids[1]);
+    assert_eq!(expansion.faces()[&face_ids[0]].foreground.a, 1.0);
+    assert_eq!(expansion.faces()[&face_ids[1]].foreground.a, 0.5);
+}

--- a/neomacs-display-runtime/src/terminal/view.rs
+++ b/neomacs-display-runtime/src/terminal/view.rs
@@ -479,7 +479,9 @@ impl TerminalManager {
 
     /// Get all terminal IDs.
     pub fn ids(&self) -> Vec<TerminalId> {
-        self.terminals.keys().copied().collect()
+        let mut ids: Vec<_> = self.terminals.keys().copied().collect();
+        ids.sort_unstable_by_key(|id| id.get());
+        ids
     }
 
     /// Number of active terminals.


### PR DESCRIPTION
## Problem

NeoTerm had two related render-state problems:

- synthesized terminal faces did not carry the resolved frame font identity, forcing the renderer to use an emergency monospace fallback that could disagree with the metrics used for terminal cell geometry;
- each render preparation appended another expanded copy of the terminal glyphs and faces to the retained editor frame, causing identical glyph sets and overlap reports to accumulate.

## Solution

Make synthesized terminal faces inherit the frame default font's resolved identity, file, family, and metrics. Track the immutable editor glyph boundary and generated face IDs so the previous terminal expansion is removed before rebuilding it, making repeated render preparation idempotent.
