### PR TITLE
Compare byte-code objects slot-wise in equal and sxhash, like GNU's PVEC_CLOSURE

### DIFF
--- a/crates/neovm-core/src/emacs_core/runtime/bytecode/chunk.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/bytecode/chunk.rs
@@ -122,6 +122,23 @@ fn arglist_value_from_params(params: &LambdaParams) -> Value {
     Value::list(elements)
 }
 
+/// One element of [`ByteCodeFunction::structural_slots`].
+#[derive(Clone, Copy, Debug)]
+pub enum ByteCodeSlot<'a> {
+    /// A Lisp value compared, hashed and keyed as any other.
+    Value(Value),
+    /// The GNU bytecode string, byte-exact.
+    Bytes(&'a [u8]),
+    /// Decoded instructions of a function with no retained GNU bytes.
+    Ops(&'a [Op]),
+    /// The constants vector, element-wise like a Lisp vector.
+    Values(&'a [Value]),
+    /// A docstring, under GNU string equality: characters, bytes, contents.
+    Text(&'a LispString),
+    /// An optional slot that is not there.
+    Absent,
+}
+
 /// A compiled bytecode function.
 #[derive(Debug)]
 pub struct ByteCodeFunction {
@@ -615,6 +632,59 @@ impl ByteCodeFunction {
                 .unwrap_or(0),
             None => self.gnu_byte_offset_map.as_ref().map_or(0, Vec::capacity),
         }
+    }
+
+    /// The structural view of this function: GNU's closure slots, in GNU's
+    /// order, plus the one field GNU keeps inside a slot and this port keeps
+    /// beside it.
+    ///
+    /// GNU's `internal_equal_1` compares a `PVEC_CLOSURE` element-wise
+    /// (src/fns.c:2984-2998 in emacs-31.1) and `sxhash_obj` hashes it through
+    /// `sxhash_vector` (:5525-5536); `equal` hash tables therefore key on the
+    /// same elements.  Neomacs stores those elements in typed fields, so
+    /// `equal`, its fallible twin, `sxhash-equal` and the `equal`-table key
+    /// all read THIS sequence rather than each re-deriving the schema:
+    ///
+    /// | index | GNU slot            | here                                   |
+    /// |-------|---------------------|----------------------------------------|
+    /// | 0     | arglist             | `Value`                                |
+    /// | 1     | bytecode string     | `Bytes`, or `Ops` when none is retained|
+    /// | 2     | constants vector    | `Values`                               |
+    /// | 3     | (inside slot 2)     | captured `env`: `Value`, else `Absent` |
+    /// | 4     | max stack depth     | `Value` (a fixnum)                     |
+    /// | 5     | docstring / form    | `Text`, `Value`, or `Absent`           |
+    /// | 6     | interactive spec    | `Value` or `Absent`                    |
+    /// | 7..   | `&rest ELEMENTS`    | `Value` each                           |
+    ///
+    /// `Absent` is distinct from a present `nil`: `Op::MakeClosure` stores
+    /// `Some(lexenv)`, and a closure over no variables has a present, `nil`
+    /// environment that `(aref FN 2)` reports as `nil` rather than as the
+    /// constants vector.  A function with no retained GNU bytes compares its
+    /// decoded instructions instead, so two functions with different code are
+    /// never equal even though GNU's slot 1 would be `nil` for both.
+    pub(crate) fn structural_slots(&self) -> Vec<ByteCodeSlot<'_>> {
+        let mut slots = Vec::with_capacity(7 + self.extra_slots.len());
+        slots.push(ByteCodeSlot::Value(self.arglist));
+        slots.push(match &self.gnu_bytecode_bytes {
+            Some(bytes) => ByteCodeSlot::Bytes(bytes.as_slice()),
+            None => ByteCodeSlot::Ops(&self.ops),
+        });
+        slots.push(ByteCodeSlot::Values(self.constants.as_slice()));
+        slots.push(self.env.map_or(ByteCodeSlot::Absent, ByteCodeSlot::Value));
+        slots.push(ByteCodeSlot::Value(Value::fixnum(i64::from(
+            self.max_stack,
+        ))));
+        slots.push(match (self.doc_form, &self.docstring) {
+            (Some(form), _) => ByteCodeSlot::Value(form),
+            (None, Some(doc)) => ByteCodeSlot::Text(doc),
+            (None, None) => ByteCodeSlot::Absent,
+        });
+        slots.push(
+            self.interactive
+                .map_or(ByteCodeSlot::Absent, ByteCodeSlot::Value),
+        );
+        slots.extend(self.extra_slots.iter().copied().map(ByteCodeSlot::Value));
+        slots
     }
 
     pub fn observable_closure_slot_count(&self) -> usize {

--- a/crates/neovm-core/src/emacs_core/runtime/bytecode/chunk.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/bytecode/chunk.rs
@@ -122,9 +122,18 @@ fn arglist_value_from_params(params: &LambdaParams) -> Value {
     Value::list(elements)
 }
 
-/// One element of [`ByteCodeFunction::structural_slots`].
+/// One piece of evidence used for structural byte-code equality and hashing.
+///
+/// This is deliberately named a "part", not a GNU closure "slot": Neomacs
+/// keeps some execution state (notably the captured environment) beside the
+/// GNU-compatible slot projection.  Consumers must compare that state too,
+/// because it affects execution even when it has no independently observable
+/// GNU slot.
 #[derive(Clone, Copy, Debug)]
-pub enum ByteCodeSlot<'a> {
+pub enum ByteCodeStructuralPart<'a> {
+    /// GNU's observable pseudovector size.  Keeping shape in the sequence
+    /// makes it impossible for a consumer to forget the `ASIZE` comparison.
+    ObservableSlotCount(usize),
     /// A Lisp value compared, hashed and keyed as any other.
     Value(Value),
     /// The GNU bytecode string, byte-exact.
@@ -135,9 +144,36 @@ pub enum ByteCodeSlot<'a> {
     Values(&'a [Value]),
     /// A docstring, under GNU string equality: characters, bytes, contents.
     Text(&'a LispString),
-    /// An optional slot that is not there.
+    /// An optional structural part that is not present.
     Absent,
 }
+
+/// Allocation-free iterator over a byte-code function's structural evidence.
+pub(crate) struct ByteCodeStructuralParts<'a> {
+    fixed: std::array::IntoIter<ByteCodeStructuralPart<'a>, 8>,
+    extras: std::slice::Iter<'a, Value>,
+}
+
+impl<'a> Iterator for ByteCodeStructuralParts<'a> {
+    type Item = ByteCodeStructuralPart<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.fixed.next().or_else(|| {
+            self.extras
+                .next()
+                .copied()
+                .map(ByteCodeStructuralPart::Value)
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.fixed.len() + self.extras.len();
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for ByteCodeStructuralParts<'_> {}
+impl std::iter::FusedIterator for ByteCodeStructuralParts<'_> {}
 
 /// A compiled bytecode function.
 #[derive(Debug)]
@@ -634,9 +670,9 @@ impl ByteCodeFunction {
         }
     }
 
-    /// The structural view of this function: GNU's closure slots, in GNU's
-    /// order, plus the one field GNU keeps inside a slot and this port keeps
-    /// beside it.
+    /// The structural evidence for this function: GNU's observable shape and
+    /// closure slots, in GNU's order, plus the environment this port keeps
+    /// beside the constants vector.
     ///
     /// GNU's `internal_equal_1` compares a `PVEC_CLOSURE` element-wise
     /// (src/fns.c:2984-2998 in emacs-31.1) and `sxhash_obj` hashes it through
@@ -645,16 +681,17 @@ impl ByteCodeFunction {
     /// `equal`, its fallible twin, `sxhash-equal` and the `equal`-table key
     /// all read THIS sequence rather than each re-deriving the schema:
     ///
-    /// | index | GNU slot            | here                                   |
-    /// |-------|---------------------|----------------------------------------|
-    /// | 0     | arglist             | `Value`                                |
-    /// | 1     | bytecode string     | `Bytes`, or `Ops` when none is retained|
-    /// | 2     | constants vector    | `Values`                               |
-    /// | 3     | (inside slot 2)     | captured `env`: `Value`, else `Absent` |
-    /// | 4     | max stack depth     | `Value` (a fixnum)                     |
-    /// | 5     | docstring / form    | `Text`, `Value`, or `Absent`           |
-    /// | 6     | interactive spec    | `Value` or `Absent`                    |
-    /// | 7..   | `&rest ELEMENTS`    | `Value` each                           |
+    /// | part | GNU representation  | Neomacs structural evidence             |
+    /// |------|---------------------|------------------------------------------|
+    /// | 0    | pseudovector ASIZE  | `ObservableSlotCount`                    |
+    /// | 1    | arglist             | `Value`                                  |
+    /// | 2    | bytecode string     | `Bytes`, or `Ops` when none is retained  |
+    /// | 3    | constants vector    | `Values`                                 |
+    /// | 4    | inside constants    | captured `env`: `Value`, else `Absent`   |
+    /// | 5    | max stack depth     | `Value` (a fixnum)                       |
+    /// | 6    | docstring / form    | `Text`, `Value`, or `Absent`             |
+    /// | 7    | interactive spec    | `Value` or `Absent`                      |
+    /// | 8..  | `&rest ELEMENTS`    | `Value` each                             |
     ///
     /// `Absent` is distinct from a present `nil`: `Op::MakeClosure` stores
     /// `Some(lexenv)`, and a closure over no variables has a present, `nil`
@@ -662,29 +699,30 @@ impl ByteCodeFunction {
     /// constants vector.  A function with no retained GNU bytes compares its
     /// decoded instructions instead, so two functions with different code are
     /// never equal even though GNU's slot 1 would be `nil` for both.
-    pub(crate) fn structural_slots(&self) -> Vec<ByteCodeSlot<'_>> {
-        let mut slots = Vec::with_capacity(7 + self.extra_slots.len());
-        slots.push(ByteCodeSlot::Value(self.arglist));
-        slots.push(match &self.gnu_bytecode_bytes {
-            Some(bytes) => ByteCodeSlot::Bytes(bytes.as_slice()),
-            None => ByteCodeSlot::Ops(&self.ops),
-        });
-        slots.push(ByteCodeSlot::Values(self.constants.as_slice()));
-        slots.push(self.env.map_or(ByteCodeSlot::Absent, ByteCodeSlot::Value));
-        slots.push(ByteCodeSlot::Value(Value::fixnum(i64::from(
-            self.max_stack,
-        ))));
-        slots.push(match (self.doc_form, &self.docstring) {
-            (Some(form), _) => ByteCodeSlot::Value(form),
-            (None, Some(doc)) => ByteCodeSlot::Text(doc),
-            (None, None) => ByteCodeSlot::Absent,
-        });
-        slots.push(
-            self.interactive
-                .map_or(ByteCodeSlot::Absent, ByteCodeSlot::Value),
-        );
-        slots.extend(self.extra_slots.iter().copied().map(ByteCodeSlot::Value));
-        slots
+    pub(crate) fn structural_parts(&self) -> ByteCodeStructuralParts<'_> {
+        use ByteCodeStructuralPart as Part;
+
+        ByteCodeStructuralParts {
+            fixed: [
+                Part::ObservableSlotCount(self.observable_closure_slot_count()),
+                Part::Value(self.arglist),
+                match &self.gnu_bytecode_bytes {
+                    Some(bytes) => Part::Bytes(bytes.as_slice()),
+                    None => Part::Ops(&self.ops),
+                },
+                Part::Values(self.constants.as_slice()),
+                self.env.map_or(Part::Absent, Part::Value),
+                Part::Value(Value::fixnum(i64::from(self.max_stack))),
+                match (self.doc_form, &self.docstring) {
+                    (Some(form), _) => Part::Value(form),
+                    (None, Some(doc)) => Part::Text(doc),
+                    (None, None) => Part::Absent,
+                },
+                self.interactive.map_or(Part::Absent, Part::Value),
+            ]
+            .into_iter(),
+            extras: self.extra_slots.iter(),
+        }
     }
 
     pub fn observable_closure_slot_count(&self) -> usize {

--- a/crates/neovm-core/src/emacs_core/runtime/bytecode/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/bytecode/mod.rs
@@ -13,6 +13,6 @@ pub mod vm;
 
 // Re-export main types
 pub(crate) use chunk::fresh_bytecode_source_id;
-pub use chunk::{ByteCodeFunction, ByteCodeSlot};
+pub use chunk::{ByteCodeFunction, ByteCodeStructuralPart};
 pub use opcode::Op;
 pub use vm::Vm;

--- a/crates/neovm-core/src/emacs_core/runtime/bytecode/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/bytecode/mod.rs
@@ -12,7 +12,7 @@ pub mod opcode;
 pub mod vm;
 
 // Re-export main types
-pub use chunk::ByteCodeFunction;
 pub(crate) use chunk::fresh_bytecode_source_id;
+pub use chunk::{ByteCodeFunction, ByteCodeSlot};
 pub use opcode::Op;
 pub use vm::Vm;

--- a/crates/neovm-core/src/emacs_core/runtime/bytecode/opcode.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/bytecode/opcode.rs
@@ -7,7 +7,7 @@
 use serde::{Deserialize, Serialize};
 
 /// A single bytecode instruction.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Op {
     // -- Constants and stack --------------------------------------------------
     /// Push a constant from the constant pool.

--- a/crates/neovm-core/src/emacs_core/runtime/hashtab/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/hashtab/mod.rs
@@ -251,43 +251,34 @@ fn emacs_sxhash_overlay(value: &Value, depth: usize) -> Option<u64> {
 /// GNU `sxhash_obj` (src/fns.c:5525-5536) sends a `PVEC_CLOSURE` through
 /// `sxhash_vector` like any pseudovector `internal_equal` walks, so two
 /// `equal` byte-code objects hash alike and share an `equal` hash-table
-/// bucket.  The slots are the GNU closure slots in GNU's order (see
-/// `bytecode_equal` in `value/mod.rs`); `sxhash_vector` folds at most
-/// `SXHASH_MAX_LEN` of them over a hash seeded with the slot count.
+/// bucket.  The elements are [`ByteCodeFunction::structural_slots`] -- the
+/// same sequence `equal` compares, so everything `equal` distinguishes,
+/// including a captured environment beside the constants, moves the hash --
+/// folded like `sxhash_vector`: seeded with the slot count, at most
+/// `SXHASH_MAX_LEN` elements.
 fn emacs_sxhash_bytecode(value: &Value, depth: usize) -> Option<u64> {
+    use crate::emacs_core::bytecode::ByteCodeSlot;
     let bc = value.get_bytecode_data()?;
-    let obj = |v: &Value| emacs_sxhash_obj_with_fallback(v, depth + 1);
-    let len = bc.observable_closure_slot_count();
-    let mut hash = len as u64;
-    for index in 0..len.min(SXHASH_MAX_LEN) {
-        let slot_hash = match index {
-            0 => obj(&bc.arglist),
-            1 => match &bc.gnu_bytecode_bytes {
-                Some(bytes) => emacs_hash_char_array(bytes.as_slice()),
-                None => obj(&Value::NIL),
-            },
-            2 => match bc.env {
-                Some(env) => obj(&env),
-                None => {
-                    let constants = bc.constants.as_slice();
-                    let mut vector_hash = constants.len() as u64;
-                    for constant in constants.iter().take(SXHASH_MAX_LEN) {
-                        vector_hash = sxhash_combine(
-                            vector_hash,
-                            emacs_sxhash_obj_with_fallback(constant, depth + 2),
-                        );
-                    }
-                    vector_hash
+    let mut hash = bc.observable_closure_slot_count() as u64;
+    for slot in bc.structural_slots().into_iter().take(SXHASH_MAX_LEN) {
+        let slot_hash = match slot {
+            ByteCodeSlot::Value(value) => emacs_sxhash_obj_with_fallback(&value, depth + 1),
+            ByteCodeSlot::Bytes(bytes) => emacs_hash_char_array(bytes),
+            ByteCodeSlot::Ops(ops) => emacs_hash_char_array(format!("{ops:?}").as_bytes()),
+            ByteCodeSlot::Values(values) => {
+                let mut vector_hash = values.len() as u64;
+                for value in values.iter().take(SXHASH_MAX_LEN) {
+                    vector_hash = sxhash_combine(
+                        vector_hash,
+                        emacs_sxhash_obj_with_fallback(value, depth + 2),
+                    );
                 }
-            },
-            3 => obj(&Value::fixnum(i64::from(bc.max_stack))),
-            4 => match (bc.doc_form, &bc.docstring) {
-                (Some(form), _) => obj(&form),
-                (None, Some(doc)) => emacs_hash_char_array(doc.as_bytes()),
-                (None, None) => obj(&Value::NIL),
-            },
-            5 => obj(&bc.interactive.unwrap_or(Value::NIL)),
-            extra => obj(&bc.extra_slots.get(extra - 6).copied().unwrap_or(Value::NIL)),
+                vector_hash
+            }
+            // GNU `sxhash_string` hashes the bytes; equal strings have equal
+            // bytes whatever their representation.
+            ByteCodeSlot::Text(text) => emacs_hash_char_array(text.as_bytes()),
+            ByteCodeSlot::Absent => 42,
         };
         hash = sxhash_combine(hash, slot_hash);
     }

--- a/crates/neovm-core/src/emacs_core/runtime/hashtab/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/hashtab/mod.rs
@@ -73,6 +73,7 @@ fn hash_key_to_value(key: &HashKey) -> Value {
             let vals: Vec<Value> = items.iter().map(hash_key_to_value).collect();
             Value::vector(vals)
         }
+        HashKey::ByteCode(_) => Value::NIL,
         HashKey::Marker(_) | HashKey::Overlay(_) => Value::NIL,
         HashKey::BoolVec(parts) => {
             let (len, bits) = **parts;
@@ -251,21 +252,32 @@ fn emacs_sxhash_overlay(value: &Value, depth: usize) -> Option<u64> {
 /// GNU `sxhash_obj` (src/fns.c:5525-5536) sends a `PVEC_CLOSURE` through
 /// `sxhash_vector` like any pseudovector `internal_equal` walks, so two
 /// `equal` byte-code objects hash alike and share an `equal` hash-table
-/// bucket.  The elements are [`ByteCodeFunction::structural_slots`] -- the
+/// bucket.  The elements are [`ByteCodeFunction::structural_parts`] -- the
 /// same sequence `equal` compares, so everything `equal` distinguishes,
 /// including a captured environment beside the constants, moves the hash --
 /// folded like `sxhash_vector`: seeded with the slot count, at most
 /// `SXHASH_MAX_LEN` elements.
 fn emacs_sxhash_bytecode(value: &Value, depth: usize) -> Option<u64> {
-    use crate::emacs_core::bytecode::ByteCodeSlot;
+    use crate::emacs_core::bytecode::ByteCodeStructuralPart as Part;
     let bc = value.get_bytecode_data()?;
-    let mut hash = bc.observable_closure_slot_count() as u64;
-    for slot in bc.structural_slots().into_iter().take(SXHASH_MAX_LEN) {
-        let slot_hash = match slot {
-            ByteCodeSlot::Value(value) => emacs_sxhash_obj_with_fallback(&value, depth + 1),
-            ByteCodeSlot::Bytes(bytes) => emacs_hash_char_array(bytes),
-            ByteCodeSlot::Ops(ops) => emacs_hash_char_array(format!("{ops:?}").as_bytes()),
-            ByteCodeSlot::Values(values) => {
+    let mut parts = bc.structural_parts();
+    let Part::ObservableSlotCount(slot_count) = parts.next()? else {
+        unreachable!("byte-code structure starts with its observable shape")
+    };
+    let mut hash = slot_count as u64;
+    for part in parts.take(SXHASH_MAX_LEN) {
+        let part_hash = match part {
+            Part::ObservableSlotCount(_) => {
+                unreachable!("byte-code structure contains one leading shape")
+            }
+            Part::Value(value) => emacs_sxhash_obj_with_fallback(&value, depth + 1),
+            Part::Bytes(bytes) => emacs_hash_char_array(bytes),
+            Part::Ops(ops) => {
+                let mut hasher = DefaultHasher::new();
+                ops.hash(&mut hasher);
+                hasher.finish() & SXHASH_FALLBACK_NONNEG_MASK
+            }
+            Part::Values(values) => {
                 let mut vector_hash = values.len() as u64;
                 for value in values.iter().take(SXHASH_MAX_LEN) {
                     vector_hash = sxhash_combine(
@@ -277,10 +289,10 @@ fn emacs_sxhash_bytecode(value: &Value, depth: usize) -> Option<u64> {
             }
             // GNU `sxhash_string` hashes the bytes; equal strings have equal
             // bytes whatever their representation.
-            ByteCodeSlot::Text(text) => emacs_hash_char_array(text.as_bytes()),
-            ByteCodeSlot::Absent => 42,
+            Part::Text(text) => emacs_hash_char_array(text.as_bytes()),
+            Part::Absent => 42,
         };
-        hash = sxhash_combine(hash, slot_hash);
+        hash = sxhash_combine(hash, part_hash);
     }
     Some(hash)
 }

--- a/crates/neovm-core/src/emacs_core/runtime/hashtab/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/hashtab/mod.rs
@@ -248,6 +248,52 @@ fn emacs_sxhash_overlay(value: &Value, depth: usize) -> Option<u64> {
     Some(hash)
 }
 
+/// GNU `sxhash_obj` (src/fns.c:5525-5536) sends a `PVEC_CLOSURE` through
+/// `sxhash_vector` like any pseudovector `internal_equal` walks, so two
+/// `equal` byte-code objects hash alike and share an `equal` hash-table
+/// bucket.  The slots are the GNU closure slots in GNU's order (see
+/// `bytecode_equal` in `value/mod.rs`); `sxhash_vector` folds at most
+/// `SXHASH_MAX_LEN` of them over a hash seeded with the slot count.
+fn emacs_sxhash_bytecode(value: &Value, depth: usize) -> Option<u64> {
+    let bc = value.get_bytecode_data()?;
+    let obj = |v: &Value| emacs_sxhash_obj_with_fallback(v, depth + 1);
+    let len = bc.observable_closure_slot_count();
+    let mut hash = len as u64;
+    for index in 0..len.min(SXHASH_MAX_LEN) {
+        let slot_hash = match index {
+            0 => obj(&bc.arglist),
+            1 => match &bc.gnu_bytecode_bytes {
+                Some(bytes) => emacs_hash_char_array(bytes.as_slice()),
+                None => obj(&Value::NIL),
+            },
+            2 => match bc.env {
+                Some(env) => obj(&env),
+                None => {
+                    let constants = bc.constants.as_slice();
+                    let mut vector_hash = constants.len() as u64;
+                    for constant in constants.iter().take(SXHASH_MAX_LEN) {
+                        vector_hash = sxhash_combine(
+                            vector_hash,
+                            emacs_sxhash_obj_with_fallback(constant, depth + 2),
+                        );
+                    }
+                    vector_hash
+                }
+            },
+            3 => obj(&Value::fixnum(i64::from(bc.max_stack))),
+            4 => match (bc.doc_form, &bc.docstring) {
+                (Some(form), _) => obj(&form),
+                (None, Some(doc)) => emacs_hash_char_array(doc.as_bytes()),
+                (None, None) => obj(&Value::NIL),
+            },
+            5 => obj(&bc.interactive.unwrap_or(Value::NIL)),
+            extra => obj(&bc.extra_slots.get(extra - 6).copied().unwrap_or(Value::NIL)),
+        };
+        hash = sxhash_combine(hash, slot_hash);
+    }
+    Some(hash)
+}
+
 fn emacs_sxhash_obj(value: &Value, depth: usize) -> Option<u64> {
     if depth > SXHASH_MAX_DEPTH {
         return Some(0);
@@ -268,6 +314,7 @@ fn emacs_sxhash_obj(value: &Value, depth: usize) -> Option<u64> {
         | ValueKind::Veclike(VecLikeType::SubCharTable) => {
             emacs_sxhash_structural_pseudovector(value, depth)
         }
+        ValueKind::Veclike(VecLikeType::ByteCode) => emacs_sxhash_bytecode(value, depth),
         ValueKind::Veclike(VecLikeType::Bignum) => sxhash_bignum(value),
         ValueKind::Veclike(VecLikeType::Marker) => emacs_sxhash_marker(value),
         ValueKind::Veclike(VecLikeType::Overlay) => emacs_sxhash_overlay(value, depth),

--- a/crates/neovm-core/src/emacs_core/runtime/pdump/convert.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/pdump/convert.rs
@@ -51,8 +51,8 @@ use crate::emacs_core::rect::RectangleState;
 use crate::emacs_core::register::{RegisterContent, RegisterManager};
 use crate::emacs_core::symbol::{LispSymbol, Obarray, SymbolTrappedWrite};
 use crate::emacs_core::value::{
-    HashKey, HashTableTest, HashTableWeakness, LambdaParams, LispHashTable, RuntimeBindingValue,
-    StringTextPropertyRun, Value,
+    ByteCodeKeyPart, HashKey, HashTableTest, HashTableWeakness, LambdaParams, LispHashTable,
+    RuntimeBindingValue, StringTextPropertyRun, Value,
 };
 use crate::emacs_core::value::{ValueKind, VecLikeType};
 use crate::emacs_core::value::{
@@ -3046,6 +3046,12 @@ pub(crate) fn dump_hash_key(encoder: &mut DumpEncoder, k: &HashKey) -> DumpHashK
         HashKey::EqualVec(v) => {
             DumpHashKey::EqualVec(v.iter().map(|key| dump_hash_key(encoder, key)).collect())
         }
+        HashKey::ByteCode(parts) => DumpHashKey::ByteCode(
+            parts
+                .iter()
+                .map(|part| dump_byte_code_key_part(encoder, part))
+                .collect(),
+        ),
         HashKey::Marker(parts) => DumpHashKey::Marker(parts.0, parts.1.get()),
         HashKey::Overlay(parts) => DumpHashKey::Overlay {
             buffer: parts.0,
@@ -3063,6 +3069,31 @@ pub(crate) fn dump_hash_key(encoder: &mut DumpEncoder, k: &HashKey) -> DumpHashK
         ),
         HashKey::Cycle(index) => DumpHashKey::Cycle(*index),
         HashKey::Text(text) => DumpHashKey::Text(text.to_string()),
+    }
+}
+
+fn dump_byte_code_key_part(
+    encoder: &mut DumpEncoder,
+    part: &ByteCodeKeyPart,
+) -> DumpByteCodeKeyPart {
+    match part {
+        ByteCodeKeyPart::ObservableSlotCount(count) => {
+            DumpByteCodeKeyPart::ObservableSlotCount(*count)
+        }
+        ByteCodeKeyPart::Value(value) => DumpByteCodeKeyPart::Value(dump_hash_key(encoder, value)),
+        ByteCodeKeyPart::Bytes(bytes) => DumpByteCodeKeyPart::Bytes(bytes.to_vec()),
+        ByteCodeKeyPart::Ops(ops) => DumpByteCodeKeyPart::Ops(ops.to_vec()),
+        ByteCodeKeyPart::Values(values) => DumpByteCodeKeyPart::Values(
+            values
+                .iter()
+                .map(|value| dump_hash_key(encoder, value))
+                .collect(),
+        ),
+        ByteCodeKeyPart::Text { char_count, bytes } => DumpByteCodeKeyPart::Text {
+            char_count: *char_count,
+            bytes: bytes.to_vec(),
+        },
+        ByteCodeKeyPart::Absent => DumpByteCodeKeyPart::Absent,
     }
 }
 
@@ -4701,6 +4732,13 @@ pub(crate) fn load_hash_key(decoder: &mut LoadDecoder, k: &DumpHashKey) -> HashK
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
         ),
+        DumpHashKey::ByteCode(parts) => HashKey::ByteCode(
+            parts
+                .iter()
+                .map(|part| load_byte_code_key_part(decoder, part))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        ),
         DumpHashKey::Marker(buffer, bytepos) => {
             HashKey::Marker(Box::new((*buffer, EmacsBytePos::new(*bytepos))))
         }
@@ -4722,6 +4760,34 @@ pub(crate) fn load_hash_key(decoder: &mut LoadDecoder, k: &DumpHashKey) -> HashK
         ),
         DumpHashKey::Cycle(index) => HashKey::Cycle(*index),
         DumpHashKey::Text(text) => HashKey::Text(text.clone().into_boxed_str()),
+    }
+}
+
+fn load_byte_code_key_part(
+    decoder: &mut LoadDecoder,
+    part: &DumpByteCodeKeyPart,
+) -> ByteCodeKeyPart {
+    match part {
+        DumpByteCodeKeyPart::ObservableSlotCount(count) => {
+            ByteCodeKeyPart::ObservableSlotCount(*count)
+        }
+        DumpByteCodeKeyPart::Value(value) => ByteCodeKeyPart::Value(load_hash_key(decoder, value)),
+        DumpByteCodeKeyPart::Bytes(bytes) => {
+            ByteCodeKeyPart::Bytes(bytes.clone().into_boxed_slice())
+        }
+        DumpByteCodeKeyPart::Ops(ops) => ByteCodeKeyPart::Ops(ops.clone().into_boxed_slice()),
+        DumpByteCodeKeyPart::Values(values) => ByteCodeKeyPart::Values(
+            values
+                .iter()
+                .map(|value| load_hash_key(decoder, value))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        ),
+        DumpByteCodeKeyPart::Text { char_count, bytes } => ByteCodeKeyPart::Text {
+            char_count: *char_count,
+            bytes: bytes.clone().into_boxed_slice(),
+        },
+        DumpByteCodeKeyPart::Absent => ByteCodeKeyPart::Absent,
     }
 }
 
@@ -4755,6 +4821,13 @@ fn load_hash_key_owned(decoder: &mut LoadDecoder, k: DumpHashKey) -> HashKey {
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
         ),
+        DumpHashKey::ByteCode(parts) => HashKey::ByteCode(
+            parts
+                .into_iter()
+                .map(|part| load_byte_code_key_part_owned(decoder, part))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        ),
         DumpHashKey::Marker(buffer, bytepos) => {
             HashKey::Marker(Box::new((buffer, EmacsBytePos::new(bytepos))))
         }
@@ -4776,6 +4849,34 @@ fn load_hash_key_owned(decoder: &mut LoadDecoder, k: DumpHashKey) -> HashKey {
         ),
         DumpHashKey::Cycle(index) => HashKey::Cycle(index),
         DumpHashKey::Text(text) => HashKey::Text(text.into_boxed_str()),
+    }
+}
+
+fn load_byte_code_key_part_owned(
+    decoder: &mut LoadDecoder,
+    part: DumpByteCodeKeyPart,
+) -> ByteCodeKeyPart {
+    match part {
+        DumpByteCodeKeyPart::ObservableSlotCount(count) => {
+            ByteCodeKeyPart::ObservableSlotCount(count)
+        }
+        DumpByteCodeKeyPart::Value(value) => {
+            ByteCodeKeyPart::Value(load_hash_key_owned(decoder, value))
+        }
+        DumpByteCodeKeyPart::Bytes(bytes) => ByteCodeKeyPart::Bytes(bytes.into_boxed_slice()),
+        DumpByteCodeKeyPart::Ops(ops) => ByteCodeKeyPart::Ops(ops.into_boxed_slice()),
+        DumpByteCodeKeyPart::Values(values) => ByteCodeKeyPart::Values(
+            values
+                .into_iter()
+                .map(|value| load_hash_key_owned(decoder, value))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        ),
+        DumpByteCodeKeyPart::Text { char_count, bytes } => ByteCodeKeyPart::Text {
+            char_count,
+            bytes: bytes.into_boxed_slice(),
+        },
+        DumpByteCodeKeyPart::Absent => ByteCodeKeyPart::Absent,
     }
 }
 

--- a/crates/neovm-core/src/emacs_core/runtime/pdump/object_value_codec.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/pdump/object_value_codec.rs
@@ -6,10 +6,10 @@
 
 use super::DumpError;
 use super::types::{
-    DumpBufferId, DumpByteCodeFunction, DumpByteCodeInstructions, DumpByteData, DumpHashKey,
-    DumpHashTableTest, DumpHashTableWeakness, DumpHeapObject, DumpHeapRef, DumpLambdaParams,
-    DumpLispHashTable, DumpLispString, DumpMarker, DumpNameId, DumpOverlay,
-    DumpStringTextPropertyRun, DumpSymId, DumpValue,
+    DumpBufferId, DumpByteCodeFunction, DumpByteCodeInstructions, DumpByteCodeKeyPart,
+    DumpByteData, DumpHashKey, DumpHashTableTest, DumpHashTableWeakness, DumpHeapObject,
+    DumpHeapRef, DumpLambdaParams, DumpLispHashTable, DumpLispString, DumpMarker, DumpNameId,
+    DumpOverlay, DumpStringTextPropertyRun, DumpSymId, DumpValue,
 };
 
 use crate::emacs_core::bytecode::opcode::Op;
@@ -323,6 +323,15 @@ const HASH_KEY_MARKER: u8 = 18;
 const HASH_KEY_OVERLAY: u8 = 19;
 const HASH_KEY_BOOL_VEC: u8 = 20;
 const HASH_KEY_BIGNUM: u8 = 21;
+const HASH_KEY_BYTE_CODE: u8 = 22;
+
+const BYTE_CODE_KEY_OBSERVABLE_SLOT_COUNT: u8 = 0;
+const BYTE_CODE_KEY_VALUE: u8 = 1;
+const BYTE_CODE_KEY_BYTES: u8 = 2;
+const BYTE_CODE_KEY_OPS: u8 = 3;
+const BYTE_CODE_KEY_VALUES: u8 = 4;
+const BYTE_CODE_KEY_TEXT: u8 = 5;
+const BYTE_CODE_KEY_ABSENT: u8 = 6;
 
 fn write_hash_key(out: &mut Vec<u8>, key: &DumpHashKey) -> Result<(), DumpError> {
     match key {
@@ -389,6 +398,13 @@ fn write_hash_key(out: &mut Vec<u8>, key: &DumpHashKey) -> Result<(), DumpError>
             write_u8(out, HASH_KEY_EQUAL_VEC);
             write_hash_keys(out, keys)?;
         }
+        DumpHashKey::ByteCode(parts) => {
+            write_u8(out, HASH_KEY_BYTE_CODE);
+            write_len(out, parts.len(), "byte-code hash key part count")?;
+            for part in parts {
+                write_byte_code_key_part(out, part)?;
+            }
+        }
         DumpHashKey::Marker(buffer, bytepos) => {
             write_u8(out, HASH_KEY_MARKER);
             write_opt_u64(out, *buffer);
@@ -425,6 +441,41 @@ fn write_hash_key(out: &mut Vec<u8>, key: &DumpHashKey) -> Result<(), DumpError>
             write_u8(out, HASH_KEY_TEXT);
             write_string(out, text)?;
         }
+    }
+    Ok(())
+}
+
+fn write_byte_code_key_part(
+    out: &mut Vec<u8>,
+    part: &DumpByteCodeKeyPart,
+) -> Result<(), DumpError> {
+    match part {
+        DumpByteCodeKeyPart::ObservableSlotCount(count) => {
+            write_u8(out, BYTE_CODE_KEY_OBSERVABLE_SLOT_COUNT);
+            write_usize(out, *count)?;
+        }
+        DumpByteCodeKeyPart::Value(value) => {
+            write_u8(out, BYTE_CODE_KEY_VALUE);
+            write_hash_key(out, value)?;
+        }
+        DumpByteCodeKeyPart::Bytes(bytes) => {
+            write_u8(out, BYTE_CODE_KEY_BYTES);
+            write_bytes(out, bytes)?;
+        }
+        DumpByteCodeKeyPart::Ops(ops) => {
+            write_u8(out, BYTE_CODE_KEY_OPS);
+            write_ops(out, ops);
+        }
+        DumpByteCodeKeyPart::Values(values) => {
+            write_u8(out, BYTE_CODE_KEY_VALUES);
+            write_hash_keys(out, values)?;
+        }
+        DumpByteCodeKeyPart::Text { char_count, bytes } => {
+            write_u8(out, BYTE_CODE_KEY_TEXT);
+            write_usize(out, *char_count)?;
+            write_bytes(out, bytes)?;
+        }
+        DumpByteCodeKeyPart::Absent => write_u8(out, BYTE_CODE_KEY_ABSENT),
     }
     Ok(())
 }
@@ -1099,6 +1150,14 @@ impl<'a> Cursor<'a> {
                 Box::new(self.read_hash_key()?),
             )),
             HASH_KEY_EQUAL_VEC => Ok(DumpHashKey::EqualVec(self.read_hash_keys()?)),
+            HASH_KEY_BYTE_CODE => {
+                let len = self.read_len("byte-code hash key part count")?;
+                let mut parts = Vec::with_capacity(len);
+                for _ in 0..len {
+                    parts.push(self.read_byte_code_key_part()?);
+                }
+                Ok(DumpHashKey::ByteCode(parts))
+            }
             HASH_KEY_MARKER => Ok(DumpHashKey::Marker(
                 self.read_opt_u64()?,
                 self.read_usize("hash marker byte position")?,
@@ -1137,6 +1196,26 @@ impl<'a> Cursor<'a> {
             keys.push(self.read_hash_key()?);
         }
         Ok(keys)
+    }
+
+    fn read_byte_code_key_part(&mut self) -> Result<DumpByteCodeKeyPart, DumpError> {
+        match self.read_u8("byte-code hash key part tag")? {
+            BYTE_CODE_KEY_OBSERVABLE_SLOT_COUNT => Ok(DumpByteCodeKeyPart::ObservableSlotCount(
+                self.read_usize("byte-code observable slot count")?,
+            )),
+            BYTE_CODE_KEY_VALUE => Ok(DumpByteCodeKeyPart::Value(self.read_hash_key()?)),
+            BYTE_CODE_KEY_BYTES => Ok(DumpByteCodeKeyPart::Bytes(self.read_bytes()?)),
+            BYTE_CODE_KEY_OPS => Ok(DumpByteCodeKeyPart::Ops(self.read_ops()?)),
+            BYTE_CODE_KEY_VALUES => Ok(DumpByteCodeKeyPart::Values(self.read_hash_keys()?)),
+            BYTE_CODE_KEY_TEXT => Ok(DumpByteCodeKeyPart::Text {
+                char_count: self.read_usize("byte-code hash key character count")?,
+                bytes: self.read_bytes()?,
+            }),
+            BYTE_CODE_KEY_ABSENT => Ok(DumpByteCodeKeyPart::Absent),
+            other => Err(DumpError::ImageFormatError(format!(
+                "unknown byte-code hash key part tag {other}"
+            ))),
+        }
     }
 
     fn read_ordered_hash_entries(
@@ -1596,6 +1675,22 @@ mod tests {
                     (
                         DumpHashKey::Bignum(vec![0, 0xFFFF_FFFF_FFFF_FFFF, 1]),
                         DumpValue::Int(9),
+                        None,
+                    ),
+                    (
+                        DumpHashKey::ByteCode(vec![
+                            DumpByteCodeKeyPart::ObservableSlotCount(5),
+                            DumpByteCodeKeyPart::Value(DumpHashKey::Int(257)),
+                            DumpByteCodeKeyPart::Bytes(vec![0xC0, 0x87]),
+                            DumpByteCodeKeyPart::Ops(vec![Op::Constant(0), Op::Return]),
+                            DumpByteCodeKeyPart::Values(vec![DumpHashKey::Int(42)]),
+                            DumpByteCodeKeyPart::Text {
+                                char_count: 3,
+                                bytes: b"doc".to_vec(),
+                            },
+                            DumpByteCodeKeyPart::Absent,
+                        ]),
+                        DumpValue::Int(10),
                         None,
                     ),
                     (DumpHashKey::Char('x'), DumpValue::Int(8), None),

--- a/crates/neovm-core/src/emacs_core/runtime/pdump/types.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/pdump/types.rs
@@ -285,6 +285,7 @@ pub enum DumpHashKey {
     HeapRef(u32),
     EqualCons(Box<DumpHashKey>, Box<DumpHashKey>),
     EqualVec(Vec<DumpHashKey>),
+    ByteCode(Vec<DumpByteCodeKeyPart>),
     Marker(Option<u64>, usize),
     Overlay {
         buffer: Option<u64>,
@@ -299,6 +300,18 @@ pub enum DumpHashKey {
     SymbolWithPos(Box<DumpHashKey>, Box<DumpHashKey>),
     Cycle(u32),
     Text(String),
+}
+
+/// Serializable mirror of `ByteCodeKeyPart`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum DumpByteCodeKeyPart {
+    ObservableSlotCount(usize),
+    Value(DumpHashKey),
+    Bytes(Vec<u8>),
+    Ops(Vec<crate::emacs_core::bytecode::Op>),
+    Values(Vec<DumpHashKey>),
+    Text { char_count: usize, bytes: Vec<u8> },
+    Absent,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/neovm-core/src/emacs_core/runtime/value/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/value/mod.rs
@@ -1106,6 +1106,23 @@ impl HashTableLiteralKey {
     }
 }
 
+/// Domain-tagged structural evidence for one byte-code key part.
+///
+/// Keeping these cases distinct prevents an internal marker such as absence
+/// or decoded instructions from aliasing an ordinary Lisp value with matching
+/// contents.  `HashKey::ByteCode` also makes this representation unavailable
+/// to keys produced by regular Lisp vectors.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ByteCodeKeyPart {
+    ObservableSlotCount(usize),
+    Value(HashKey),
+    Bytes(Box<[u8]>),
+    Ops(Box<[super::bytecode::Op]>),
+    Values(Box<[HashKey]>),
+    Text { char_count: usize, bytes: Box<[u8]> },
+    Absent,
+}
+
 /// Key type that supports hashing for `eq`, `eql`, and `equal` tests.
 #[derive(Clone, Debug)]
 pub enum HashKey {
@@ -1130,6 +1147,9 @@ pub enum HashKey {
     EqualCons(Box<HashKey>, Box<HashKey>),
     /// Structural pseudovector key for `equal`-test hash tables.
     EqualVec(Box<[HashKey]>),
+    /// Structural byte-code key. Its nested enum preserves the semantic kind
+    /// of every part rather than encoding type information as sentinel text.
+    ByteCode(Box<[ByteCodeKeyPart]>),
     /// Structural marker key for `equal`-test hash tables.
     Marker(Box<(Option<u64>, EmacsBytePos)>),
     /// Structural overlay key for `equal`-test hash tables.
@@ -1160,6 +1180,7 @@ impl std::hash::Hash for HashKey {
             HashKey::Ptr(_) => 10,
             HashKey::EqualCons(_, _) => 12,
             HashKey::EqualVec(_) => 13,
+            HashKey::ByteCode(_) => 22,
             HashKey::Keyword(_) => 14,
             HashKey::Cycle(_) => 15,
             HashKey::Text(_) => 16,
@@ -1192,6 +1213,7 @@ impl std::hash::Hash for HashKey {
                     item.hash(state);
                 }
             }
+            HashKey::ByteCode(parts) => parts.hash(state),
             HashKey::Marker(parts) => {
                 parts.0.hash(state);
                 parts.1.hash(state);
@@ -1235,6 +1257,7 @@ impl PartialEq for HashKey {
                 a_car == b_car && a_cdr == b_cdr
             }
             (HashKey::EqualVec(a), HashKey::EqualVec(b)) => a == b,
+            (HashKey::ByteCode(a), HashKey::ByteCode(b)) => a == b,
             (HashKey::Marker(a), HashKey::Marker(b)) => a == b,
             (HashKey::Overlay(a), HashKey::Overlay(b)) => a == b,
             (HashKey::BoolVec(a), HashKey::BoolVec(b)) => a == b,
@@ -3834,7 +3857,7 @@ fn closure_params_to_equal_key(params: &LambdaParams) -> HashKey {
 }
 
 /// `equal`-table key for a byte-code object, derived from
-/// [`ByteCodeFunction::structural_slots`] so it agrees with [`bytecode_equal`]
+/// [`ByteCodeFunction::structural_parts`] so it agrees with [`bytecode_equal`]
 /// by construction: equal objects produce equal keys, and every difference
 /// `equal` sees -- including an absent versus a present-but-`nil` captured
 /// environment, and a docstring's character count -- reaches the key.  GNU's
@@ -3846,43 +3869,37 @@ fn bytecode_to_equal_key(
     seen: &mut Vec<usize>,
     symbols_with_pos_enabled: bool,
 ) -> HashKey {
-    use super::bytecode::ByteCodeSlot;
+    use super::bytecode::ByteCodeStructuralPart as Part;
     if depth > 200 {
-        return HashKey::Text("#<byte-code-depth-limit>".into());
+        return value.to_eq_key();
     }
     let Some(bc) = value.get_bytecode_data() else {
         return value.to_eq_key();
     };
     let mut key_of =
         |slot: &Value| slot.to_equal_key_depth_swp(depth + 1, seen, symbols_with_pos_enabled);
-    fn byte_keys(bytes: &[u8]) -> impl Iterator<Item = HashKey> + '_ {
-        bytes.iter().map(|byte| HashKey::Int(i64::from(*byte)))
-    }
-
-    let slots = bc.structural_slots();
-    let mut keys = Vec::with_capacity(slots.len() + 2);
-    keys.push(HashKey::Text("#<byte-code>".into()));
-    keys.push(HashKey::Int(bc.observable_closure_slot_count() as i64));
-    for slot in slots {
-        keys.push(match slot {
-            ByteCodeSlot::Value(value) => key_of(&value),
-            ByteCodeSlot::Bytes(bytes) => HashKey::EqualVec(byte_keys(bytes).collect()),
-            ByteCodeSlot::Ops(ops) => HashKey::Text(format!("#<ops {ops:?}>").into()),
-            ByteCodeSlot::Values(values) => {
-                HashKey::EqualVec(values.iter().map(&mut key_of).collect())
+    let parts = bc.structural_parts();
+    let mut keys = Vec::with_capacity(parts.len());
+    for part in parts {
+        keys.push(match part {
+            Part::ObservableSlotCount(count) => ByteCodeKeyPart::ObservableSlotCount(count),
+            Part::Value(value) => ByteCodeKeyPart::Value(key_of(&value)),
+            Part::Bytes(bytes) => ByteCodeKeyPart::Bytes(bytes.into()),
+            Part::Ops(ops) => ByteCodeKeyPart::Ops(ops.into()),
+            Part::Values(values) => {
+                ByteCodeKeyPart::Values(values.iter().map(&mut key_of).collect())
             }
             // GNU string equality is characters + bytes + contents; the
             // representation flag is not part of it, and the character count
             // is (two raw bytes are not one multibyte character).
-            ByteCodeSlot::Text(text) => HashKey::EqualVec(
-                std::iter::once(HashKey::Int(text.schars() as i64))
-                    .chain(byte_keys(text.as_bytes()))
-                    .collect(),
-            ),
-            ByteCodeSlot::Absent => HashKey::Text("#<absent>".into()),
+            Part::Text(text) => ByteCodeKeyPart::Text {
+                char_count: text.schars(),
+                bytes: text.as_bytes().into(),
+            },
+            Part::Absent => ByteCodeKeyPart::Absent,
         });
     }
-    HashKey::EqualVec(keys.into_boxed_slice())
+    HashKey::ByteCode(keys.into_boxed_slice())
 }
 
 fn closure_to_equal_key(value: Value, depth: usize, seen: &mut Vec<usize>) -> HashKey {
@@ -4049,7 +4066,7 @@ fn gnu_string_contents_equal(left: &LispString, right: &LispString) -> bool {
 }
 
 /// The slot walk behind both [`bytecode_equal`] and [`try_bytecode_equal`]:
-/// GNU's `ASIZE` check first, then [`ByteCodeFunction::structural_slots`]
+/// GNU's `ASIZE` check first, then [`ByteCodeFunction::structural_parts`]
 /// pairwise, with `value_equal` deciding the Lisp values (constants at one
 /// extra level of depth, as elements of the vector they sit in).
 fn bytecode_slots_equal(
@@ -4058,20 +4075,18 @@ fn bytecode_slots_equal(
     depth: usize,
     value_equal: &mut dyn FnMut(&Value, &Value, usize) -> Result<bool, Flow>,
 ) -> Result<bool, Flow> {
-    use super::bytecode::ByteCodeSlot;
-    if left.observable_closure_slot_count() != right.observable_closure_slot_count() {
+    use super::bytecode::ByteCodeStructuralPart as Part;
+    let (left_parts, right_parts) = (left.structural_parts(), right.structural_parts());
+    if left_parts.len() != right_parts.len() {
         return Ok(false);
     }
-    let (left_slots, right_slots) = (left.structural_slots(), right.structural_slots());
-    if left_slots.len() != right_slots.len() {
-        return Ok(false);
-    }
-    for (left, right) in left_slots.into_iter().zip(right_slots) {
+    for (left, right) in left_parts.zip(right_parts) {
         let equal = match (left, right) {
-            (ByteCodeSlot::Value(a), ByteCodeSlot::Value(b)) => value_equal(&a, &b, depth + 1)?,
-            (ByteCodeSlot::Bytes(a), ByteCodeSlot::Bytes(b)) => a == b,
-            (ByteCodeSlot::Ops(a), ByteCodeSlot::Ops(b)) => a == b,
-            (ByteCodeSlot::Values(a), ByteCodeSlot::Values(b)) => {
+            (Part::ObservableSlotCount(a), Part::ObservableSlotCount(b)) => a == b,
+            (Part::Value(a), Part::Value(b)) => value_equal(&a, &b, depth + 1)?,
+            (Part::Bytes(a), Part::Bytes(b)) => a == b,
+            (Part::Ops(a), Part::Ops(b)) => a == b,
+            (Part::Values(a), Part::Values(b)) => {
                 if a.len() != b.len() {
                     return Ok(false);
                 }
@@ -4082,8 +4097,8 @@ fn bytecode_slots_equal(
                 }
                 true
             }
-            (ByteCodeSlot::Text(a), ByteCodeSlot::Text(b)) => gnu_string_contents_equal(a, b),
-            (ByteCodeSlot::Absent, ByteCodeSlot::Absent) => true,
+            (Part::Text(a), Part::Text(b)) => gnu_string_contents_equal(a, b),
+            (Part::Absent, Part::Absent) => true,
             _ => false,
         };
         if !equal {
@@ -4098,7 +4113,7 @@ fn bytecode_slots_equal(
 /// test first -- which is also the type test, so a five-slot closure never
 /// equals a four-slot one -- then every slot element-wise.  This port keeps
 /// a byte-code function's GNU slots in typed fields, so the walk reads
-/// [`ByteCodeFunction::structural_slots`], the one place that spells the
+/// [`ByteCodeFunction::structural_parts`], the one place that spells the
 /// schema; `make-closure` (bytecode.c `Fmake_closure`) copies the prototype
 /// and replaces the leading constants, so two instances of one prototype
 /// with `equal` captures are `equal` -- the property `remove-hook` needs to

--- a/crates/neovm-core/src/emacs_core/runtime/value/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/value/mod.rs
@@ -2997,6 +2997,16 @@ impl TaggedValue {
                     self.to_eq_key()
                 }
             }
+            ValueKind::Veclike(VecLikeType::ByteCode) => {
+                let ptr = self.bits();
+                if let Some(index) = seen.iter().position(|&p| p == ptr) {
+                    return HashKey::Cycle(index as u32);
+                }
+                seen.push(ptr);
+                let key = bytecode_to_equal_key(self, depth + 1, seen, symbols_with_pos_enabled);
+                seen.pop();
+                key
+            }
             ValueKind::Veclike(VecLikeType::Lambda) => {
                 let ptr = self.bits();
                 if let Some(index) = seen.iter().position(|&p| p == ptr) {
@@ -3470,6 +3480,9 @@ fn equal_value_inner(
             true
         }
         VecLikeType::HashTable => false,
+        VecLikeType::ByteCode => {
+            bytecode_equal(&left, &right, depth, seen, symbols_with_pos_enabled, kind)
+        }
         VecLikeType::Lambda => {
             if depth > 10 {
                 let pair = EqualSeenPair::new(left, right);
@@ -3769,6 +3782,9 @@ fn try_equal_value_inner(
             Ok(true)
         }
         VecLikeType::HashTable => Ok(false),
+        VecLikeType::ByteCode => {
+            try_bytecode_equal(&left, &right, depth, seen, symbols_with_pos_enabled, kind)
+        }
         VecLikeType::Lambda => {
             if depth > 10 {
                 let pair = EqualSeenPair::new(left, right);
@@ -3815,6 +3831,77 @@ fn closure_params_to_equal_key(params: &LambdaParams) -> HashKey {
         values.push(HashKey::Symbol(rest));
     }
     HashKey::EqualVec(values.into_boxed_slice())
+}
+
+/// `equal`-table key for a byte-code object: the GNU closure slots that
+/// [`bytecode_equal`] compares, in the same order, behind a type tag and the
+/// slot count (GNU's `ASIZE`, which its `internal_equal` checks first).  Two
+/// byte-code objects that are `equal` produce the same key, so an `equal`
+/// hash table finds a closure by a freshly rebuilt twin, as GNU's
+/// `sxhash_obj` -> `sxhash_vector` arranges (src/fns.c:5525-5536).
+///
+/// The bytecode string is keyed as its exact byte sequence rather than as
+/// text: it is unibyte and rarely valid UTF-8.
+fn bytecode_to_equal_key(
+    value: Value,
+    depth: usize,
+    seen: &mut Vec<usize>,
+    symbols_with_pos_enabled: bool,
+) -> HashKey {
+    if depth > 200 {
+        return HashKey::Text("#<byte-code-depth-limit>".into());
+    }
+    let Some(bc) = value.get_bytecode_data() else {
+        return value.to_eq_key();
+    };
+    let mut key_of =
+        |slot: &Value| slot.to_equal_key_depth_swp(depth + 1, seen, symbols_with_pos_enabled);
+
+    let mut slots = Vec::with_capacity(bc.observable_closure_slot_count() + 3);
+    slots.push(HashKey::Text("#<byte-code>".into()));
+    slots.push(HashKey::Int(bc.observable_closure_slot_count() as i64));
+    // Slot 0: arglist.
+    slots.push(key_of(&bc.arglist));
+    // Slot 1: bytecode string, byte-exact.
+    slots.push(match &bc.gnu_bytecode_bytes {
+        Some(bytes) => HashKey::EqualVec(
+            bytes
+                .as_slice()
+                .iter()
+                .map(|byte| HashKey::Int(i64::from(*byte)))
+                .collect(),
+        ),
+        None => HashKey::Text(format!("#<ops {:?}>", bc.ops).into()),
+    });
+    // Slot 2: constants vector, plus the captured env when there is one.
+    slots.push(HashKey::EqualVec(
+        bc.constants.as_slice().iter().map(&mut key_of).collect(),
+    ));
+    slots.push(match bc.env {
+        Some(env) => key_of(&env),
+        None => HashKey::Nil,
+    });
+    // Slot 3: maximum stack depth.
+    slots.push(HashKey::Int(i64::from(bc.max_stack)));
+    // Slot 4: documentation form or docstring.
+    slots.push(match (bc.doc_form, &bc.docstring) {
+        (Some(form), _) => key_of(&form),
+        (None, Some(doc)) => HashKey::EqualVec(
+            doc.as_bytes()
+                .iter()
+                .map(|byte| HashKey::Int(i64::from(*byte)))
+                .collect(),
+        ),
+        (None, None) => HashKey::Nil,
+    });
+    // Slot 5: interactive spec.
+    slots.push(match bc.interactive {
+        Some(spec) => key_of(&spec),
+        None => HashKey::Nil,
+    });
+    // Slots 6..: extras.
+    slots.extend(bc.extra_slots.iter().map(&mut key_of));
+    HashKey::EqualVec(slots.into_boxed_slice())
 }
 
 fn closure_to_equal_key(value: Value, depth: usize, seen: &mut Vec<usize>) -> HashKey {
@@ -3967,6 +4054,234 @@ fn try_closure_equal(
         }
         _ => Ok(false),
     }
+}
+
+/// GNU `internal_equal_1` compares a `PVEC_CLOSURE` exactly like a vector
+/// (src/fns.c:2984-2998 in emacs-31.1, :2987-3001 on master): the `ASIZE`
+/// test first -- which is also the type test, so a five-slot closure never
+/// equals a four-slot one -- then every slot element-wise.  This port keeps a
+/// byte-code function's GNU slots in typed fields rather than in a vector, so
+/// the walk is spelled out here in GNU's slot order, the same order `aref`
+/// exposes through `bytecode_to_closure_vector`:
+///
+///   0 arglist, 1 bytecode string, 2 constants vector, 3 max depth,
+///   4 doc (string or form), 5 interactive spec, 6.. extra slots.
+///
+/// Two things have no GNU counterpart and are compared strictly: a function
+/// without retained GNU bytes compares its decoded instructions instead (two
+/// functions with different code are never `equal`), and a captured `env`
+/// alist is compared in addition to the constants it accompanies.
+///
+/// `make-closure` (bytecode.c `Fmake_closure`) copies the prototype and
+/// replaces the leading constants, so two instances of one prototype with
+/// `equal` captures are `equal` -- the property `remove-hook` needs to find a
+/// closure it was handed a freshly rebuilt twin of.
+fn bytecode_equal(
+    left: &Value,
+    right: &Value,
+    depth: usize,
+    seen: &mut Option<HashSet<EqualSeenPair>>,
+    symbols_with_pos_enabled: bool,
+    kind: EqualKind,
+) -> bool {
+    let (Some(l), Some(r)) = (left.get_bytecode_data(), right.get_bytecode_data()) else {
+        return false;
+    };
+    if l.observable_closure_slot_count() != r.observable_closure_slot_count() {
+        return false;
+    }
+    if depth > 10 {
+        let pair = EqualSeenPair::new(*left, *right);
+        if !seen.get_or_insert_with(HashSet::new).insert(pair) {
+            return true;
+        }
+    }
+    let mut slot_equal = |a: &Value, b: &Value, extra_depth: usize| {
+        equal_value_inner(
+            a,
+            b,
+            depth + extra_depth,
+            seen,
+            symbols_with_pos_enabled,
+            kind,
+        )
+    };
+
+    // Slot 0: arglist (an arg descriptor fixnum or an old-style list).
+    if !slot_equal(&l.arglist, &r.arglist, 1) {
+        return false;
+    }
+    // Slot 1: the bytecode string.
+    match (&l.gnu_bytecode_bytes, &r.gnu_bytecode_bytes) {
+        (Some(a), Some(b)) => {
+            if a.as_slice() != b.as_slice() {
+                return false;
+            }
+        }
+        (None, None) => {
+            if l.ops != r.ops {
+                return false;
+            }
+        }
+        _ => return false,
+    }
+    // Slot 2: the constants vector, element-wise as GNU compares the vector.
+    let (lc, rc) = (l.constants.as_slice(), r.constants.as_slice());
+    if lc.len() != rc.len() {
+        return false;
+    }
+    for (a, b) in lc.iter().zip(rc.iter()) {
+        if !slot_equal(a, b, 2) {
+            return false;
+        }
+    }
+    match (l.env, r.env) {
+        (None, None) => {}
+        (Some(a), Some(b)) => {
+            if !slot_equal(&a, &b, 1) {
+                return false;
+            }
+        }
+        _ => return false,
+    }
+    // Slot 3: maximum stack depth.
+    if l.max_stack != r.max_stack {
+        return false;
+    }
+    // Slot 4: docstring or documentation form.
+    match (l.doc_form, r.doc_form) {
+        (Some(a), Some(b)) => {
+            if !slot_equal(&a, &b, 1) {
+                return false;
+            }
+        }
+        (None, None) => {
+            if l.docstring != r.docstring {
+                return false;
+            }
+        }
+        _ => return false,
+    }
+    // Slot 5: interactive spec.
+    match (l.interactive, r.interactive) {
+        (None, None) => {}
+        (Some(a), Some(b)) => {
+            if !slot_equal(&a, &b, 1) {
+                return false;
+            }
+        }
+        _ => return false,
+    }
+    // Slots 6..: GNU's `&rest ELEMENTS`.
+    if l.extra_slots.len() != r.extra_slots.len() {
+        return false;
+    }
+    l.extra_slots
+        .iter()
+        .zip(r.extra_slots.iter())
+        .all(|(a, b)| slot_equal(a, b, 1))
+}
+
+/// [`bytecode_equal`] for the error-propagating walk.
+fn try_bytecode_equal(
+    left: &Value,
+    right: &Value,
+    depth: usize,
+    seen: &mut Option<HashSet<EqualSeenPair>>,
+    symbols_with_pos_enabled: bool,
+    kind: EqualKind,
+) -> Result<bool, Flow> {
+    let (Some(l), Some(r)) = (left.get_bytecode_data(), right.get_bytecode_data()) else {
+        return Ok(false);
+    };
+    if l.observable_closure_slot_count() != r.observable_closure_slot_count() {
+        return Ok(false);
+    }
+    if depth > 10 {
+        let pair = EqualSeenPair::new(*left, *right);
+        if !seen.get_or_insert_with(HashSet::new).insert(pair) {
+            return Ok(true);
+        }
+    }
+    let mut slot_equal = |a: &Value, b: &Value, extra_depth: usize| {
+        try_equal_value_inner(
+            a,
+            b,
+            depth + extra_depth,
+            seen,
+            symbols_with_pos_enabled,
+            kind,
+        )
+    };
+
+    if !slot_equal(&l.arglist, &r.arglist, 1)? {
+        return Ok(false);
+    }
+    match (&l.gnu_bytecode_bytes, &r.gnu_bytecode_bytes) {
+        (Some(a), Some(b)) => {
+            if a.as_slice() != b.as_slice() {
+                return Ok(false);
+            }
+        }
+        (None, None) => {
+            if l.ops != r.ops {
+                return Ok(false);
+            }
+        }
+        _ => return Ok(false),
+    }
+    let (lc, rc) = (l.constants.as_slice(), r.constants.as_slice());
+    if lc.len() != rc.len() {
+        return Ok(false);
+    }
+    for (a, b) in lc.iter().zip(rc.iter()) {
+        if !slot_equal(a, b, 2)? {
+            return Ok(false);
+        }
+    }
+    match (l.env, r.env) {
+        (None, None) => {}
+        (Some(a), Some(b)) => {
+            if !slot_equal(&a, &b, 1)? {
+                return Ok(false);
+            }
+        }
+        _ => return Ok(false),
+    }
+    if l.max_stack != r.max_stack {
+        return Ok(false);
+    }
+    match (l.doc_form, r.doc_form) {
+        (Some(a), Some(b)) => {
+            if !slot_equal(&a, &b, 1)? {
+                return Ok(false);
+            }
+        }
+        (None, None) => {
+            if l.docstring != r.docstring {
+                return Ok(false);
+            }
+        }
+        _ => return Ok(false),
+    }
+    match (l.interactive, r.interactive) {
+        (None, None) => {}
+        (Some(a), Some(b)) => {
+            if !slot_equal(&a, &b, 1)? {
+                return Ok(false);
+            }
+        }
+        _ => return Ok(false),
+    }
+    if l.extra_slots.len() != r.extra_slots.len() {
+        return Ok(false);
+    }
+    for (a, b) in l.extra_slots.iter().zip(r.extra_slots.iter()) {
+        if !slot_equal(a, b, 1)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/neovm-core/src/emacs_core/runtime/value/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/value/mod.rs
@@ -3833,21 +3833,20 @@ fn closure_params_to_equal_key(params: &LambdaParams) -> HashKey {
     HashKey::EqualVec(values.into_boxed_slice())
 }
 
-/// `equal`-table key for a byte-code object: the GNU closure slots that
-/// [`bytecode_equal`] compares, in the same order, behind a type tag and the
-/// slot count (GNU's `ASIZE`, which its `internal_equal` checks first).  Two
-/// byte-code objects that are `equal` produce the same key, so an `equal`
-/// hash table finds a closure by a freshly rebuilt twin, as GNU's
-/// `sxhash_obj` -> `sxhash_vector` arranges (src/fns.c:5525-5536).
-///
-/// The bytecode string is keyed as its exact byte sequence rather than as
-/// text: it is unibyte and rarely valid UTF-8.
+/// `equal`-table key for a byte-code object, derived from
+/// [`ByteCodeFunction::structural_slots`] so it agrees with [`bytecode_equal`]
+/// by construction: equal objects produce equal keys, and every difference
+/// `equal` sees -- including an absent versus a present-but-`nil` captured
+/// environment, and a docstring's character count -- reaches the key.  GNU's
+/// `sxhash_obj` -> `sxhash_vector` gives equal closures one bucket
+/// (src/fns.c:5525-5536); this is the table's side of that promise.
 fn bytecode_to_equal_key(
     value: Value,
     depth: usize,
     seen: &mut Vec<usize>,
     symbols_with_pos_enabled: bool,
 ) -> HashKey {
+    use super::bytecode::ByteCodeSlot;
     if depth > 200 {
         return HashKey::Text("#<byte-code-depth-limit>".into());
     }
@@ -3856,52 +3855,34 @@ fn bytecode_to_equal_key(
     };
     let mut key_of =
         |slot: &Value| slot.to_equal_key_depth_swp(depth + 1, seen, symbols_with_pos_enabled);
+    fn byte_keys(bytes: &[u8]) -> impl Iterator<Item = HashKey> + '_ {
+        bytes.iter().map(|byte| HashKey::Int(i64::from(*byte)))
+    }
 
-    let mut slots = Vec::with_capacity(bc.observable_closure_slot_count() + 3);
-    slots.push(HashKey::Text("#<byte-code>".into()));
-    slots.push(HashKey::Int(bc.observable_closure_slot_count() as i64));
-    // Slot 0: arglist.
-    slots.push(key_of(&bc.arglist));
-    // Slot 1: bytecode string, byte-exact.
-    slots.push(match &bc.gnu_bytecode_bytes {
-        Some(bytes) => HashKey::EqualVec(
-            bytes
-                .as_slice()
-                .iter()
-                .map(|byte| HashKey::Int(i64::from(*byte)))
-                .collect(),
-        ),
-        None => HashKey::Text(format!("#<ops {:?}>", bc.ops).into()),
-    });
-    // Slot 2: constants vector, plus the captured env when there is one.
-    slots.push(HashKey::EqualVec(
-        bc.constants.as_slice().iter().map(&mut key_of).collect(),
-    ));
-    slots.push(match bc.env {
-        Some(env) => key_of(&env),
-        None => HashKey::Nil,
-    });
-    // Slot 3: maximum stack depth.
-    slots.push(HashKey::Int(i64::from(bc.max_stack)));
-    // Slot 4: documentation form or docstring.
-    slots.push(match (bc.doc_form, &bc.docstring) {
-        (Some(form), _) => key_of(&form),
-        (None, Some(doc)) => HashKey::EqualVec(
-            doc.as_bytes()
-                .iter()
-                .map(|byte| HashKey::Int(i64::from(*byte)))
-                .collect(),
-        ),
-        (None, None) => HashKey::Nil,
-    });
-    // Slot 5: interactive spec.
-    slots.push(match bc.interactive {
-        Some(spec) => key_of(&spec),
-        None => HashKey::Nil,
-    });
-    // Slots 6..: extras.
-    slots.extend(bc.extra_slots.iter().map(&mut key_of));
-    HashKey::EqualVec(slots.into_boxed_slice())
+    let slots = bc.structural_slots();
+    let mut keys = Vec::with_capacity(slots.len() + 2);
+    keys.push(HashKey::Text("#<byte-code>".into()));
+    keys.push(HashKey::Int(bc.observable_closure_slot_count() as i64));
+    for slot in slots {
+        keys.push(match slot {
+            ByteCodeSlot::Value(value) => key_of(&value),
+            ByteCodeSlot::Bytes(bytes) => HashKey::EqualVec(byte_keys(bytes).collect()),
+            ByteCodeSlot::Ops(ops) => HashKey::Text(format!("#<ops {ops:?}>").into()),
+            ByteCodeSlot::Values(values) => {
+                HashKey::EqualVec(values.iter().map(&mut key_of).collect())
+            }
+            // GNU string equality is characters + bytes + contents; the
+            // representation flag is not part of it, and the character count
+            // is (two raw bytes are not one multibyte character).
+            ByteCodeSlot::Text(text) => HashKey::EqualVec(
+                std::iter::once(HashKey::Int(text.schars() as i64))
+                    .chain(byte_keys(text.as_bytes()))
+                    .collect(),
+            ),
+            ByteCodeSlot::Absent => HashKey::Text("#<absent>".into()),
+        });
+    }
+    HashKey::EqualVec(keys.into_boxed_slice())
 }
 
 fn closure_to_equal_key(value: Value, depth: usize, seen: &mut Vec<usize>) -> HashKey {
@@ -4056,26 +4037,72 @@ fn try_closure_equal(
     }
 }
 
+/// GNU string equality (src/fns.c `internal_equal_1`, `Lisp_String`):
+/// character count, byte count and contents.  The unibyte/multibyte
+/// representation flag `LispString::eq` also compares is not part of it: an
+/// ASCII string stored unibyte equals the same text stored multibyte, while
+/// two raw bytes never equal the one multibyte character with those bytes.
+fn gnu_string_contents_equal(left: &LispString, right: &LispString) -> bool {
+    left.schars() == right.schars()
+        && left.sbytes() == right.sbytes()
+        && left.as_bytes() == right.as_bytes()
+}
+
+/// The slot walk behind both [`bytecode_equal`] and [`try_bytecode_equal`]:
+/// GNU's `ASIZE` check first, then [`ByteCodeFunction::structural_slots`]
+/// pairwise, with `value_equal` deciding the Lisp values (constants at one
+/// extra level of depth, as elements of the vector they sit in).
+fn bytecode_slots_equal(
+    left: &super::bytecode::ByteCodeFunction,
+    right: &super::bytecode::ByteCodeFunction,
+    depth: usize,
+    value_equal: &mut dyn FnMut(&Value, &Value, usize) -> Result<bool, Flow>,
+) -> Result<bool, Flow> {
+    use super::bytecode::ByteCodeSlot;
+    if left.observable_closure_slot_count() != right.observable_closure_slot_count() {
+        return Ok(false);
+    }
+    let (left_slots, right_slots) = (left.structural_slots(), right.structural_slots());
+    if left_slots.len() != right_slots.len() {
+        return Ok(false);
+    }
+    for (left, right) in left_slots.into_iter().zip(right_slots) {
+        let equal = match (left, right) {
+            (ByteCodeSlot::Value(a), ByteCodeSlot::Value(b)) => value_equal(&a, &b, depth + 1)?,
+            (ByteCodeSlot::Bytes(a), ByteCodeSlot::Bytes(b)) => a == b,
+            (ByteCodeSlot::Ops(a), ByteCodeSlot::Ops(b)) => a == b,
+            (ByteCodeSlot::Values(a), ByteCodeSlot::Values(b)) => {
+                if a.len() != b.len() {
+                    return Ok(false);
+                }
+                for (a, b) in a.iter().zip(b) {
+                    if !value_equal(a, b, depth + 2)? {
+                        return Ok(false);
+                    }
+                }
+                true
+            }
+            (ByteCodeSlot::Text(a), ByteCodeSlot::Text(b)) => gnu_string_contents_equal(a, b),
+            (ByteCodeSlot::Absent, ByteCodeSlot::Absent) => true,
+            _ => false,
+        };
+        if !equal {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 /// GNU `internal_equal_1` compares a `PVEC_CLOSURE` exactly like a vector
 /// (src/fns.c:2984-2998 in emacs-31.1, :2987-3001 on master): the `ASIZE`
 /// test first -- which is also the type test, so a five-slot closure never
-/// equals a four-slot one -- then every slot element-wise.  This port keeps a
-/// byte-code function's GNU slots in typed fields rather than in a vector, so
-/// the walk is spelled out here in GNU's slot order, the same order `aref`
-/// exposes through `bytecode_to_closure_vector`:
-///
-///   0 arglist, 1 bytecode string, 2 constants vector, 3 max depth,
-///   4 doc (string or form), 5 interactive spec, 6.. extra slots.
-///
-/// Two things have no GNU counterpart and are compared strictly: a function
-/// without retained GNU bytes compares its decoded instructions instead (two
-/// functions with different code are never `equal`), and a captured `env`
-/// alist is compared in addition to the constants it accompanies.
-///
-/// `make-closure` (bytecode.c `Fmake_closure`) copies the prototype and
-/// replaces the leading constants, so two instances of one prototype with
-/// `equal` captures are `equal` -- the property `remove-hook` needs to find a
-/// closure it was handed a freshly rebuilt twin of.
+/// equals a four-slot one -- then every slot element-wise.  This port keeps
+/// a byte-code function's GNU slots in typed fields, so the walk reads
+/// [`ByteCodeFunction::structural_slots`], the one place that spells the
+/// schema; `make-closure` (bytecode.c `Fmake_closure`) copies the prototype
+/// and replaces the leading constants, so two instances of one prototype
+/// with `equal` captures are `equal` -- the property `remove-hook` needs to
+/// find a closure it was handed a freshly rebuilt twin of.
 fn bytecode_equal(
     left: &Value,
     right: &Value,
@@ -4087,99 +4114,23 @@ fn bytecode_equal(
     let (Some(l), Some(r)) = (left.get_bytecode_data(), right.get_bytecode_data()) else {
         return false;
     };
-    if l.observable_closure_slot_count() != r.observable_closure_slot_count() {
-        return false;
-    }
     if depth > 10 {
         let pair = EqualSeenPair::new(*left, *right);
         if !seen.get_or_insert_with(HashSet::new).insert(pair) {
             return true;
         }
     }
-    let mut slot_equal = |a: &Value, b: &Value, extra_depth: usize| {
-        equal_value_inner(
+    bytecode_slots_equal(l, r, depth, &mut |a, b, depth| {
+        Ok(equal_value_inner(
             a,
             b,
-            depth + extra_depth,
+            depth,
             seen,
             symbols_with_pos_enabled,
             kind,
-        )
-    };
-
-    // Slot 0: arglist (an arg descriptor fixnum or an old-style list).
-    if !slot_equal(&l.arglist, &r.arglist, 1) {
-        return false;
-    }
-    // Slot 1: the bytecode string.
-    match (&l.gnu_bytecode_bytes, &r.gnu_bytecode_bytes) {
-        (Some(a), Some(b)) => {
-            if a.as_slice() != b.as_slice() {
-                return false;
-            }
-        }
-        (None, None) => {
-            if l.ops != r.ops {
-                return false;
-            }
-        }
-        _ => return false,
-    }
-    // Slot 2: the constants vector, element-wise as GNU compares the vector.
-    let (lc, rc) = (l.constants.as_slice(), r.constants.as_slice());
-    if lc.len() != rc.len() {
-        return false;
-    }
-    for (a, b) in lc.iter().zip(rc.iter()) {
-        if !slot_equal(a, b, 2) {
-            return false;
-        }
-    }
-    match (l.env, r.env) {
-        (None, None) => {}
-        (Some(a), Some(b)) => {
-            if !slot_equal(&a, &b, 1) {
-                return false;
-            }
-        }
-        _ => return false,
-    }
-    // Slot 3: maximum stack depth.
-    if l.max_stack != r.max_stack {
-        return false;
-    }
-    // Slot 4: docstring or documentation form.
-    match (l.doc_form, r.doc_form) {
-        (Some(a), Some(b)) => {
-            if !slot_equal(&a, &b, 1) {
-                return false;
-            }
-        }
-        (None, None) => {
-            if l.docstring != r.docstring {
-                return false;
-            }
-        }
-        _ => return false,
-    }
-    // Slot 5: interactive spec.
-    match (l.interactive, r.interactive) {
-        (None, None) => {}
-        (Some(a), Some(b)) => {
-            if !slot_equal(&a, &b, 1) {
-                return false;
-            }
-        }
-        _ => return false,
-    }
-    // Slots 6..: GNU's `&rest ELEMENTS`.
-    if l.extra_slots.len() != r.extra_slots.len() {
-        return false;
-    }
-    l.extra_slots
-        .iter()
-        .zip(r.extra_slots.iter())
-        .all(|(a, b)| slot_equal(a, b, 1))
+        ))
+    })
+    .unwrap_or(false)
 }
 
 /// [`bytecode_equal`] for the error-propagating walk.
@@ -4194,94 +4145,15 @@ fn try_bytecode_equal(
     let (Some(l), Some(r)) = (left.get_bytecode_data(), right.get_bytecode_data()) else {
         return Ok(false);
     };
-    if l.observable_closure_slot_count() != r.observable_closure_slot_count() {
-        return Ok(false);
-    }
     if depth > 10 {
         let pair = EqualSeenPair::new(*left, *right);
         if !seen.get_or_insert_with(HashSet::new).insert(pair) {
             return Ok(true);
         }
     }
-    let mut slot_equal = |a: &Value, b: &Value, extra_depth: usize| {
-        try_equal_value_inner(
-            a,
-            b,
-            depth + extra_depth,
-            seen,
-            symbols_with_pos_enabled,
-            kind,
-        )
-    };
-
-    if !slot_equal(&l.arglist, &r.arglist, 1)? {
-        return Ok(false);
-    }
-    match (&l.gnu_bytecode_bytes, &r.gnu_bytecode_bytes) {
-        (Some(a), Some(b)) => {
-            if a.as_slice() != b.as_slice() {
-                return Ok(false);
-            }
-        }
-        (None, None) => {
-            if l.ops != r.ops {
-                return Ok(false);
-            }
-        }
-        _ => return Ok(false),
-    }
-    let (lc, rc) = (l.constants.as_slice(), r.constants.as_slice());
-    if lc.len() != rc.len() {
-        return Ok(false);
-    }
-    for (a, b) in lc.iter().zip(rc.iter()) {
-        if !slot_equal(a, b, 2)? {
-            return Ok(false);
-        }
-    }
-    match (l.env, r.env) {
-        (None, None) => {}
-        (Some(a), Some(b)) => {
-            if !slot_equal(&a, &b, 1)? {
-                return Ok(false);
-            }
-        }
-        _ => return Ok(false),
-    }
-    if l.max_stack != r.max_stack {
-        return Ok(false);
-    }
-    match (l.doc_form, r.doc_form) {
-        (Some(a), Some(b)) => {
-            if !slot_equal(&a, &b, 1)? {
-                return Ok(false);
-            }
-        }
-        (None, None) => {
-            if l.docstring != r.docstring {
-                return Ok(false);
-            }
-        }
-        _ => return Ok(false),
-    }
-    match (l.interactive, r.interactive) {
-        (None, None) => {}
-        (Some(a), Some(b)) => {
-            if !slot_equal(&a, &b, 1)? {
-                return Ok(false);
-            }
-        }
-        _ => return Ok(false),
-    }
-    if l.extra_slots.len() != r.extra_slots.len() {
-        return Ok(false);
-    }
-    for (a, b) in l.extra_slots.iter().zip(r.extra_slots.iter()) {
-        if !slot_equal(a, b, 1)? {
-            return Ok(false);
-        }
-    }
-    Ok(true)
+    bytecode_slots_equal(l, r, depth, &mut |a, b, depth| {
+        try_equal_value_inner(a, b, depth, seen, symbols_with_pos_enabled, kind)
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/neovm-core/src/emacs_core/runtime/value/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/value/tests/mod.rs
@@ -1077,6 +1077,35 @@ fn equal_table_keys_keep_the_presence_of_a_captured_environment() {
     );
 }
 
+/// Structural key evidence must be domain-tagged rather than represented by
+/// Lisp-reachable sentinel contents. `ByteCodeStructuralPart::Absent` used to become
+/// the same `HashKey::Text` as a present string containing `"#<absent>"`, so
+/// the hash table treated two objects that `equal` rejected as one key.
+#[test]
+fn equal_table_keys_do_not_alias_absence_with_lisp_values() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = Context::new();
+    let consts = || vec![Value::fixnum(42)];
+    let bytes = || Some(vec![0xC0, 0x87]);
+
+    let absent = byte_code_probe(None, None, bytes(), simple_ops(), consts());
+    let sentinel_text = byte_code_probe(
+        Some(Value::string("#<absent>")),
+        None,
+        bytes(),
+        simple_ops(),
+        consts(),
+    );
+
+    let (equal, _same_hash, table_found) =
+        byte_code_probe_agreement(&mut eval, absent, sentinel_text);
+    assert!(!equal, "an absent environment is not a present Lisp value");
+    assert!(
+        !table_found,
+        "an equal table must not alias typed absence with Lisp string contents"
+    );
+}
+
 /// GNU string equality is character count, byte count and contents
 /// (src/fns.c `internal_equal_1`, Lisp_String); the unibyte/multibyte
 /// representation flag is not part of it.  An ASCII docstring stored
@@ -1174,20 +1203,15 @@ fn functions_without_gnu_bytes_compare_their_decoded_instructions() {
     );
 }
 
-/// `sxhash_obj` hashes every slot `internal_equal` walks (src/fns.c:5525):
-/// the constants vector and the captured environment both move the hash.
+/// GNU only promises that `equal` byte-code objects have equal hashes;
+/// collisions between unequal objects are valid. Exercise that implication
+/// for both constants and captured environments, and independently require
+/// the equal-table key to distinguish the unequal pairs.
 #[test]
-fn sxhash_equal_folds_constants_and_the_captured_environment() {
+fn sxhash_equal_obeys_the_contract_for_constants_and_captured_environments() {
     crate::test_utils::init_test_tracing();
     let mut eval = Context::new();
     let bytes = || Some(vec![0xC0, 0x87]);
-    let hash = |eval: &mut Context, value: Value| -> i64 {
-        eval.obarray.set_symbol_value("neomacs-probe-a", value);
-        eval.eval_str("(sxhash-equal neomacs-probe-a)")
-            .expect("sxhash")
-            .as_fixnum()
-            .expect("fixnum hash")
-    };
 
     let base = byte_code_probe(
         Some(Value::NIL),
@@ -1196,7 +1220,21 @@ fn sxhash_equal_folds_constants_and_the_captured_environment() {
         simple_ops(),
         vec![Value::fixnum(1)],
     );
+    let base_twin = byte_code_probe(
+        Some(Value::NIL),
+        None,
+        bytes(),
+        simple_ops(),
+        vec![Value::fixnum(1)],
+    );
     let other_constants = byte_code_probe(
+        Some(Value::NIL),
+        None,
+        bytes(),
+        simple_ops(),
+        vec![Value::fixnum(2)],
+    );
+    let other_constants_twin = byte_code_probe(
         Some(Value::NIL),
         None,
         bytes(),
@@ -1213,16 +1251,37 @@ fn sxhash_equal_folds_constants_and_the_captured_environment() {
         simple_ops(),
         vec![Value::fixnum(1)],
     );
-
-    let base_hash = hash(&mut eval, base);
-    assert_ne!(
-        base_hash,
-        hash(&mut eval, other_constants),
-        "constants participate"
+    let other_env_twin = byte_code_probe(
+        Some(Value::list(vec![Value::cons(
+            Value::symbol("x"),
+            Value::fixnum(1),
+        )])),
+        None,
+        bytes(),
+        simple_ops(),
+        vec![Value::fixnum(1)],
     );
-    assert_ne!(
-        base_hash,
-        hash(&mut eval, other_env),
-        "the environment participates"
+
+    assert_eq!(
+        byte_code_probe_agreement(&mut eval, base, base_twin),
+        (true, true, true)
+    );
+    assert_eq!(
+        byte_code_probe_agreement(&mut eval, other_constants, other_constants_twin),
+        (true, true, true)
+    );
+    assert_eq!(
+        byte_code_probe_agreement(&mut eval, other_env, other_env_twin),
+        (true, true, true)
+    );
+
+    let (equal, _same_hash, table_found) =
+        byte_code_probe_agreement(&mut eval, base, other_constants);
+    assert!(!equal && !table_found, "constants participate in structure");
+
+    let (equal, _same_hash, table_found) = byte_code_probe_agreement(&mut eval, base, other_env);
+    assert!(
+        !equal && !table_found,
+        "the environment participates in structure"
     );
 }

--- a/crates/neovm-core/src/emacs_core/runtime/value/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/value/tests/mod.rs
@@ -970,3 +970,259 @@ fn equal_compares_byte_code_functions_element_wise_like_gnu_closures() {
         ]
     );
 }
+
+/// Build a byte-code object the way the VM and `make-closure` do, so the
+/// probes below can reach states `make-byte-code` cannot: a captured
+/// lexical environment (`Op::MakeClosure` stores `Some(lexenv)`, and that
+/// environment is `nil` for a closure over no variables), a docstring in
+/// either string representation, and a function with no retained GNU
+/// bytecode string.
+fn byte_code_probe(
+    env: Option<Value>,
+    docstring: Option<crate::heap_types::LispString>,
+    gnu_bytes: Option<Vec<u8>>,
+    ops: Vec<crate::emacs_core::bytecode::Op>,
+    constants: Vec<Value>,
+) -> Value {
+    use crate::emacs_core::bytecode::ByteCodeFunction;
+    Value::make_bytecode(ByteCodeFunction {
+        source_id: crate::emacs_core::bytecode::fresh_bytecode_source_id(),
+        ops_sealed: true,
+        stack_verified: false,
+        ops,
+        constants: constants.into(),
+        max_stack: 1,
+        params: LambdaParams::simple(vec![]),
+        arglist: Value::fixnum(257),
+        lexical: true,
+        env,
+        gnu_byte_offset_map: None,
+        gnu_bytecode_bytes: gnu_bytes.map(crate::tagged::header::LispByteVec::owned),
+        docstring,
+        doc_form: None,
+        interactive: None,
+        closure_slot_count: 4,
+        extra_slots: Vec::new(),
+        #[cfg(feature = "jit")]
+        runtime: Some(crate::emacs_core::jit::Runtime::new()),
+        lazy_gnu_code: None,
+    })
+}
+
+/// `(equal A B)`, whether `sxhash-equal` agrees, and whether an `equal`
+/// hash table keyed by A finds B -- the three surfaces that must agree.
+fn byte_code_probe_agreement(eval: &mut Context, a: Value, b: Value) -> (bool, bool, bool) {
+    eval.obarray.set_symbol_value("neomacs-probe-a", a);
+    eval.obarray.set_symbol_value("neomacs-probe-b", b);
+    let result = eval
+        .eval_str(
+            r#"
+(list (equal neomacs-probe-a neomacs-probe-b)
+      (= (sxhash-equal neomacs-probe-a) (sxhash-equal neomacs-probe-b))
+      (let ((table (make-hash-table :test 'equal)))
+        (puthash neomacs-probe-a 'found table)
+        (eq (gethash neomacs-probe-b table) 'found)))"#,
+        )
+        .expect("probe should evaluate");
+    let values = list_to_vec(&result).expect("probe list");
+    (
+        !values[0].is_nil(),
+        !values[1].is_nil(),
+        !values[2].is_nil(),
+    )
+}
+
+fn simple_ops() -> Vec<crate::emacs_core::bytecode::Op> {
+    use crate::emacs_core::bytecode::Op;
+    vec![Op::Constant(0), Op::Return]
+}
+
+/// A closure that captured an empty lexical environment (`env: Some(nil)`)
+/// is observably different from a function with no environment (`aref`
+/// slot 2 answers nil versus the constants vector), so `equal` says so --
+/// and the `equal`-table key must say the same, or two unequal objects
+/// share a bucket.
+#[test]
+fn equal_table_keys_keep_the_presence_of_a_captured_environment() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = Context::new();
+    let consts = || vec![Value::fixnum(42)];
+    let bytes = || Some(vec![0xC0, 0x87]);
+
+    let absent = byte_code_probe(None, None, bytes(), simple_ops(), consts());
+    let captured_nil = byte_code_probe(Some(Value::NIL), None, bytes(), simple_ops(), consts());
+    let captured_nil_twin =
+        byte_code_probe(Some(Value::NIL), None, bytes(), simple_ops(), consts());
+    let captured_w = byte_code_probe(
+        Some(Value::symbol("w")),
+        None,
+        bytes(),
+        simple_ops(),
+        consts(),
+    );
+
+    assert_eq!(
+        byte_code_probe_agreement(&mut eval, absent, captured_nil),
+        (false, false, false),
+        "no environment vs a captured nil environment"
+    );
+    assert_eq!(
+        byte_code_probe_agreement(&mut eval, captured_nil, captured_nil_twin),
+        (true, true, true)
+    );
+    assert_eq!(
+        byte_code_probe_agreement(&mut eval, captured_nil, captured_w),
+        (false, false, false),
+        "the captured environment participates in equal, sxhash and the key"
+    );
+}
+
+/// GNU string equality is character count, byte count and contents
+/// (src/fns.c `internal_equal_1`, Lisp_String); the unibyte/multibyte
+/// representation flag is not part of it.  An ASCII docstring stored
+/// unibyte equals the same text stored multibyte -- verified with GNU
+/// Emacs: `(equal (make-byte-code 257 "\300\207" [42] 2 "doc")
+/// (make-byte-code 257 "\300\207" [42] 2 (string-to-multibyte "doc")))` is t
+/// -- while a raw-byte unibyte string and the multibyte string with the
+/// same bytes differ in character count and are not equal.
+#[test]
+fn docstrings_compare_with_gnu_string_equality_not_representation() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = Context::new();
+    use crate::heap_types::LispString;
+    let consts = || vec![Value::fixnum(42)];
+    let bytes = || Some(vec![0xC0, 0x87]);
+
+    let unibyte = byte_code_probe(
+        None,
+        Some(LispString::from_unibyte(b"doc".to_vec())),
+        bytes(),
+        simple_ops(),
+        consts(),
+    );
+    let multibyte = byte_code_probe(
+        None,
+        Some(LispString::new("doc".to_owned(), true)),
+        bytes(),
+        simple_ops(),
+        consts(),
+    );
+    assert_eq!(
+        byte_code_probe_agreement(&mut eval, unibyte, multibyte),
+        (true, true, true),
+        "same characters, same bytes: equal in GNU"
+    );
+
+    let raw_bytes = byte_code_probe(
+        None,
+        Some(LispString::from_unibyte(vec![0xC3, 0xA9])),
+        bytes(),
+        simple_ops(),
+        consts(),
+    );
+    let e_acute = byte_code_probe(
+        None,
+        Some(LispString::new("\u{e9}".to_owned(), true)),
+        bytes(),
+        simple_ops(),
+        consts(),
+    );
+    // GNU `sxhash_string` hashes the bytes, so these two collide in the
+    // hash -- legal for unequal objects -- while `equal` and the table key
+    // both tell them apart by character count.
+    assert_eq!(
+        byte_code_probe_agreement(&mut eval, raw_bytes, e_acute),
+        (false, true, false),
+        "two raw bytes are two characters; one multibyte character is one"
+    );
+}
+
+/// A function with no retained GNU bytecode string (the `byte-code` subr's
+/// transient functions, pdump stubs) has only its decoded instructions to
+/// compare: equal instructions and constants are equal, and different
+/// instructions are not, even though GNU's slot 1 would be nil for both.
+#[test]
+fn functions_without_gnu_bytes_compare_their_decoded_instructions() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = Context::new();
+    use crate::emacs_core::bytecode::Op;
+    let consts = || vec![Value::fixnum(42)];
+
+    let a = byte_code_probe(None, None, None, simple_ops(), consts());
+    let b = byte_code_probe(None, None, None, simple_ops(), consts());
+    let other_ops = byte_code_probe(
+        None,
+        None,
+        None,
+        vec![Op::Constant(0), Op::Constant(0), Op::Return],
+        consts(),
+    );
+    let with_bytes = byte_code_probe(None, None, Some(vec![0xC0, 0x87]), simple_ops(), consts());
+
+    assert_eq!(
+        byte_code_probe_agreement(&mut eval, a, b),
+        (true, true, true)
+    );
+    assert_eq!(
+        byte_code_probe_agreement(&mut eval, a, other_ops),
+        (false, false, false)
+    );
+    assert_eq!(
+        byte_code_probe_agreement(&mut eval, a, with_bytes),
+        (false, false, false),
+        "retained bytes versus none is a different object"
+    );
+}
+
+/// `sxhash_obj` hashes every slot `internal_equal` walks (src/fns.c:5525):
+/// the constants vector and the captured environment both move the hash.
+#[test]
+fn sxhash_equal_folds_constants_and_the_captured_environment() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = Context::new();
+    let bytes = || Some(vec![0xC0, 0x87]);
+    let hash = |eval: &mut Context, value: Value| -> i64 {
+        eval.obarray.set_symbol_value("neomacs-probe-a", value);
+        eval.eval_str("(sxhash-equal neomacs-probe-a)")
+            .expect("sxhash")
+            .as_fixnum()
+            .expect("fixnum hash")
+    };
+
+    let base = byte_code_probe(
+        Some(Value::NIL),
+        None,
+        bytes(),
+        simple_ops(),
+        vec![Value::fixnum(1)],
+    );
+    let other_constants = byte_code_probe(
+        Some(Value::NIL),
+        None,
+        bytes(),
+        simple_ops(),
+        vec![Value::fixnum(2)],
+    );
+    let other_env = byte_code_probe(
+        Some(Value::list(vec![Value::cons(
+            Value::symbol("x"),
+            Value::fixnum(1),
+        )])),
+        None,
+        bytes(),
+        simple_ops(),
+        vec![Value::fixnum(1)],
+    );
+
+    let base_hash = hash(&mut eval, base);
+    assert_ne!(
+        base_hash,
+        hash(&mut eval, other_constants),
+        "constants participate"
+    );
+    assert_ne!(
+        base_hash,
+        hash(&mut eval, other_env),
+        "the environment participates"
+    );
+}

--- a/crates/neovm-core/src/emacs_core/runtime/value/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/value/tests/mod.rs
@@ -877,3 +877,96 @@ fn type_predicates() {
         assert!(Value::char('x').is_char());
     });
 }
+
+/// GNU `internal_equal_1` (src/fns.c:2984-2998 in emacs-31.1, :2987-3001 on
+/// master) compares a `PVEC_CLOSURE` exactly like a vector: the size check
+/// first (`ASIZE`, so a five-slot closure never equals a four-slot one), then
+/// every slot element-wise -- arglist, bytecode string, constants vector,
+/// max depth, doc, interactive spec, and any extras.  `sxhash_obj`
+/// (:5525-5536) hashes the same slots through `sxhash_vector`, so two `equal`
+/// closures land in the same `equal` hash-table bucket.
+///
+/// The Lisp-visible consequence lsp-mode depends on: it removes the request
+/// cancel closure it put on the global `post-command-hook` by rebuilding an
+/// `equal` closure and calling `remove-hook` -> `delete`.  When byte-code
+/// objects compare only by identity, that hook is never removed, fires on
+/// every later command, and keeps sending `$/cancelRequest` to a server that
+/// has since been shut down ("Sending to process failed ... not running").
+///
+/// Expected values are GNU Emacs 32's for this exact probe.
+#[test]
+fn equal_compares_byte_code_functions_element_wise_like_gnu_closures() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = Context::new();
+    let result = eval
+        .eval_str(
+            r#"
+(let* ((a (make-byte-code 257 "\300\207" [42] 2))
+       (b (make-byte-code 257 "\300\207" [42] 2))
+       (c (make-byte-code 257 "\300\207" [43] 2))
+       (d (make-byte-code 257 "\300\207" [42] 3))
+       (e (make-byte-code 257 "\300\207" [42] 2 "doc"))
+       (f (make-byte-code 257 "\300\207" [42] 2 "doc"))
+       (g (make-byte-code 257 "\300\207" [42] 2 nil))
+       (h (make-byte-code 257 "\300\207" [42] 2 nil (list 'interactive "p")))
+       (i (make-byte-code 257 "\300\207" [42] 2 nil (list 'interactive "p")))
+       (j (make-byte-code 257 "\301\207" [42] 2))
+       (k (make-byte-code '(x) "\300\207" [42] 2))
+       (proto (make-byte-code 257 "\300\207" [placeholder] 2))
+       (k1 (make-closure proto 'w))
+       (k2 (make-closure proto 'w))
+       (k3 (make-closure proto 'z))
+       (table (make-hash-table :test 'equal))
+       (v (vector 257 "\300\207" [42] 2)))
+  (puthash a 'found table)
+  (list (equal a b)                       ; same slots, distinct objects
+        (equal a c)                       ; constants differ
+        (equal a d)                       ; max depth differs
+        (equal a e)                       ; doc slot differs
+        (equal e f)                       ; same doc
+        (equal a g)                       ; GNU ASIZE: 4 slots vs 5 slots
+        (equal h i)                       ; same interactive spec
+        (equal a j)                       ; bytecode differs
+        (equal a k)                       ; arglist differs
+        (equal k1 k2)                     ; make-closure: same captures
+        (equal k1 k3)                     ; make-closure: different capture
+        (eq k1 k2)
+        (equal a v)                       ; a plain vector is not a closure
+        (equal (list a 1) (list b 1))
+        (length (delete b (list a 1)))    ; what remove-hook does
+        (eq (car (member b (list 1 a))) a)
+        (= (sxhash-equal a) (sxhash-equal b))
+        (= (sxhash-equal k1) (sxhash-equal k2))
+        (gethash b table)
+        (gethash k1 (let ((tb (make-hash-table :test 'equal)))
+                      (puthash k2 'closure-found tb)
+                      tb))))"#,
+        )
+        .expect("byte-code equality probe should evaluate");
+
+    assert_eq!(
+        list_to_vec(&result).expect("probe returns a list"),
+        vec![
+            Value::T,
+            Value::NIL,
+            Value::NIL,
+            Value::NIL,
+            Value::T,
+            Value::NIL,
+            Value::T,
+            Value::NIL,
+            Value::NIL,
+            Value::T,
+            Value::NIL,
+            Value::NIL,
+            Value::NIL,
+            Value::T,
+            Value::fixnum(1),
+            Value::T,
+            Value::T,
+            Value::T,
+            Value::symbol("found"),
+            Value::symbol("closure-found"),
+        ]
+    );
+}

--- a/crates/neovm-oracle-tests/src/equality/hash_semantics.rs
+++ b/crates/neovm-oracle-tests/src/equality/hash_semantics.rs
@@ -188,6 +188,35 @@ fn oracle_equal_char_tables_obey_structural_hash_contract() {
 }
 
 #[test]
+fn oracle_byte_code_closures_obey_structural_equal_and_hash_contracts() {
+    return_if_neovm_enable_oracle_proptest_not_set!();
+
+    let form = r#"
+(let* ((a (make-byte-code 257 "\300\207" [42] 2))
+       (b (make-byte-code 257 "\300\207" [42] 2))
+       (different (make-byte-code 257 "\300\207" [43] 2))
+       (proto (make-byte-code 257 "\300\207" [placeholder] 2))
+       (closure-a (make-closure proto 'captured))
+       (closure-b (make-closure proto 'captured))
+       (table (make-hash-table :test 'equal)))
+  (puthash a 'byte-code-found table)
+  (puthash closure-a 'closure-found table)
+  (list
+   (equal a b)
+   (equal a different)
+   (equal closure-a closure-b)
+   (= (sxhash-equal a) (sxhash-equal b))
+   (= (sxhash-equal closure-a) (sxhash-equal closure-b))
+   (gethash b table 'missing)
+   (gethash closure-b table 'missing)
+   (length (delete b (list a 1)))))
+"#;
+
+    let expect = expect_test::expect![[r#""OK (t nil t t t byte-code-found closure-found 1)""#]];
+    crate::common::assert_oracle_parity_expect(form, expect);
+}
+
+#[test]
 fn oracle_sxhash_equal_invariants_for_properties_and_structures() {
     return_if_neovm_enable_oracle_proptest_not_set!();
 


### PR DESCRIPTION
## Summary

`equal` on two distinct byte-code objects always answered nil, and an `equal` hash table never found a closure by a rebuilt twin. GNU compares a `PVEC_CLOSURE` exactly like a vector: `internal_equal_1` (src/fns.c:2984-2998 in emacs-31.1, :2987-3001 on master) checks `ASIZE` first, then every slot element-wise (arglist, bytecode string, constants, max depth, doc, interactive spec, extras), and `sxhash_obj` (:5525-5536) hashes the same slots through `sxhash_vector`. Here the pseudovector arm of `equal_value_inner`, its error-propagating twin, `emacs_sxhash_obj`, and the `equal`-table key builder all fell through to identity for `VecLikeType::ByteCode`, while interpreted closures were already compared structurally.

This PR adds the slot walk in all four places, in GNU's slot order, over the typed fields that stand in for GNU's vector (`bytecode_equal`, `try_bytecode_equal`, `emacs_sxhash_bytecode`, `bytecode_to_equal_key`). Two cases have no GNU counterpart and compare strictly: a function with no retained GNU bytes compares its decoded instructions, and a captured `env` alist is compared in addition to the constants. The equal-table key reuses existing `HashKey` variants (a tagged `EqualVec` with the bytecode keyed byte-exact), so the pdump codec is untouched.

## User-visible failure

After a language server shut down cleanly (follow-up to #310), every mouse movement produced

```
LSP :: Sending to process failed with the following error: Process nixd-lsp not running: killed: 9
```

For requests sent with `:mode 'unchanged`, `lsp--send-request-async` installs a cancel closure on the **global** `post-command-hook` and later removes it by rebuilding an `equal` closure and calling `remove-hook` (`delete`). With identity-only `equal` the hook was never removed; it fired on every later command, and with eldoc-box's mouse mode setting `track-mouse` every mouse motion is a command, so each one sent `$/cancelRequest` to the dead workspace.

## Oracle

Same probe under GNU Emacs 32 and neomacs (`-Q --batch`), before and after:

```elisp
(let* ((a (make-byte-code 257 "\300\207" [42] 2))
       (b (make-byte-code 257 "\300\207" [42] 2))
       (proto (make-byte-code 257 "\300\207" [placeholder] 2))
       (k1 (make-closure proto 'w)) (k2 (make-closure proto 'w)))
  (list (equal a b) (equal k1 k2) (length (delete b (list a 1)))
        (= (sxhash-equal a) (sxhash-equal b))))
```

| | result |
|---|---|
| GNU Emacs 32 | `(t t 1 t)` |
| neomacs before | `(nil nil 2 nil)` |
| neomacs after | `(t t 1 t)` |

With the user's real lsp-mode (plists) and real nixd in batch: the cancel closure count on the global hook goes 1 → 0 after one command in another buffer, and stays 0 after the server is shut down, identical to vanilla. Before the fix the closure stayed on the hook (count 1) and `remove-hook` with the factory's rebuilt closure was a no-op.

## Test

`equal_compares_byte_code_functions_element_wise_like_gnu_closures` (red first) pins a twenty-probe list against GNU's values: `make-byte-code` twins; differing constants, depth, doc, bytecode, arglist, and slot count (`ASIZE`); `make-closure` instances with equal and different captures; closure vs. plain vector; `delete`, `member`, `sxhash-equal`, and `equal` hash-table lookup.

Ran on macOS (Darwin 25.6.0, arm64): the new test plus the `value::tests`, `hashtab`, `equal_including`, `sxhash`, `bytecode::tests`, `make_closure`, and `closure` filters. One slow test (`expanded_cache_replay_preserves_oclosure_define_class_registration`) failed once in the parallel run and passed solo three times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117NsCB7AbwgdEqduGF5Kww
