### PR TITLE
Keep oversized xwidgets visible with GNU-compatible geometry (#301)

### DIFF
--- a/crates/neomacs-display-protocol/src/frame_glyphs.rs
+++ b/crates/neomacs-display-protocol/src/frame_glyphs.rs
@@ -12,6 +12,7 @@ use crate::types::{
     Color, DisplayFrameId, DisplayWindowId, FaceId, ImageId, Px, Rect, SurfaceId, VideoId,
     WebViewId, XwidgetId,
 };
+use crate::xwidget_extent::XwidgetContentExtent;
 use crate::{ContentTransitionIntent, TransitionDirection};
 use std::collections::HashMap;
 
@@ -242,6 +243,14 @@ pub enum FrameGlyph {
     },
 
     /// Xwidget glyph (inline in buffer).
+    ///
+    /// Three extents, as in GNU (see [`XwidgetContentExtent`]): `x`, `y`,
+    /// `width`, `height` are the glyph slot, the layout advance after
+    /// `produce_xwidget_glyph`'s right-edge crop and the cell a cursor on the
+    /// glyph occupies; `content` is the widget's own size, which sizes the
+    /// native view; `clip_rect` is the window's text area, which bounds what
+    /// of the widget is visible.  Native placement reads `content`, never
+    /// `width`.
     Xwidget {
         window_id: DisplayWindowId,
         row_role: GlyphRowRole,
@@ -253,6 +262,7 @@ pub enum FrameGlyph {
         y: f32,
         width: f32,
         height: f32,
+        content: XwidgetContentExtent,
         face_id: FaceId,
         box_vertical_edges: BoxVerticalEdges,
     },
@@ -2027,15 +2037,16 @@ impl FrameGlyphBuffer {
         });
     }
 
-    /// Add an xwidget glyph.
+    /// Add an xwidget glyph whose slot is `slot_width` wide: the widget's
+    /// `content` width when nothing cropped it, less when the right edge did.
     pub fn add_xwidget(
         &mut self,
         xwidget_id: XwidgetId,
         webview_id: WebViewId,
         x: f32,
         y: f32,
-        width: f32,
-        height: f32,
+        content: XwidgetContentExtent,
+        slot_width: f32,
     ) {
         self.glyphs.push(FrameGlyph::Xwidget {
             window_id: self.current_window_id,
@@ -2046,8 +2057,9 @@ impl FrameGlyphBuffer {
             webview_id,
             x,
             y,
-            width,
-            height,
+            width: slot_width,
+            height: content.height_px(),
+            content,
             face_id: self.current_face_id,
             box_vertical_edges: BoxVerticalEdges::Both,
         });

--- a/crates/neomacs-display-protocol/src/frame_glyphs.rs
+++ b/crates/neomacs-display-protocol/src/frame_glyphs.rs
@@ -12,8 +12,10 @@ use crate::types::{
     Color, DisplayFrameId, DisplayWindowId, FaceId, ImageId, Px, Rect, SurfaceId, VideoId,
     WebViewId, XwidgetId,
 };
-use crate::xwidget_extent::XwidgetContentExtent;
-use crate::{ContentTransitionIntent, TransitionDirection};
+use crate::xwidget_extent::XwidgetPresentationGeometry;
+use crate::{
+    ContentTransitionIntent, FrameSpace, GeometryRect, LogicalPixels, TransitionDirection,
+};
 use std::collections::HashMap;
 
 pub use crate::cursor::{CursorBarWidth, CursorKind, CursorSpec, CursorStyle};
@@ -244,25 +246,17 @@ pub enum FrameGlyph {
 
     /// Xwidget glyph (inline in buffer).
     ///
-    /// Three extents, as in GNU (see [`XwidgetContentExtent`]): `x`, `y`,
-    /// `width`, `height` are the glyph slot, the layout advance after
-    /// `produce_xwidget_glyph`'s right-edge crop and the cell a cursor on the
-    /// glyph occupies; `content` is the widget's own size, which sizes the
-    /// native view; `clip_rect` is the window's text area, which bounds what
-    /// of the widget is visible.  Native placement reads `content`, never
-    /// `width`.
+    /// [`XwidgetPresentationGeometry`] keeps GNU's three distinct geometries
+    /// together: intrinsic widget content, possibly cropped glyph advance,
+    /// and the window clip.  Native placement, Linux composition, cursor
+    /// geometry, and hit-testing all consume that one typed contract.
     Xwidget {
         window_id: DisplayWindowId,
         row_role: GlyphRowRole,
-        clip_rect: Option<Rect>,
         slot_id: Option<DisplaySlotId>,
         xwidget_id: XwidgetId,
         webview_id: WebViewId,
-        x: f32,
-        y: f32,
-        width: f32,
-        height: f32,
-        content: XwidgetContentExtent,
+        presentation: XwidgetPresentationGeometry<FrameSpace>,
         face_id: FaceId,
         box_vertical_edges: BoxVerticalEdges,
     },
@@ -490,13 +484,6 @@ impl FrameGlyph {
                 height,
                 ..
             }
-            | FrameGlyph::Xwidget {
-                x,
-                y,
-                width,
-                height,
-                ..
-            }
             | FrameGlyph::Surface {
                 x,
                 y,
@@ -504,6 +491,10 @@ impl FrameGlyph {
                 height,
                 ..
             } => Some((*x, *y, *width, *height)),
+            FrameGlyph::Xwidget { presentation, .. } => {
+                let slot = presentation.layout_slot_rect();
+                Some((slot.x(), slot.y(), slot.width(), slot.height()))
+            }
             FrameGlyph::Image { slot_rect, .. } => {
                 Some((slot_rect.x, slot_rect.y, slot_rect.width, slot_rect.height))
             }
@@ -574,11 +565,13 @@ impl FrameGlyph {
             | FrameGlyph::Stretch { clip_rect, .. }
             | FrameGlyph::Image { clip_rect, .. }
             | FrameGlyph::Video { clip_rect, .. }
-            | FrameGlyph::Xwidget { clip_rect, .. }
             | FrameGlyph::Surface { clip_rect, .. }
             | FrameGlyph::FringeBitmap { clip_rect, .. }
             | FrameGlyph::Border { clip_rect, .. }
             | FrameGlyph::ScrollBar { clip_rect, .. } => *clip_rect,
+            FrameGlyph::Xwidget { presentation, .. } => presentation
+                .clip_rect()
+                .map(|clip| Rect::new(clip.x(), clip.y(), clip.width(), clip.height())),
             _ => None,
         }
     }
@@ -617,13 +610,6 @@ impl FrameGlyph {
                 height,
                 ..
             }
-            | FrameGlyph::Xwidget {
-                x,
-                y,
-                width,
-                height,
-                ..
-            }
             | FrameGlyph::Surface {
                 x,
                 y,
@@ -652,6 +638,10 @@ impl FrameGlyph {
                 height,
                 ..
             } => Some(Rect::new(*x, *y, *width, *height)),
+            FrameGlyph::Xwidget { presentation, .. } => {
+                let slot = presentation.layout_slot_rect();
+                Some(Rect::new(slot.x(), slot.y(), slot.width(), slot.height()))
+            }
             FrameGlyph::Background { bounds, .. } => Some(*bounds),
             #[cfg(feature = "neo-term")]
             FrameGlyph::Terminal {
@@ -2043,23 +2033,21 @@ impl FrameGlyphBuffer {
         &mut self,
         xwidget_id: XwidgetId,
         webview_id: WebViewId,
-        x: f32,
-        y: f32,
-        content: XwidgetContentExtent,
-        slot_width: f32,
+        presentation: XwidgetPresentationGeometry<FrameSpace>,
     ) {
+        let clip = self.current_clip_rect.map(|clip| {
+            GeometryRect::<FrameSpace, LogicalPixels>::new(clip.x, clip.y, clip.width, clip.height)
+                .expect("a frame draw-context clip has valid geometry")
+        });
+        let presentation = presentation.with_clip(clip);
+        let origin = presentation.origin();
         self.glyphs.push(FrameGlyph::Xwidget {
             window_id: self.current_window_id,
             row_role: self.current_row_role,
-            clip_rect: self.current_clip_rect,
-            slot_id: Some(self.current_slot_id(x, y)),
+            slot_id: Some(self.current_slot_id(origin.x(), origin.y())),
             xwidget_id,
             webview_id,
-            x,
-            y,
-            width: slot_width,
-            height: content.height_px(),
-            content,
+            presentation,
             face_id: self.current_face_id,
             box_vertical_edges: BoxVerticalEdges::Both,
         });
@@ -2413,13 +2401,6 @@ impl FrameGlyphBuffer {
                     height: slot_height,
                     ..
                 }
-                | FrameGlyph::Xwidget {
-                    x: slot_x,
-                    y: slot_y,
-                    width: slot_width,
-                    height: slot_height,
-                    ..
-                }
                 | FrameGlyph::Surface {
                     x: slot_x,
                     y: slot_y,
@@ -2428,6 +2409,15 @@ impl FrameGlyphBuffer {
                     ..
                 } => {
                     return (*slot_x, *slot_y, slot_width.max(1.0), slot_height.max(1.0));
+                }
+                FrameGlyph::Xwidget { presentation, .. } => {
+                    let slot = presentation.layout_slot_rect();
+                    return (
+                        slot.x(),
+                        slot.y(),
+                        slot.width().max(1.0),
+                        slot.height().max(1.0),
+                    );
                 }
                 _ => {}
             }

--- a/crates/neomacs-display-protocol/src/frame_glyphs_test.rs
+++ b/crates/neomacs-display-protocol/src/frame_glyphs_test.rs
@@ -1718,13 +1718,14 @@ fn add_video_appends_video_glyph() {
 #[test]
 fn add_xwidget_appends_xwidget_glyph() {
     let mut buf = FrameGlyphBuffer::new();
+    let content = crate::XwidgetContentExtent::new(800.0, 600.0).expect("content extent");
     buf.add_xwidget(
         XwidgetId::new(99),
         WebViewId::new(700),
         0.0,
         0.0,
+        content,
         800.0,
-        600.0,
     );
 
     match &buf.glyphs[0] {

--- a/crates/neomacs-display-protocol/src/frame_glyphs_test.rs
+++ b/crates/neomacs-display-protocol/src/frame_glyphs_test.rs
@@ -1719,23 +1719,25 @@ fn add_video_appends_video_glyph() {
 fn add_xwidget_appends_xwidget_glyph() {
     let mut buf = FrameGlyphBuffer::new();
     let content = crate::XwidgetContentExtent::new(800.0, 600.0).expect("content extent");
-    buf.add_xwidget(
-        XwidgetId::new(99),
-        WebViewId::new(700),
-        0.0,
-        0.0,
+    let presentation = crate::XwidgetPresentationGeometry::new(
+        crate::GeometryPoint::<crate::FrameSpace, crate::LogicalPixels>::from_px(0.0, 0.0)
+            .expect("frame-local origin"),
         content,
-        800.0,
+        crate::XwidgetLayoutAdvance::new(crate::Px(800.0)).expect("layout advance"),
+        None,
     );
+    buf.add_xwidget(XwidgetId::new(99), WebViewId::new(700), presentation);
 
     match &buf.glyphs[0] {
         FrameGlyph::Xwidget {
             xwidget_id,
             webview_id,
+            presentation,
             ..
         } => {
             assert_eq!(xwidget_id.get(), 99);
             assert_eq!(webview_id.get(), 700);
+            assert_eq!(presentation.content_extent(), content);
         }
         other => panic!("Expected Xwidget glyph, got {:?}", other),
     }

--- a/crates/neomacs-display-protocol/src/glyph_matrix.rs
+++ b/crates/neomacs-display-protocol/src/glyph_matrix.rs
@@ -22,7 +22,10 @@ use super::types::{
     Color, DisplayWindowId, FaceId, ImageId, Px, Rect, ResolvedBidiDirection, SurfaceId, VideoId,
     WebViewId, XwidgetId,
 };
-use super::xwidget_extent::XwidgetContentExtent;
+use super::xwidget_extent::{
+    XwidgetContentExtent, XwidgetLayoutAdvance, XwidgetPresentationGeometry,
+};
+use super::{FrameSpace, GeometryPoint, GeometryRect, LogicalPixels};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::collections::HashMap;
 
@@ -3236,20 +3239,34 @@ impl FrameDisplayState {
                         } else {
                             row_height
                         };
+                        let origin = GeometryPoint::<FrameSpace, LogicalPixels>::from_px(
+                            x,
+                            baseline - layout_ascent + glyph.vertical_offset_px,
+                        )
+                        .expect("materialized xwidget origin is finite");
+                        let clip = clip_rect.map(|clip| {
+                            GeometryRect::<FrameSpace, LogicalPixels>::new(
+                                clip.x,
+                                clip.y,
+                                clip.width,
+                                clip.height,
+                            )
+                            .expect("materialized xwidget clip is valid")
+                        });
+                        let layout_advance = XwidgetLayoutAdvance::new(Px(materialized_width))
+                            .expect("a materialized xwidget has positive finite width");
                         push(FrameGlyph::Xwidget {
                             window_id,
                             row_role,
-                            clip_rect,
                             slot_id: Some(slot_id),
                             xwidget_id: *xwidget_id,
                             webview_id: *webview_id,
-                            x,
-                            y: baseline - layout_ascent + glyph.vertical_offset_px,
-                            width: materialized_width,
-                            // The slot is as tall as the widget; the row's
-                            // vertical clip, not the glyph, bounds what shows.
-                            height: content.height_px(),
-                            content: *content,
+                            presentation: XwidgetPresentationGeometry::new(
+                                origin,
+                                *content,
+                                layout_advance,
+                                clip,
+                            ),
                             face_id: glyph.face_id,
                             box_vertical_edges: glyph.box_vertical_edges,
                         });

--- a/crates/neomacs-display-protocol/src/glyph_matrix.rs
+++ b/crates/neomacs-display-protocol/src/glyph_matrix.rs
@@ -3253,7 +3253,13 @@ impl FrameDisplayState {
                             )
                             .expect("materialized xwidget clip is valid")
                         });
-                        let layout_advance = XwidgetLayoutAdvance::new(Px(materialized_width))
+                        // Unlike ordinary painted glyphs, an xwidget carries
+                        // its visible text-area clip separately.  GNU keeps a
+                        // narrow overflowing xwidget's whole glyph advance in
+                        // truncating rows (`display_line`, src/xdisp.c) and
+                        // clips only the native presentation
+                        // (`x_draw_xwidget_glyph_string`, src/xwidget.c).
+                        let layout_advance = XwidgetLayoutAdvance::new(Px(glyph_width))
                             .expect("a materialized xwidget has positive finite width");
                         push(FrameGlyph::Xwidget {
                             window_id,

--- a/crates/neomacs-display-protocol/src/glyph_matrix.rs
+++ b/crates/neomacs-display-protocol/src/glyph_matrix.rs
@@ -3246,7 +3246,9 @@ impl FrameDisplayState {
                             x,
                             y: baseline - layout_ascent + glyph.vertical_offset_px,
                             width: materialized_width,
-                            height: layout_height,
+                            // The slot is as tall as the widget; the row's
+                            // vertical clip, not the glyph, bounds what shows.
+                            height: content.height_px(),
                             content: *content,
                             face_id: glyph.face_id,
                             box_vertical_edges: glyph.box_vertical_edges,

--- a/crates/neomacs-display-protocol/src/glyph_matrix.rs
+++ b/crates/neomacs-display-protocol/src/glyph_matrix.rs
@@ -22,6 +22,7 @@ use super::types::{
     Color, DisplayWindowId, FaceId, ImageId, Px, Rect, ResolvedBidiDirection, SurfaceId, VideoId,
     WebViewId, XwidgetId,
 };
+use super::xwidget_extent::XwidgetContentExtent;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::collections::HashMap;
 
@@ -99,11 +100,16 @@ pub enum GlyphType {
         width_cols: u16,
         opacity: f32,
     },
-    /// Inline native/web widget.
+    /// Inline native/web widget.  `width_cols` and the glyph's `pixel_width`
+    /// are the layout advance, which `produce_xwidget_glyph` may crop at the
+    /// right edge (src/xdisp.c:32577-32579, emacs-31.0.90); `content` is the
+    /// widget's own size, GNU `xw->width`/`xw->height`, which the crop never
+    /// touches.
     Xwidget {
         xwidget_id: XwidgetId,
         webview_id: WebViewId,
         width_cols: u16,
+        content: XwidgetContentExtent,
     },
     /// Inline shader surface (NeoMacs extension): a compositor-rendered GPU
     /// texture owned by the row primitive that reserves its layout slot.
@@ -1141,11 +1147,14 @@ impl GlyphRow {
                         xwidget_id,
                         webview_id,
                         width_cols,
+                        content,
                     } => {
                         0x5000_0000
                             ^ u64::from(xwidget_id.get())
                             ^ u64::from(webview_id.get()).rotate_left(17)
                             ^ u64::from(*width_cols).rotate_left(9)
+                            ^ u64::from(content.width_px().to_bits()).rotate_left(29)
+                            ^ u64::from(content.height_px().to_bits()).rotate_left(41)
                     }
                     GlyphType::Surface {
                         surface_id,
@@ -3209,6 +3218,7 @@ impl FrameDisplayState {
                     GlyphType::Xwidget {
                         xwidget_id,
                         webview_id,
+                        content,
                         ..
                     } => {
                         let layout_height = if glyph.pixel_height > 0.0 {
@@ -3237,6 +3247,7 @@ impl FrameDisplayState {
                             y: baseline - layout_ascent + glyph.vertical_offset_px,
                             width: materialized_width,
                             height: layout_height,
+                            content: *content,
                             face_id: glyph.face_id,
                             box_vertical_edges: glyph.box_vertical_edges,
                         });

--- a/crates/neomacs-display-protocol/src/lib.rs
+++ b/crates/neomacs-display-protocol/src/lib.rs
@@ -33,6 +33,7 @@ pub mod types;
 pub mod ui_types;
 pub mod visual_config;
 pub mod xterm_palette;
+pub mod xwidget_extent;
 pub use glyph_matrix::*;
 pub mod tty_capabilities;
 
@@ -59,6 +60,7 @@ pub use types::*;
 pub use ui_types::*;
 pub use visual_config::*;
 pub use xterm_palette::xterm_256_rgb;
+pub use xwidget_extent::*;
 
 #[cfg(test)]
 #[path = "frame_chrome_test.rs"]

--- a/crates/neomacs-display-protocol/src/xwidget_extent.rs
+++ b/crates/neomacs-display-protocol/src/xwidget_extent.rs
@@ -21,11 +21,54 @@
 /// with, and therefore the size of the native web view's content area.
 ///
 /// Both dimensions are finite and strictly positive; a widget with no area
-/// has no native view to place.
+/// has no native view to place.  [`XwidgetContentExtent::new`] is the only
+/// way in: deserialization goes through it as well, so a serialized frame
+/// cannot carry an extent the constructor would refuse.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "XwidgetContentExtentWire")]
 pub struct XwidgetContentExtent {
     width_px: f32,
     height_px: f32,
+}
+
+/// The serialized shape of [`XwidgetContentExtent`]: the two raw
+/// dimensions, validated by [`XwidgetContentExtent::new`] on the way in.
+#[derive(serde::Deserialize)]
+struct XwidgetContentExtentWire {
+    width_px: f32,
+    height_px: f32,
+}
+
+/// A serialized extent that [`XwidgetContentExtent::new`] refuses.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct InvalidXwidgetContentExtent {
+    /// The rejected width.
+    pub width_px: f32,
+    /// The rejected height.
+    pub height_px: f32,
+}
+
+impl std::fmt::Display for InvalidXwidgetContentExtent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "xwidget content extent {} x {} px is not finite and strictly positive",
+            self.width_px, self.height_px
+        )
+    }
+}
+
+impl std::error::Error for InvalidXwidgetContentExtent {}
+
+impl TryFrom<XwidgetContentExtentWire> for XwidgetContentExtent {
+    type Error = InvalidXwidgetContentExtent;
+
+    fn try_from(wire: XwidgetContentExtentWire) -> Result<Self, Self::Error> {
+        Self::new(wire.width_px, wire.height_px).ok_or(InvalidXwidgetContentExtent {
+            width_px: wire.width_px,
+            height_px: wire.height_px,
+        })
+    }
 }
 
 impl XwidgetContentExtent {

--- a/crates/neomacs-display-protocol/src/xwidget_extent.rs
+++ b/crates/neomacs-display-protocol/src/xwidget_extent.rs
@@ -17,6 +17,10 @@
 //! frame glyph carry it next to the cropped advance so the native placement
 //! reads the widget size from here and never from the layout width.
 
+use crate::{
+    GeometryError, GeometryPoint, GeometryRect, GeometrySize, LogicalPixels, Px, SpaceTranslation,
+};
+
 /// GNU `xw->width` / `xw->height`: the pixel size the xwidget was created
 /// with, and therefore the size of the native web view's content area.
 ///
@@ -90,6 +94,241 @@ impl XwidgetContentExtent {
     #[must_use]
     pub const fn height_px(self) -> f32 {
         self.height_px
+    }
+
+    fn geometry_size(self) -> GeometrySize<LogicalPixels> {
+        GeometrySize::<LogicalPixels>::from_px(self.width_px, self.height_px)
+            .expect("an xwidget content extent is finite and positive")
+    }
+}
+
+/// The horizontal row advance occupied by one xwidget glyph.
+///
+/// This is deliberately distinct from [`XwidgetContentExtent`].  GNU may
+/// crop the advance while keeping the native widget at its intrinsic size;
+/// carrying a branded value prevents a caller from accidentally passing the
+/// content width where a cropped glyph width is required.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct XwidgetLayoutAdvance(Px);
+
+impl XwidgetLayoutAdvance {
+    /// Construct a finite, strictly positive glyph advance.
+    #[must_use]
+    pub fn new(px: Px) -> Option<Self> {
+        (px.get().is_finite() && px.get() > 0.0).then_some(Self(px))
+    }
+
+    #[must_use]
+    pub const fn px(self) -> Px {
+        self.0
+    }
+}
+
+/// Coordinates inside the xwidget's own content surface.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum XwidgetContentSpace {}
+
+/// The complete portable geometry contract for one presented xwidget.
+///
+/// `Space` brands the coordinate system of the origin and clip.  Layout emits
+/// frame-space geometry; child-frame ingestion translates it into root-surface
+/// geometry.  The intrinsic content extent and cropped layout advance remain
+/// different types throughout that conversion.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct XwidgetPresentationGeometry<Space> {
+    origin: GeometryPoint<Space, LogicalPixels>,
+    content: XwidgetContentExtent,
+    layout_advance: XwidgetLayoutAdvance,
+    clip: Option<GeometryRect<Space, LogicalPixels>>,
+}
+
+impl<Space: Copy> XwidgetPresentationGeometry<Space> {
+    #[must_use]
+    pub const fn new(
+        origin: GeometryPoint<Space, LogicalPixels>,
+        content: XwidgetContentExtent,
+        layout_advance: XwidgetLayoutAdvance,
+        clip: Option<GeometryRect<Space, LogicalPixels>>,
+    ) -> Self {
+        Self {
+            origin,
+            content,
+            layout_advance,
+            clip,
+        }
+    }
+
+    #[must_use]
+    pub const fn origin(&self) -> &GeometryPoint<Space, LogicalPixels> {
+        &self.origin
+    }
+
+    #[must_use]
+    pub const fn content_extent(self) -> XwidgetContentExtent {
+        self.content
+    }
+
+    #[must_use]
+    pub const fn layout_advance(self) -> XwidgetLayoutAdvance {
+        self.layout_advance
+    }
+
+    #[must_use]
+    pub const fn clip_rect(self) -> Option<GeometryRect<Space, LogicalPixels>> {
+        self.clip
+    }
+
+    /// Replace the presentation clip while preserving intrinsic content and
+    /// layout geometry.  Frame builders use this to install their current
+    /// draw-context clip exactly once.
+    #[must_use]
+    pub const fn with_clip(mut self, clip: Option<GeometryRect<Space, LogicalPixels>>) -> Self {
+        self.clip = clip;
+        self
+    }
+
+    #[must_use]
+    pub fn content_rect(self) -> GeometryRect<Space, LogicalPixels> {
+        GeometryRect::from_origin_and_size(self.origin, self.content.geometry_size())
+    }
+
+    #[must_use]
+    pub fn layout_slot_rect(self) -> GeometryRect<Space, LogicalPixels> {
+        GeometryRect::from_origin_and_size(
+            self.origin,
+            GeometrySize::<LogicalPixels>::from_px(
+                self.layout_advance.px().get(),
+                self.content.height_px(),
+            )
+            .expect("an xwidget advance and content height are finite and positive"),
+        )
+    }
+
+    /// Resolve the native/GPU-visible part of the widget through its text-area
+    /// clip and an optional enclosing-frame clip.
+    pub fn resolve_visible(
+        self,
+        enclosing_clip: Option<GeometryRect<Space, LogicalPixels>>,
+    ) -> Result<Option<XwidgetVisibleGeometry<Space>>, GeometryError> {
+        let content = self.content_rect();
+        let visible = match self.clip {
+            Some(clip) => content.try_intersection(clip)?,
+            None => Some(content),
+        };
+        let visible = match (visible, enclosing_clip) {
+            (Some(visible), Some(clip)) => visible.try_intersection(clip)?,
+            (visible, None) => visible,
+            (None, _) => None,
+        };
+        Ok(visible.map(|visible| XwidgetVisibleGeometry { content, visible }))
+    }
+
+    /// Translate the presentation while changing its coordinate-space brand.
+    pub fn translated<To: Copy>(
+        self,
+        translation: SpaceTranslation<Space, To, LogicalPixels>,
+    ) -> Result<XwidgetPresentationGeometry<To>, GeometryError> {
+        let origin = translation.map_point(&self.origin)?;
+        let clip = self
+            .clip
+            .map(|clip| translation.map_rect(clip))
+            .transpose()?;
+        Ok(XwidgetPresentationGeometry::new(
+            origin,
+            self.content,
+            self.layout_advance,
+            clip,
+        ))
+    }
+
+    /// Move the glyph within the same coordinate space without moving its
+    /// enclosing window clip.
+    ///
+    /// This is distinct from [`Self::translated`], which maps the complete
+    /// presentation into another coordinate space and therefore translates
+    /// both origin and clip.  Post-layout glyph spacing moves only the glyph.
+    pub fn translated_origin(
+        self,
+        displacement: SpaceTranslation<Space, Space, LogicalPixels>,
+    ) -> Result<Self, GeometryError> {
+        Ok(Self::new(
+            displacement.map_point(&self.origin)?,
+            self.content,
+            self.layout_advance,
+            self.clip,
+        ))
+    }
+}
+
+/// Intrinsic and clipped rectangles after resolving one presentation.
+///
+/// All consumers use this result: native placement reads both rectangles,
+/// Linux composition additionally reads the texture coordinates, and pointer
+/// dispatch maps a visible point into [`XwidgetContentSpace`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct XwidgetVisibleGeometry<Space> {
+    content: GeometryRect<Space, LogicalPixels>,
+    visible: GeometryRect<Space, LogicalPixels>,
+}
+
+impl<Space: Copy> XwidgetVisibleGeometry<Space> {
+    #[must_use]
+    pub const fn content_rect(self) -> GeometryRect<Space, LogicalPixels> {
+        self.content
+    }
+
+    #[must_use]
+    pub const fn visible_rect(self) -> GeometryRect<Space, LogicalPixels> {
+        self.visible
+    }
+
+    #[must_use]
+    pub fn texture_coordinates(self) -> XwidgetTextureCoordinates {
+        XwidgetTextureCoordinates {
+            u_min: (self.visible.x() - self.content.x()) / self.content.width(),
+            u_max: (self.visible.x() + self.visible.width() - self.content.x())
+                / self.content.width(),
+            v_min: (self.visible.y() - self.content.y()) / self.content.height(),
+            v_max: (self.visible.y() + self.visible.height() - self.content.y())
+                / self.content.height(),
+        }
+    }
+
+    /// Map a visible point in the presentation's coordinate space into the
+    /// widget's intrinsic content coordinates.
+    #[must_use]
+    pub fn content_point_at(
+        self,
+        point: GeometryPoint<Space, LogicalPixels>,
+    ) -> Option<GeometryPoint<XwidgetContentSpace, LogicalPixels>> {
+        let inside = point.x() >= self.visible.x()
+            && point.x() < self.visible.x() + self.visible.width()
+            && point.y() >= self.visible.y()
+            && point.y() < self.visible.y() + self.visible.height();
+        inside.then(|| {
+            GeometryPoint::<XwidgetContentSpace, LogicalPixels>::from_px(
+                point.x() - self.content.x(),
+                point.y() - self.content.y(),
+            )
+            .expect("the difference of finite visible and content coordinates is finite")
+        })
+    }
+}
+
+/// Normalized source coordinates for the visible part of an xwidget texture.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct XwidgetTextureCoordinates {
+    u_min: f32,
+    u_max: f32,
+    v_min: f32,
+    v_max: f32,
+}
+
+impl XwidgetTextureCoordinates {
+    #[must_use]
+    pub const fn as_array(self) -> [f32; 4] {
+        [self.u_min, self.u_max, self.v_min, self.v_max]
     }
 }
 

--- a/crates/neomacs-display-protocol/src/xwidget_extent.rs
+++ b/crates/neomacs-display-protocol/src/xwidget_extent.rs
@@ -5,7 +5,7 @@
 //!
 //! - the widget's own size, `xw->width` / `xw->height`, which is what the
 //!   native view is sized to (`x_draw_xwidget_glyph_string` sizes the view
-//!   from `xww->width` and only clips it, src/xwidget.c:2841-2847 in
+//!   from `xww->width` and only clips it, src/xwidget.c:2841-2849 in
 //!   emacs-31.0.90);
 //! - the glyph's layout advance, `glyph->pixel_width`, which
 //!   `produce_xwidget_glyph` may crop at the right edge of the text area

--- a/crates/neomacs-display-protocol/src/xwidget_extent.rs
+++ b/crates/neomacs-display-protocol/src/xwidget_extent.rs
@@ -1,0 +1,55 @@
+//! The intrinsic size of an inline xwidget, kept apart from the glyph that
+//! places it.
+//!
+//! GNU keeps three extents for one xwidget glyph and never conflates them:
+//!
+//! - the widget's own size, `xw->width` / `xw->height`, which is what the
+//!   native view is sized to (`x_draw_xwidget_glyph_string` sizes the view
+//!   from `xww->width` and only clips it, src/xwidget.c:2841-2847 in
+//!   emacs-31.0.90);
+//! - the glyph's layout advance, `glyph->pixel_width`, which
+//!   `produce_xwidget_glyph` may crop at the right edge of the text area
+//!   (src/xdisp.c:32577-32579);
+//! - the visible clip, the window's text area (`window_box (s->w, xv->area,
+//!   …)`, src/xwidget.c:2841).
+//!
+//! [`XwidgetContentExtent`] is the first of these.  The glyph matrix and the
+//! frame glyph carry it next to the cropped advance so the native placement
+//! reads the widget size from here and never from the layout width.
+
+/// GNU `xw->width` / `xw->height`: the pixel size the xwidget was created
+/// with, and therefore the size of the native web view's content area.
+///
+/// Both dimensions are finite and strictly positive; a widget with no area
+/// has no native view to place.
+#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct XwidgetContentExtent {
+    width_px: f32,
+    height_px: f32,
+}
+
+impl XwidgetContentExtent {
+    /// `None` unless both dimensions are finite and strictly positive.
+    #[must_use]
+    pub fn new(width_px: f32, height_px: f32) -> Option<Self> {
+        let valid = |value: f32| value.is_finite() && value > 0.0;
+        (valid(width_px) && valid(height_px)).then_some(Self {
+            width_px,
+            height_px,
+        })
+    }
+
+    #[must_use]
+    pub const fn width_px(self) -> f32 {
+        self.width_px
+    }
+
+    #[must_use]
+    pub const fn height_px(self) -> f32 {
+        self.height_px
+    }
+}
+
+#[cfg(test)]
+#[path = "xwidget_extent_test.rs"]
+mod tests;

--- a/crates/neomacs-display-protocol/src/xwidget_extent_test.rs
+++ b/crates/neomacs-display-protocol/src/xwidget_extent_test.rs
@@ -1,4 +1,7 @@
-use super::XwidgetContentExtent;
+use super::{XwidgetContentExtent, XwidgetLayoutAdvance, XwidgetPresentationGeometry};
+use crate::{
+    FrameSpace, GeometryPoint, GeometryRect, LogicalPixels, Px, RootSurfaceSpace, SpaceTranslation,
+};
 
 #[test]
 fn a_content_extent_needs_two_finite_positive_dimensions() {
@@ -35,4 +38,96 @@ fn deserialization_goes_through_the_constructor() {
             "{rejected}: {error}"
         );
     }
+}
+
+/// GNU keeps the widget, glyph, and clip extents separate.  This is the
+/// protocol seam consumed by native placement, Linux composition, pointer
+/// hit-testing, and cursor geometry; callers should not need to reconstruct
+/// those meanings from three unrelated `f32` fields.
+#[test]
+fn presentation_geometry_keeps_content_advance_and_clip_distinct() {
+    let content = XwidgetContentExtent::new(600.0, 40.0).expect("content extent");
+    let advance = XwidgetLayoutAdvance::new(Px(304.0)).expect("layout advance");
+    let origin =
+        GeometryPoint::<FrameSpace, LogicalPixels>::from_px(8.0, 16.0).expect("frame-local origin");
+    let clip = GeometryRect::<FrameSpace, LogicalPixels>::new(0.0, 0.0, 312.0, 120.0)
+        .expect("frame-local clip");
+    let presentation = XwidgetPresentationGeometry::new(origin, content, advance, Some(clip));
+
+    let slot = presentation.layout_slot_rect();
+    assert_eq!(
+        (slot.x(), slot.y(), slot.width(), slot.height()),
+        (8.0, 16.0, 304.0, 40.0)
+    );
+
+    let visible = presentation
+        .resolve_visible(None)
+        .expect("valid geometry")
+        .expect("part of the widget is visible");
+    assert_eq!(visible.content_rect().width(), 600.0);
+    assert_eq!(visible.visible_rect().width(), 304.0);
+    assert_eq!(
+        visible.texture_coordinates().as_array(),
+        [0.0, 304.0 / 600.0, 0.0, 1.0]
+    );
+
+    let point = GeometryPoint::<FrameSpace, LogicalPixels>::from_px(300.0, 20.0)
+        .expect("frame-local pointer");
+    let content_point = visible
+        .content_point_at(point)
+        .expect("point lies in the visible portion");
+    assert_eq!((content_point.x(), content_point.y()), (292.0, 4.0));
+}
+
+#[test]
+fn an_xwidget_layout_advance_is_finite_and_strictly_positive() {
+    assert_eq!(
+        XwidgetLayoutAdvance::new(Px(304.0)).unwrap().px(),
+        Px(304.0)
+    );
+    assert_eq!(XwidgetLayoutAdvance::new(Px(0.0)), None);
+    assert_eq!(XwidgetLayoutAdvance::new(Px(-1.0)), None);
+    assert_eq!(XwidgetLayoutAdvance::new(Px(f32::NAN)), None);
+    assert_eq!(XwidgetLayoutAdvance::new(Px(f32::INFINITY)), None);
+}
+
+#[test]
+fn presentation_translation_changes_coordinate_space_at_compile_time() {
+    let content = XwidgetContentExtent::new(600.0, 40.0).expect("content extent");
+    let presentation = XwidgetPresentationGeometry::new(
+        GeometryPoint::<FrameSpace, LogicalPixels>::from_px(8.0, 16.0).unwrap(),
+        content,
+        XwidgetLayoutAdvance::new(Px(304.0)).unwrap(),
+        None,
+    );
+    let frame_to_root =
+        SpaceTranslation::<FrameSpace, RootSurfaceSpace, LogicalPixels>::from_px(100.0, 50.0)
+            .unwrap();
+
+    let rooted: XwidgetPresentationGeometry<RootSurfaceSpace> =
+        presentation.translated(frame_to_root).unwrap();
+
+    assert_eq!(
+        (rooted.content_rect().x(), rooted.content_rect().y()),
+        (108.0, 66.0)
+    );
+}
+
+#[test]
+fn moving_a_glyph_origin_does_not_move_its_window_clip() {
+    let presentation = XwidgetPresentationGeometry::new(
+        GeometryPoint::<FrameSpace, LogicalPixels>::from_px(8.0, 16.0).unwrap(),
+        XwidgetContentExtent::new(600.0, 40.0).unwrap(),
+        XwidgetLayoutAdvance::new(Px(304.0)).unwrap(),
+        Some(GeometryRect::new(0.0, 0.0, 312.0, 120.0).unwrap()),
+    );
+    let displacement =
+        SpaceTranslation::<FrameSpace, FrameSpace, LogicalPixels>::from_px(12.0, 6.0).unwrap();
+
+    let moved = presentation
+        .translated_origin(displacement)
+        .expect("valid displaced origin");
+
+    assert_eq!((moved.origin().x(), moved.origin().y()), (20.0, 22.0));
+    assert_eq!(moved.clip_rect(), presentation.clip_rect());
 }

--- a/crates/neomacs-display-protocol/src/xwidget_extent_test.rs
+++ b/crates/neomacs-display-protocol/src/xwidget_extent_test.rs
@@ -1,0 +1,13 @@
+use super::XwidgetContentExtent;
+
+#[test]
+fn a_content_extent_needs_two_finite_positive_dimensions() {
+    let extent = XwidgetContentExtent::new(600.0, 40.0).expect("valid extent");
+    assert_eq!(extent.width_px(), 600.0);
+    assert_eq!(extent.height_px(), 40.0);
+
+    assert_eq!(XwidgetContentExtent::new(0.0, 40.0), None);
+    assert_eq!(XwidgetContentExtent::new(600.0, -1.0), None);
+    assert_eq!(XwidgetContentExtent::new(f32::NAN, 40.0), None);
+    assert_eq!(XwidgetContentExtent::new(600.0, f32::INFINITY), None);
+}

--- a/crates/neomacs-display-protocol/src/xwidget_extent_test.rs
+++ b/crates/neomacs-display-protocol/src/xwidget_extent_test.rs
@@ -11,3 +11,28 @@ fn a_content_extent_needs_two_finite_positive_dimensions() {
     assert_eq!(XwidgetContentExtent::new(f32::NAN, 40.0), None);
     assert_eq!(XwidgetContentExtent::new(600.0, f32::INFINITY), None);
 }
+
+#[test]
+fn deserialization_goes_through_the_constructor() {
+    let extent = XwidgetContentExtent::new(600.0, 40.0).expect("valid extent");
+    let json = serde_json::to_string(&extent).expect("serialize");
+    assert_eq!(json, r#"{"width_px":600.0,"height_px":40.0}"#);
+    let round_trip: XwidgetContentExtent = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(round_trip, extent);
+
+    for rejected in [
+        r#"{"width_px":0.0,"height_px":40.0}"#,
+        r#"{"width_px":600.0,"height_px":-1.0}"#,
+        r#"{"width_px":600.0,"height_px":null}"#,
+    ] {
+        let error = serde_json::from_str::<XwidgetContentExtent>(rejected)
+            .expect_err("an extent the constructor refuses must not deserialize");
+        assert!(
+            error
+                .to_string()
+                .contains("not finite and strictly positive")
+                || error.to_string().contains("invalid type"),
+            "{rejected}: {error}"
+        );
+    }
+}

--- a/crates/neomacs-display-runtime/src/render_thread/frame_ingest.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/frame_ingest.rs
@@ -9,20 +9,6 @@ use crate::render_thread::cursor::{CursorConfigSnapshot, CursorTarget};
 use neomacs_display_protocol::frame_chrome::{FrameChrome, FrameChromeContent};
 
 #[cfg(feature = "webview")]
-fn intersect_webview_rect(
-    left: neomacs_display_protocol::RootSurfaceRect,
-    right: neomacs_display_protocol::RootSurfaceRect,
-) -> Option<neomacs_display_protocol::RootSurfaceRect> {
-    let x = left.x().max(right.x());
-    let y = left.y().max(right.y());
-    let far_x = (left.x() + left.width()).min(right.x() + right.width());
-    let far_y = (left.y() + left.height()).min(right.y() + right.height());
-    (far_x > x && far_y > y)
-        .then(|| neomacs_display_protocol::RootSurfaceRect::new(x, y, far_x - x, far_y - y).ok())
-        .flatten()
-}
-
-#[cfg(feature = "webview")]
 fn collect_frame_webviews(
     frame: &crate::core::frame_glyphs::FrameGlyphBuffer,
     offset_x: f32,
@@ -39,10 +25,7 @@ fn collect_frame_webviews(
         let crate::core::frame_glyphs::FrameGlyph::Xwidget {
             window_id,
             webview_id,
-            x,
-            y,
-            content,
-            clip_rect,
+            presentation,
             ..
         } = glyph
         else {
@@ -54,36 +37,28 @@ fn collect_frame_webviews(
         // src/xdisp.c:32577-32579, emacs-31.0.90) and GNU answers that by
         // clipping the view, not resizing it (`x_draw_xwidget_glyph_string`,
         // src/xwidget.c:2841-2849).  The clip below is that text-area clip.
-        let Ok(content) = neomacs_display_protocol::RootSurfaceRect::new(
-            offset_x + *x,
-            offset_y + *y,
-            content.width_px(),
-            content.height_px(),
-        ) else {
+        let Ok(frame_to_root) = neomacs_display_protocol::SpaceTranslation::<
+            neomacs_display_protocol::FrameSpace,
+            neomacs_display_protocol::RootSurfaceSpace,
+            neomacs_display_protocol::LogicalPixels,
+        >::from_px(offset_x, offset_y) else {
             continue;
         };
-        let mut visible = intersect_webview_rect(content, frame_clip);
-        if let Some(clip) = clip_rect {
-            let Ok(clip) = neomacs_display_protocol::RootSurfaceRect::new(
-                offset_x + clip.x,
-                offset_y + clip.y,
-                clip.width,
-                clip.height,
-            ) else {
-                continue;
-            };
-            visible = visible.and_then(|visible| intersect_webview_rect(visible, clip));
-        }
-        let Some(visible) = visible else {
+        let Ok(root_presentation) = presentation.translated(frame_to_root) else {
             continue;
         };
+        let Ok(Some(visible)) = root_presentation.resolve_visible(Some(frame_clip)) else {
+            continue;
+        };
+        let content_rect = visible.content_rect();
+        let visible_rect = visible.visible_rect();
         *next_occurrence = next_occurrence.saturating_add(1);
         let Ok(placement) = neomacs_webview::ResolvedWebViewPlacement::new(
             *webview_id,
             neomacs_webview::WebViewOccurrenceId::new(*next_occurrence),
             *window_id,
-            content,
-            visible,
+            content_rect,
+            visible_rect,
             scale,
         ) else {
             continue;
@@ -166,10 +141,6 @@ impl WebViewSceneClock {
         )
     }
 }
-
-#[cfg(all(test, feature = "webview"))]
-#[path = "frame_ingest_test.rs"]
-mod tests;
 
 struct CursorSyncOutcome {
     target: CursorTarget,

--- a/crates/neomacs-display-runtime/src/render_thread/frame_ingest.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/frame_ingest.rs
@@ -53,7 +53,7 @@ fn collect_frame_webviews(
         // have cropped the slot at the right edge (`produce_xwidget_glyph`,
         // src/xdisp.c:32577-32579, emacs-31.0.90) and GNU answers that by
         // clipping the view, not resizing it (`x_draw_xwidget_glyph_string`,
-        // src/xwidget.c:2841-2847).  The clip below is that text-area clip.
+        // src/xwidget.c:2841-2849).  The clip below is that text-area clip.
         let Ok(content) = neomacs_display_protocol::RootSurfaceRect::new(
             offset_x + *x,
             offset_y + *y,

--- a/crates/neomacs-display-runtime/src/render_thread/frame_ingest.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/frame_ingest.rs
@@ -41,19 +41,24 @@ fn collect_frame_webviews(
             webview_id,
             x,
             y,
-            width,
-            height,
+            content,
             clip_rect,
             ..
         } = glyph
         else {
             continue;
         };
+        // The native view is sized from the widget's own extent, GNU
+        // `xww->width`/`xww->height`, never from the glyph slot: layout may
+        // have cropped the slot at the right edge (`produce_xwidget_glyph`,
+        // src/xdisp.c:32577-32579, emacs-31.0.90) and GNU answers that by
+        // clipping the view, not resizing it (`x_draw_xwidget_glyph_string`,
+        // src/xwidget.c:2841-2847).  The clip below is that text-area clip.
         let Ok(content) = neomacs_display_protocol::RootSurfaceRect::new(
             offset_x + *x,
             offset_y + *y,
-            *width,
-            *height,
+            content.width_px(),
+            content.height_px(),
         ) else {
             continue;
         };
@@ -1153,3 +1158,7 @@ fn dump_frame_glyphs_resolved(frame: &crate::core::frame_glyphs::FrameGlyphBuffe
     }
     out
 }
+
+#[cfg(all(test, feature = "webview"))]
+#[path = "frame_ingest_test.rs"]
+mod tests;

--- a/crates/neomacs-display-runtime/src/render_thread/frame_ingest_test.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/frame_ingest_test.rs
@@ -2,8 +2,9 @@
 //! per presentation, and the scene revision moves only on a real change.
 
 use neomacs_display_protocol::{
-    DeviceScale, DisplayWindowId, FrameGlyphBuffer, GlyphRowRole, Rect, RootSurfaceRect, WebViewId,
-    XwidgetContentExtent, XwidgetId,
+    DeviceScale, DisplayWindowId, FrameGlyphBuffer, FrameSpace, GeometryPoint, GlyphRowRole,
+    LogicalPixels, Px, Rect, RootSurfaceRect, WebViewId, XwidgetContentExtent, XwidgetId,
+    XwidgetLayoutAdvance, XwidgetPresentationGeometry,
 };
 use neomacs_webview::{
     HostWindowId, ResolvedWebViewPlacement, WebViewOccurrenceId, WebViewSceneRevision,
@@ -119,6 +120,8 @@ fn removing_the_newest_child_advances_the_host_scene_revision() {
     assert_eq!(with_child.revision(), WebViewSceneRevision::new(1));
     assert_eq!(unchanged.revision(), WebViewSceneRevision::new(1));
     assert_eq!(child_removed.revision(), WebViewSceneRevision::new(2));
+}
+
 /// GNU sizes the native view from the widget (`xww->width`) and clips it to
 /// the text area (`x_draw_xwidget_glyph_string`, src/xwidget.c:2841-2849,
 /// emacs-31.0.90); the glyph's cropped advance is not the view's size.  A
@@ -133,14 +136,13 @@ fn a_cropped_xwidget_slot_keeps_the_native_content_width_behind_the_clip() {
         Some(Rect::new(0.0, 0.0, 312.0, 120.0)),
     );
     let content = XwidgetContentExtent::new(600.0, 40.0).expect("content extent");
-    frame.add_xwidget(
-        XwidgetId::new(7),
-        WebViewId::new(91),
-        8.0,
-        16.0,
+    let presentation = XwidgetPresentationGeometry::new(
+        GeometryPoint::<FrameSpace, LogicalPixels>::from_px(8.0, 16.0).expect("origin"),
         content,
-        304.0,
+        XwidgetLayoutAdvance::new(Px(304.0)).expect("cropped advance"),
+        None,
     );
+    frame.add_xwidget(XwidgetId::new(7), WebViewId::new(91), presentation);
 
     let mut occurrence = 0;
     let mut placements = std::collections::HashMap::new();

--- a/crates/neomacs-display-runtime/src/render_thread/frame_ingest_test.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/frame_ingest_test.rs
@@ -1,12 +1,15 @@
 //! Scene-clock behaviour of `frame_ingest.rs`: placement resolution runs once
 //! per presentation, and the scene revision moves only on a real change.
 
-use neomacs_display_protocol::{DeviceScale, DisplayWindowId, RootSurfaceRect, WebViewId};
+use neomacs_display_protocol::{
+    DeviceScale, DisplayWindowId, FrameGlyphBuffer, GlyphRowRole, Rect, RootSurfaceRect, WebViewId,
+    XwidgetContentExtent, XwidgetId,
+};
 use neomacs_webview::{
     HostWindowId, ResolvedWebViewPlacement, WebViewOccurrenceId, WebViewSceneRevision,
 };
 
-use super::{WebViewPlacementInputs, WebViewSceneClock};
+use super::{WebViewPlacementInputs, WebViewSceneClock, collect_frame_webviews};
 
 fn placement(view: u32) -> ResolvedWebViewPlacement {
     let rect = RootSurfaceRect::new(0.0, 0.0, 20.0, 10.0).unwrap();
@@ -116,4 +119,51 @@ fn removing_the_newest_child_advances_the_host_scene_revision() {
     assert_eq!(with_child.revision(), WebViewSceneRevision::new(1));
     assert_eq!(unchanged.revision(), WebViewSceneRevision::new(1));
     assert_eq!(child_removed.revision(), WebViewSceneRevision::new(2));
+/// GNU sizes the native view from the widget (`xww->width`) and clips it to
+/// the text area (`x_draw_xwidget_glyph_string`, src/xwidget.c:2841-2847,
+/// emacs-31.0.90); the glyph's cropped advance is not the view's size.  A
+/// 600 px page cropped to a 304 px slot is therefore a 600 px viewport behind
+/// a 304 px clip, not a 304 px viewport.
+#[test]
+fn a_cropped_xwidget_slot_keeps_the_native_content_width_behind_the_clip() {
+    let mut frame = FrameGlyphBuffer::new();
+    frame.set_draw_context(
+        DisplayWindowId::new(1),
+        GlyphRowRole::Text,
+        Some(Rect::new(0.0, 0.0, 312.0, 120.0)),
+    );
+    let content = XwidgetContentExtent::new(600.0, 40.0).expect("content extent");
+    frame.add_xwidget(
+        XwidgetId::new(7),
+        WebViewId::new(91),
+        8.0,
+        16.0,
+        content,
+        304.0,
+    );
+
+    let mut occurrence = 0;
+    let mut placements = std::collections::HashMap::new();
+    collect_frame_webviews(
+        &frame,
+        0.0,
+        0.0,
+        RootSurfaceRect::new(0.0, 0.0, 320.0, 120.0).expect("root clip"),
+        DeviceScale::ONE,
+        &mut occurrence,
+        &mut placements,
+    );
+
+    let placement = placements
+        .get(&WebViewId::new(91))
+        .expect("the cropped xwidget is placed");
+    assert_eq!(placement.content_rect().width(), 600.0, "GNU: xww->width");
+    assert_eq!(placement.content_rect().height(), 40.0);
+    assert_eq!(placement.content_rect().x(), 8.0);
+    assert_eq!(
+        placement.visible_rect().width(),
+        304.0,
+        "clip_right = text_area_x + text_area_width - x"
+    );
+    assert_eq!(placement.visible_rect().x(), 8.0);
 }

--- a/crates/neomacs-display-runtime/src/render_thread/frame_ingest_test.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/frame_ingest_test.rs
@@ -120,7 +120,7 @@ fn removing_the_newest_child_advances_the_host_scene_revision() {
     assert_eq!(unchanged.revision(), WebViewSceneRevision::new(1));
     assert_eq!(child_removed.revision(), WebViewSceneRevision::new(2));
 /// GNU sizes the native view from the widget (`xww->width`) and clips it to
-/// the text area (`x_draw_xwidget_glyph_string`, src/xwidget.c:2841-2847,
+/// the text area (`x_draw_xwidget_glyph_string`, src/xwidget.c:2841-2849,
 /// emacs-31.0.90); the glyph's cropped advance is not the view's size.  A
 /// 600 px page cropped to a 304 px slot is therefore a 600 px viewport behind
 /// a 304 px clip, not a 304 px viewport.

--- a/crates/neomacs-display-runtime/src/render_thread/frame_state.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/frame_state.rs
@@ -536,13 +536,6 @@ impl RenderApp {
                     slot_id,
                     ..
                 }
-                | FrameGlyph::Xwidget {
-                    x,
-                    y,
-                    row_role,
-                    slot_id,
-                    ..
-                }
                 | FrameGlyph::Surface {
                     x,
                     y,
@@ -572,6 +565,49 @@ impl RenderApp {
                     *y += row_index as f32 * line_spacing;
                     *x += char_in_row as f32 * letter_spacing;
                     slot_positions.insert(slot_id, (*x, *y));
+                }
+                FrameGlyph::Xwidget {
+                    presentation,
+                    row_role,
+                    slot_id,
+                    ..
+                } => {
+                    if row_role.is_chrome() {
+                        continue;
+                    }
+                    let Some(slot_id) = *slot_id else {
+                        continue;
+                    };
+                    let origin = *presentation.origin();
+                    let mut x = origin.x();
+                    let mut y = origin.y();
+                    if y < last_window_y - 1.0 {
+                        row_index = -1;
+                        last_y = f32::NEG_INFINITY;
+                    }
+                    last_window_y = y;
+
+                    if (y - last_y).abs() > 0.5 {
+                        row_index += 1;
+                        char_in_row = 0;
+                        last_y = y;
+                    } else {
+                        char_in_row += 1;
+                    }
+                    let dx = char_in_row as f32 * letter_spacing;
+                    let dy = row_index as f32 * line_spacing;
+                    x += dx;
+                    y += dy;
+                    let displacement = neomacs_display_protocol::SpaceTranslation::<
+                        neomacs_display_protocol::FrameSpace,
+                        neomacs_display_protocol::FrameSpace,
+                        neomacs_display_protocol::LogicalPixels,
+                    >::from_px(dx, dy)
+                    .expect("finite display spacing produces a valid displacement");
+                    *presentation = presentation
+                        .translated_origin(displacement)
+                        .expect("finite display spacing preserves valid xwidget geometry");
+                    slot_positions.insert(slot_id, (x, y));
                 }
                 _ => {}
             }

--- a/crates/neomacs-display-runtime/src/render_thread/pointer_events.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/pointer_events.rs
@@ -49,6 +49,28 @@ pub(super) enum PointerOwner {
 mod webview_tests {
     use super::*;
 
+    fn presentation(
+        x: f32,
+        y: f32,
+        content: neomacs_display_protocol::XwidgetContentExtent,
+        advance: f32,
+    ) -> neomacs_display_protocol::XwidgetPresentationGeometry<neomacs_display_protocol::FrameSpace>
+    {
+        neomacs_display_protocol::XwidgetPresentationGeometry::new(
+            neomacs_display_protocol::GeometryPoint::<
+                neomacs_display_protocol::FrameSpace,
+                neomacs_display_protocol::LogicalPixels,
+            >::from_px(x, y)
+            .expect("valid origin"),
+            content,
+            neomacs_display_protocol::XwidgetLayoutAdvance::new(neomacs_display_protocol::Px(
+                advance,
+            ))
+            .expect("valid advance"),
+            None,
+        )
+    }
+
     #[test]
     fn hit_testing_keeps_xwidget_and_webview_identities_distinct() {
         let mut glyphs = neomacs_display_protocol::FrameGlyphBuffer::new();
@@ -57,10 +79,7 @@ mod webview_tests {
         glyphs.add_xwidget(
             neomacs_display_protocol::XwidgetId::new(7),
             neomacs_display_protocol::WebViewId::new(91),
-            10.0,
-            20.0,
-            content,
-            320.0,
+            presentation(10.0, 20.0, content, 320.0),
         );
 
         assert_eq!(
@@ -85,10 +104,7 @@ mod webview_tests {
         glyphs.add_xwidget(
             neomacs_display_protocol::XwidgetId::new(7),
             neomacs_display_protocol::WebViewId::new(91),
-            10.0,
-            20.0,
-            content,
-            100.0,
+            presentation(10.0, 20.0, content, 100.0),
         );
 
         assert_eq!(webview_glyph_hit_test(&glyphs.glyphs, 15.0, 25.0), None);
@@ -111,10 +127,7 @@ mod webview_tests {
         glyphs.add_xwidget(
             neomacs_display_protocol::XwidgetId::new(7),
             neomacs_display_protocol::WebViewId::new(91),
-            8.0,
-            10.0,
-            content,
-            304.0,
+            presentation(8.0, 10.0, content, 304.0),
         );
 
         assert_eq!(
@@ -209,24 +222,25 @@ fn webview_glyph_hit_test(glyphs: &[FrameGlyph], x: f32, y: f32) -> Option<WebVi
         // places the native view with, so hits and placement cannot differ.
         if let FrameGlyph::Xwidget {
             webview_id,
-            clip_rect,
-            x: wx,
-            y: wy,
-            content,
+            presentation,
             ..
         } = glyph
-            && x >= *wx
-            && x < *wx + content.width_px()
-            && y >= *wy
-            && y < *wy + content.height_px()
-            && clip_rect.as_ref().is_none_or(|clip| {
-                x >= clip.x && x < clip.x + clip.width && y >= clip.y && y < clip.y + clip.height
-            })
         {
-            return Some(WebViewPointerHit {
-                view: *webview_id,
-                position: WebContentPoint::new(x - *wx, y - *wy),
-            });
+            let Ok(point) = neomacs_display_protocol::GeometryPoint::<
+                neomacs_display_protocol::FrameSpace,
+                neomacs_display_protocol::LogicalPixels,
+            >::from_px(x, y) else {
+                continue;
+            };
+            let Ok(Some(visible)) = presentation.resolve_visible(None) else {
+                continue;
+            };
+            if let Some(content_point) = visible.content_point_at(point) {
+                return Some(WebViewPointerHit {
+                    view: *webview_id,
+                    position: WebContentPoint::new(content_point.x(), content_point.y()),
+                });
+            }
         }
     }
     None

--- a/crates/neomacs-display-runtime/src/render_thread/pointer_events.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/pointer_events.rs
@@ -52,13 +52,15 @@ mod webview_tests {
     #[test]
     fn hit_testing_keeps_xwidget_and_webview_identities_distinct() {
         let mut glyphs = neomacs_display_protocol::FrameGlyphBuffer::new();
+        let content =
+            neomacs_display_protocol::XwidgetContentExtent::new(320.0, 200.0).expect("extent");
         glyphs.add_xwidget(
             neomacs_display_protocol::XwidgetId::new(7),
             neomacs_display_protocol::WebViewId::new(91),
             10.0,
             20.0,
+            content,
             320.0,
-            200.0,
         );
 
         assert_eq!(
@@ -78,17 +80,55 @@ mod webview_tests {
             neomacs_display_protocol::GlyphRowRole::Text,
             Some(neomacs_display_protocol::Rect::new(20.0, 30.0, 50.0, 40.0)),
         );
+        let content =
+            neomacs_display_protocol::XwidgetContentExtent::new(100.0, 80.0).expect("extent");
         glyphs.add_xwidget(
             neomacs_display_protocol::XwidgetId::new(7),
             neomacs_display_protocol::WebViewId::new(91),
             10.0,
             20.0,
+            content,
             100.0,
-            80.0,
         );
 
         assert_eq!(webview_glyph_hit_test(&glyphs.glyphs, 15.0, 25.0), None);
         assert!(webview_glyph_hit_test(&glyphs.glyphs, 25.0, 35.0).is_some());
+    }
+
+    /// A slot cropped at the right edge does not shrink the pointer target:
+    /// the widget is still its own size behind the text-area clip, so a
+    /// point inside the clip but past the cropped slot still hits it.
+    #[test]
+    fn hit_testing_uses_the_widgets_own_extent_not_the_cropped_slot() {
+        let mut glyphs = neomacs_display_protocol::FrameGlyphBuffer::new();
+        glyphs.set_draw_context(
+            neomacs_display_protocol::DisplayWindowId::new(1),
+            neomacs_display_protocol::GlyphRowRole::Text,
+            Some(neomacs_display_protocol::Rect::new(0.0, 0.0, 400.0, 100.0)),
+        );
+        let content =
+            neomacs_display_protocol::XwidgetContentExtent::new(600.0, 40.0).expect("extent");
+        glyphs.add_xwidget(
+            neomacs_display_protocol::XwidgetId::new(7),
+            neomacs_display_protocol::WebViewId::new(91),
+            8.0,
+            10.0,
+            content,
+            304.0,
+        );
+
+        assert_eq!(
+            webview_glyph_hit_test(&glyphs.glyphs, 350.0, 20.0),
+            Some(WebViewPointerHit {
+                view: neomacs_display_protocol::WebViewId::new(91),
+                position: WebContentPoint::new(342.0, 10.0),
+            })
+        );
+        assert_eq!(
+            webview_glyph_hit_test(&glyphs.glyphs, 450.0, 20.0),
+            None,
+            "past the clip nothing of the widget is visible"
+        );
     }
 }
 
@@ -163,19 +203,22 @@ impl WebViewDeliveryTarget {
 #[cfg(feature = "webview")]
 fn webview_glyph_hit_test(glyphs: &[FrameGlyph], x: f32, y: f32) -> Option<WebViewPointerHit> {
     for glyph in glyphs.iter().rev() {
+        // The pointer target is the widget itself, GNU `xww->width` by
+        // `xww->height` at the glyph origin, minus what the text-area clip
+        // hides: the same content-and-clip pair `collect_frame_webviews`
+        // places the native view with, so hits and placement cannot differ.
         if let FrameGlyph::Xwidget {
             webview_id,
             clip_rect,
             x: wx,
             y: wy,
-            width,
-            height,
+            content,
             ..
         } = glyph
             && x >= *wx
-            && x < *wx + *width
+            && x < *wx + content.width_px()
             && y >= *wy
-            && y < *wy + *height
+            && y < *wy + content.height_px()
             && clip_rect.as_ref().is_none_or(|clip| {
                 x >= clip.x && x < clip.x + clip.width && y >= clip.y && y < clip.y + clip.height
             })

--- a/crates/neomacs-gui-tests/fixtures/oversized-xwidget.el
+++ b/crates/neomacs-gui-tests/fixtures/oversized-xwidget.el
@@ -1,0 +1,44 @@
+;;; oversized-xwidget.el --- Oversized xwidget GUI fixture -*- lexical-binding: t -*-
+
+(require 'xwidget)
+
+(switch-to-buffer (get-buffer-create "*neomacs-gui-oversized-xwidget*"))
+(erase-buffer)
+(insert " ")
+(goto-char (point-min))
+
+;; GNU keeps the browser at this intrinsic size, crops only the glyph's row
+;; advance, and clips the native view to the window text area.  Make both
+;; dimensions unambiguously larger than the live text area so a missing crop
+;; makes the replacement disappear under RejectOverflowingGlyph (issue #301).
+(let* ((text-width (max 1 (window-body-width nil t)))
+       (text-height (max 1 (window-body-height nil t)))
+       (content-width (* 2 text-width))
+       (content-height (* 2 text-height))
+       (xwidget (xwidget-insert (point-min) 'webkit
+                                "Neomacs oversized xwidget"
+                                content-width content-height)))
+  (setq-local neomacs-gui-oversized-xwidget xwidget)
+  ;; A data URI avoids network, DNS, filesystem, and server timing.  Saturated
+  ;; magenta is deliberately unlike the default Neomacs frame, so the PNG
+  ;; readback can prove that WebKit content reached the compositor.
+  (xwidget-webkit-goto-uri
+   xwidget
+   "data:text/html,%3Chtml%3E%3Cbody%20style%3D%22margin%3A0%3Bbackground%3Argb%28255%2C0%2C255%29%3Bwidth%3A100vw%3Bheight%3A100vh%22%3E%3C%2Fbody%3E%3C%2Fhtml%3E"))
+
+(defun neomacs-gui-oversized-xwidget-capture ()
+  (force-window-update)
+  (redisplay t)
+  (let ((snap-json (getenv "NEOMACS_GUI_FRAME_SNAPSHOT_JSON"))
+        (snap-txt (getenv "NEOMACS_GUI_FRAME_SNAPSHOT_TXT")))
+    (when (and snap-json (fboundp 'neomacs--write-frame-snapshot))
+      (make-directory (file-name-directory snap-json) t)
+      (neomacs--write-frame-snapshot snap-json t 'json))
+    (when (and snap-txt (fboundp 'neomacs--write-frame-snapshot))
+      (make-directory (file-name-directory snap-txt) t)
+      (neomacs--write-frame-snapshot snap-txt t 'text-faces))))
+
+;; Give WPE's process and texture handoff time to publish the deterministic
+;; page before taking the semantic snapshot and the harness's final readback.
+(run-at-time 1 nil #'neomacs-gui-oversized-xwidget-capture)
+(run-at-time 3 nil (lambda () (kill-emacs 0)))

--- a/crates/neomacs-gui-tests/tests/real_gui_smoke.rs
+++ b/crates/neomacs-gui-tests/tests/real_gui_smoke.rs
@@ -101,6 +101,136 @@ fn real_gui_smoke_generates_surface_readback_png() {
 }
 
 #[test]
+fn oversized_xwidget_keeps_its_intrinsic_page_visible_behind_the_window_clip() {
+    if !cfg!(target_os = "linux") {
+        eprintln!("skipping oversized xwidget composition regression; WPE is Linux-only");
+        return;
+    }
+    let Some(backend) = requested_backend() else {
+        eprintln!(
+            "skipping oversized xwidget composition regression; set \
+             NEOMACS_GUI_TEST_BACKEND=wayland or x11 to run it"
+        );
+        return;
+    };
+
+    let workspace_root = workspace_root();
+    let binary = neomacs_binary(&workspace_root);
+    assert!(
+        binary.exists(),
+        "build {binary:?} with --features webview before running the xwidget regression"
+    );
+
+    let artifact_root = workspace_root.join("target/neomacs-gui-tests");
+    let session = DisplayHarness::for_backend(backend)
+        .start_session(&artifact_root)
+        .expect("display session should start");
+    let scenario = GuiScenario::new(
+        "oversized-xwidget",
+        workspace_root.join("crates/neomacs-gui-tests/fixtures/oversized-xwidget.el"),
+    );
+    let mut plan = GuiTestPlan::new(backend, &workspace_root, &artifact_root, scenario)
+        .with_program(binary)
+        // Keep readback armed until WPE publishes its first page texture.
+        .with_env("NEOMACS_DEBUG_SURFACE_READBACK", "120");
+    for (key, value) in session.env() {
+        plan = plan.with_env(key.clone(), value.clone());
+    }
+
+    let mut runner = ProcessGuiCommandRunner;
+    let result = plan
+        .run_with(
+            &mut runner,
+            GuiRunOptions::with_timeout(Duration::from_secs(15)),
+        )
+        .expect("oversized xwidget GUI run should produce artifacts");
+    assert_eq!(result.status, GuiRunStatus::Passed, "{result:#?}");
+
+    let snapshot_json = std::fs::read_to_string(&result.artifacts.frame_snapshot_json)
+        .expect("oversized xwidget frame snapshot JSON");
+    let snapshot: serde_json::Value =
+        serde_json::from_str(&snapshot_json).expect("snapshot JSON parses");
+    let (window_id, glyph) = xwidget_glyph(&snapshot)
+        .expect("redisplay must retain an oversized xwidget glyph instead of dropping it");
+    let xwidget = &glyph["glyph_type"]["Xwidget"];
+    let intrinsic_width = xwidget["content"]["width_px"]
+        .as_f64()
+        .expect("xwidget intrinsic width");
+    let intrinsic_height = xwidget["content"]["height_px"]
+        .as_f64()
+        .expect("xwidget intrinsic height");
+    let layout_advance = glyph["pixel_width"]
+        .as_f64()
+        .expect("xwidget cropped layout advance");
+    let window = snapshot["frames"]
+        .as_array()
+        .expect("snapshot frames")
+        .iter()
+        .flat_map(|frame| {
+            frame["window_infos"]
+                .as_array()
+                .expect("frame window infos")
+        })
+        .find(|window| window["window_id"].as_u64() == Some(window_id))
+        .expect("xwidget's window info");
+    let text_body = &window["geometry"]["Complete"]["regions"]["text_body"];
+    let text_width = text_body["width"].as_f64().expect("text body width");
+    let text_height = text_body["height"].as_f64().expect("text body height");
+
+    assert!(
+        intrinsic_width >= text_width * 2.0 - 1.0,
+        "fixture must retain an intrinsic width wider than its text area: \
+         intrinsic={intrinsic_width}, text={text_width}"
+    );
+    assert!(
+        intrinsic_height >= text_height * 2.0 - 1.0,
+        "fixture must retain an intrinsic height taller than its text area: \
+         intrinsic={intrinsic_height}, text={text_height}"
+    );
+    assert!(
+        (layout_advance - text_width).abs() <= 1.0,
+        "GNU crops only the row advance to the remaining text width: \
+         advance={layout_advance}, text={text_width}"
+    );
+
+    let readback = image::open(&result.artifacts.png)
+        .expect("decode oversized xwidget surface readback")
+        .to_rgba8();
+    let magenta_pixels = readback
+        .pixels()
+        .filter(|pixel| is_webview_magenta(pixel.0))
+        .count();
+    assert!(
+        magenta_pixels >= 1024,
+        "the semantic xwidget glyph existed, but its deterministic magenta page \
+         was not visibly composed; found only {magenta_pixels} matching pixels in {}",
+        result.artifacts.png.display()
+    );
+}
+
+fn xwidget_glyph(snapshot: &serde_json::Value) -> Option<(u64, &serde_json::Value)> {
+    for frame in snapshot["frames"].as_array()? {
+        for window_matrix in frame["window_matrices"].as_array()? {
+            let window_id = window_matrix["window_id"].as_u64()?;
+            for row in window_matrix["matrix"]["rows"].as_array()? {
+                for area in row["glyphs"].as_array()? {
+                    for glyph in area.as_array()? {
+                        if glyph["glyph_type"]["Xwidget"].is_object() {
+                            return Some((window_id, glyph));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn is_webview_magenta([red, green, blue, _alpha]: [u8; 4]) -> bool {
+    red >= 200 && green <= 80 && blue >= 200
+}
+
+#[test]
 fn imageless_gui_startup_runs_early_init_once_on_the_live_gui_terminal() {
     let Some(backend) = requested_backend() else {
         eprintln!(

--- a/crates/neomacs-layout-engine/src/display_item.rs
+++ b/crates/neomacs-layout-engine/src/display_item.rs
@@ -3,7 +3,7 @@ use crate::display_property::DisplayPropertyClassification;
 use neomacs_display_protocol::face::{BoxRunMembership, BoxVerticalEdges};
 use neomacs_display_protocol::glyph_matrix::TerminalComposition;
 use neomacs_display_protocol::types::FaceId;
-use neomacs_display_protocol::{WebViewId, XwidgetId};
+use neomacs_display_protocol::{WebViewId, XwidgetContentExtent, XwidgetId};
 use neovm_core::buffer::{BufferId, CharPos0, EmacsBytePos};
 use neovm_core::emacs_core::Value;
 use neovm_core::emacs_core::emacs_char::EmacsChar;
@@ -1373,9 +1373,12 @@ pub(crate) enum DisplayMediaReplacementKind {
         video_id: neomacs_display_protocol::VideoId,
         opacity: f32,
     },
+    /// `content` is GNU `xw->width`/`xw->height`; the outer `width` is the
+    /// layout advance, which the right-edge crop may narrow below it.
     Xwidget {
         xwidget_id: XwidgetId,
         webview_id: WebViewId,
+        content: XwidgetContentExtent,
     },
     Surface {
         surface_id: u32,
@@ -1415,35 +1418,6 @@ impl DisplayMediaReplacement {
     /// content.  Fold that inset into the durable image placement now, while
     /// the realized face is available, so layout advance and renderer replay
     /// cannot disagree or paint the border over the outer image pixels.
-    /// Narrow the replacement to `visible_width_px`, the way GNU's producers
-    /// crop a glyph at the right edge (see
-    /// `DisplayMediaReplacementOverflowAction`).  An image also narrows its
-    /// slice -- `slice.width -= crop`, src/xdisp.c:32597 -- so what remains is
-    /// the left part of the image rather than the whole image squeezed; the
-    /// other kinds keep their full content and are clipped when drawn
-    /// (`x_draw_xwidget_glyph_string`'s `clip_*`).
-    pub(crate) fn cropped_to_visible_width(mut self, visible_width_px: f32) -> Self {
-        if !visible_width_px.is_finite()
-            || visible_width_px <= 0.0
-            || visible_width_px >= self.width
-        {
-            return self;
-        }
-        if let DisplayMediaReplacementKind::Image { source_rect, .. } = &mut self.kind {
-            let kept = visible_width_px / self.width;
-            if let Some(cropped) = neomacs_display_protocol::ImageSourceRect::new(
-                source_rect.x(),
-                source_rect.y(),
-                source_rect.width() * kept,
-                source_rect.height(),
-            ) {
-                *source_rect = cropped;
-            }
-        }
-        self.width = visible_width_px;
-        self
-    }
-
     pub(crate) fn with_positive_box_line_width(mut self, per_edge: f32) -> Self {
         if !per_edge.is_finite() || per_edge <= 0.0 {
             return self;
@@ -1519,16 +1493,43 @@ impl DisplayMediaReplacement {
     }
 
     pub(crate) fn xwidget(xwidget: DisplayXwidgetItem) -> Self {
+        let width = display_replacement_dimension(xwidget.width);
+        let height = display_replacement_dimension(xwidget.height);
         Self {
             kind: DisplayMediaReplacementKind::Xwidget {
                 xwidget_id: xwidget.xwidget_id,
                 webview_id: xwidget.webview_id,
+                content: XwidgetContentExtent::new(width, height)
+                    .expect("display_replacement_dimension yields finite widths of at least 1"),
             },
-            width: display_replacement_dimension(xwidget.width),
-            height: display_replacement_dimension(xwidget.height),
+            width,
+            height,
             ascent: display_replacement_ascent(xwidget.height),
             positive_box_line_width: 0.0,
         }
+    }
+
+    /// Narrow an xwidget's layout advance to `visible_width_px`, the way
+    /// `produce_xwidget_glyph` does at the right edge (`it->pixel_width -=
+    /// crop`, src/xdisp.c:32579, emacs-31.0.90).  The widget's own size in
+    /// `DisplayMediaReplacementKind::Xwidget::content` is untouched: GNU sizes
+    /// the native view from `xww->width` and clips it
+    /// (`x_draw_xwidget_glyph_string`, src/xwidget.c:2841-2847).
+    ///
+    /// Only an xwidget has this rule; see `DisplayXwidgetOverflowAction`.
+    pub(crate) fn xwidget_advance_cropped_to(mut self, visible_width_px: f32) -> Self {
+        debug_assert!(
+            matches!(self.kind, DisplayMediaReplacementKind::Xwidget { .. }),
+            "the right-edge crop is the xwidget rule; images have their own"
+        );
+        if !visible_width_px.is_finite()
+            || visible_width_px <= 0.0
+            || visible_width_px >= self.width
+        {
+            return self;
+        }
+        self.width = visible_width_px;
+        self
     }
 
     pub(crate) fn surface(surface: DisplaySurfaceItem) -> Self {

--- a/crates/neomacs-layout-engine/src/display_item.rs
+++ b/crates/neomacs-layout-engine/src/display_item.rs
@@ -1514,7 +1514,7 @@ impl DisplayMediaReplacement {
     /// crop`, src/xdisp.c:32579, emacs-31.0.90).  The widget's own size in
     /// `DisplayMediaReplacementKind::Xwidget::content` is untouched: GNU sizes
     /// the native view from `xww->width` and clips it
-    /// (`x_draw_xwidget_glyph_string`, src/xwidget.c:2841-2847).
+    /// (`x_draw_xwidget_glyph_string`, src/xwidget.c:2841-2849).
     ///
     /// Only an xwidget has this rule; see `DisplayXwidgetOverflowAction`.
     pub(crate) fn xwidget_advance_cropped_to(mut self, visible_width_px: f32) -> Self {

--- a/crates/neomacs-layout-engine/src/display_item.rs
+++ b/crates/neomacs-layout-engine/src/display_item.rs
@@ -1415,6 +1415,35 @@ impl DisplayMediaReplacement {
     /// content.  Fold that inset into the durable image placement now, while
     /// the realized face is available, so layout advance and renderer replay
     /// cannot disagree or paint the border over the outer image pixels.
+    /// Narrow the replacement to `visible_width_px`, the way GNU's producers
+    /// crop a glyph at the right edge (see
+    /// `DisplayMediaReplacementOverflowAction`).  An image also narrows its
+    /// slice -- `slice.width -= crop`, src/xdisp.c:32597 -- so what remains is
+    /// the left part of the image rather than the whole image squeezed; the
+    /// other kinds keep their full content and are clipped when drawn
+    /// (`x_draw_xwidget_glyph_string`'s `clip_*`).
+    pub(crate) fn cropped_to_visible_width(mut self, visible_width_px: f32) -> Self {
+        if !visible_width_px.is_finite()
+            || visible_width_px <= 0.0
+            || visible_width_px >= self.width
+        {
+            return self;
+        }
+        if let DisplayMediaReplacementKind::Image { source_rect, .. } = &mut self.kind {
+            let kept = visible_width_px / self.width;
+            if let Some(cropped) = neomacs_display_protocol::ImageSourceRect::new(
+                source_rect.x(),
+                source_rect.y(),
+                source_rect.width() * kept,
+                source_rect.height(),
+            ) {
+                *source_rect = cropped;
+            }
+        }
+        self.width = visible_width_px;
+        self
+    }
+
     pub(crate) fn with_positive_box_line_width(mut self, per_edge: f32) -> Self {
         if !per_edge.is_finite() || per_edge <= 0.0 {
             return self;

--- a/crates/neomacs-layout-engine/src/display_item.rs
+++ b/crates/neomacs-layout-engine/src/display_item.rs
@@ -1,9 +1,12 @@
 use crate::buffer_source::producer::frame::ReplacementCoveredSpan;
 use crate::display_property::DisplayPropertyClassification;
+use crate::display_source_overflow::DisplayXwidgetOverflowAction;
 use neomacs_display_protocol::face::{BoxRunMembership, BoxVerticalEdges};
 use neomacs_display_protocol::glyph_matrix::TerminalComposition;
 use neomacs_display_protocol::types::FaceId;
-use neomacs_display_protocol::{WebViewId, XwidgetContentExtent, XwidgetId};
+use neomacs_display_protocol::{
+    Px, WebViewId, XwidgetContentExtent, XwidgetId, XwidgetLayoutAdvance,
+};
 use neovm_core::buffer::{BufferId, CharPos0, EmacsBytePos};
 use neovm_core::emacs_core::Value;
 use neovm_core::emacs_core::emacs_char::EmacsChar;
@@ -1385,6 +1388,39 @@ pub(crate) enum DisplayMediaReplacementKind {
     },
 }
 
+/// A media replacement proven to be an xwidget.
+///
+/// GNU's right-edge policy is meaningful only for xwidgets.  Extracting this
+/// capability from the generic media enum makes applying that policy a typed
+/// operation instead of relying on a debug-only assertion that the caller did
+/// not accidentally crop an image, video, or shader surface.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct DisplayXwidgetReplacement(DisplayMediaReplacement);
+
+impl DisplayXwidgetReplacement {
+    pub(crate) fn layout_advance(self) -> XwidgetLayoutAdvance {
+        XwidgetLayoutAdvance::new(Px(self.0.width))
+            .expect("an xwidget replacement always has a positive finite advance")
+    }
+
+    pub(crate) fn apply_overflow(mut self, action: DisplayXwidgetOverflowAction) -> Self {
+        match action {
+            DisplayXwidgetOverflowAction::Fits | DisplayXwidgetOverflowAction::LeaveWhole => {}
+            DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth { advance }
+                if advance.px().get() < self.0.width =>
+            {
+                self.0.width = advance.px().get();
+            }
+            DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth { .. } => {}
+        }
+        self
+    }
+
+    pub(crate) const fn into_media(self) -> DisplayMediaReplacement {
+        self.0
+    }
+}
+
 impl DisplayMediaReplacement {
     pub(crate) fn replacement_stretch(self) -> DisplayStretch {
         DisplayStretch {
@@ -1509,27 +1545,14 @@ impl DisplayMediaReplacement {
         }
     }
 
-    /// Narrow an xwidget's layout advance to `visible_width_px`, the way
-    /// `produce_xwidget_glyph` does at the right edge (`it->pixel_width -=
-    /// crop`, src/xdisp.c:32579, emacs-31.0.90).  The widget's own size in
-    /// `DisplayMediaReplacementKind::Xwidget::content` is untouched: GNU sizes
-    /// the native view from `xww->width` and clips it
-    /// (`x_draw_xwidget_glyph_string`, src/xwidget.c:2841-2849).
-    ///
-    /// Only an xwidget has this rule; see `DisplayXwidgetOverflowAction`.
-    pub(crate) fn xwidget_advance_cropped_to(mut self, visible_width_px: f32) -> Self {
-        debug_assert!(
-            matches!(self.kind, DisplayMediaReplacementKind::Xwidget { .. }),
-            "the right-edge crop is the xwidget rule; images have their own"
-        );
-        if !visible_width_px.is_finite()
-            || visible_width_px <= 0.0
-            || visible_width_px >= self.width
-        {
-            return self;
+    /// Prove this generic media replacement is an xwidget before exposing
+    /// GNU's xwidget-only overflow operation.
+    pub(crate) fn into_xwidget(self) -> Result<DisplayXwidgetReplacement, Self> {
+        if matches!(self.kind, DisplayMediaReplacementKind::Xwidget { .. }) {
+            Ok(DisplayXwidgetReplacement(self))
+        } else {
+            Err(self)
         }
-        self.width = visible_width_px;
-        self
     }
 
     pub(crate) fn surface(surface: DisplaySurfaceItem) -> Self {

--- a/crates/neomacs-layout-engine/src/display_item_test.rs
+++ b/crates/neomacs-layout-engine/src/display_item_test.rs
@@ -345,7 +345,18 @@ fn cropping_an_xwidgets_advance_keeps_its_content_extent() {
     assert_eq!(content(xwidget).width_px(), 600.0);
     assert_eq!(content(xwidget).height_px(), 40.0);
 
-    let cropped = xwidget.xwidget_advance_cropped_to(304.0);
+    let cropped = xwidget
+        .into_xwidget()
+        .expect("typed xwidget replacement")
+        .apply_overflow(
+            crate::display_source_overflow::DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
+                advance: neomacs_display_protocol::XwidgetLayoutAdvance::new(
+                    neomacs_display_protocol::Px(304.0),
+                )
+                .unwrap(),
+            },
+        )
+        .into_media();
     assert_eq!(cropped.width, 304.0, "the layout advance is cropped");
     assert_eq!(cropped.height, 40.0);
     assert_eq!(
@@ -354,8 +365,22 @@ fn cropping_an_xwidgets_advance_keeps_its_content_extent() {
         "the widget's own width is not"
     );
 
-    // Widening is not cropping; a non-positive width is not either.
-    assert_eq!(xwidget.xwidget_advance_cropped_to(900.0).width, 600.0);
-    assert_eq!(xwidget.xwidget_advance_cropped_to(0.0).width, 600.0);
-    assert_eq!(xwidget.xwidget_advance_cropped_to(f32::NAN).width, 600.0);
+    // Widening is not cropping. Invalid advances cannot be represented.
+    let widened = xwidget
+        .into_xwidget()
+        .unwrap()
+        .apply_overflow(
+            crate::display_source_overflow::DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
+                advance: neomacs_display_protocol::XwidgetLayoutAdvance::new(
+                    neomacs_display_protocol::Px(900.0),
+                )
+                .unwrap(),
+            },
+        )
+        .into_media();
+    assert_eq!(widened.width, 600.0);
+    assert_eq!(
+        neomacs_display_protocol::XwidgetLayoutAdvance::new(neomacs_display_protocol::Px(0.0)),
+        None
+    );
 }

--- a/crates/neomacs-layout-engine/src/display_item_test.rs
+++ b/crates/neomacs-layout-engine/src/display_item_test.rs
@@ -324,3 +324,52 @@ fn replacement_source_keeps_non_text_kinds_with_covered_span() {
         "the covered buffer span applies to every item kind the string yields"
     );
 }
+
+/// GNU crops an image's slice along with its width (src/xdisp.c:32597), so
+/// the left part stays at scale; an xwidget keeps its content and is
+/// clipped when drawn (nsxwidget.m / xwidget.c `clip_right`).
+#[test]
+fn cropping_a_media_replacement_narrows_an_image_slice_but_not_an_xwidget() {
+    let image = DisplayMediaReplacement {
+        kind: DisplayMediaReplacementKind::Image {
+            image_id: 1,
+            source_rect: neomacs_display_protocol::ImageSourceRect::FULL,
+            margin_left: 0.0,
+            margin_right: 0.0,
+            margin_top: 0.0,
+            margin_bottom: 0.0,
+            opaque_background: None,
+        },
+        width: 400.0,
+        height: 100.0,
+        ascent: 100.0,
+        positive_box_line_width: 0.0,
+    };
+    let cropped = image.cropped_to_visible_width(100.0);
+    assert_eq!(cropped.width, 100.0);
+    assert_eq!(cropped.height, 100.0);
+    let DisplayMediaReplacementKind::Image { source_rect, .. } = cropped.kind else {
+        panic!("still an image");
+    };
+    assert!((source_rect.width() - 0.25).abs() < 1e-4, "{source_rect:?}");
+    assert_eq!(source_rect.x(), 0.0);
+    assert!((source_rect.height() - 1.0).abs() < 1e-4);
+
+    let xwidget = DisplayMediaReplacement::xwidget(DisplayXwidgetItem {
+        xwidget_id: neomacs_display_protocol::XwidgetId::new(1),
+        webview_id: neomacs_display_protocol::WebViewId::new(1),
+        width: 600.0,
+        height: 40.0,
+    });
+    let cropped = xwidget.cropped_to_visible_width(304.0);
+    assert_eq!(cropped.width, 304.0);
+    assert_eq!(cropped.height, 40.0);
+    assert!(matches!(
+        cropped.kind,
+        DisplayMediaReplacementKind::Xwidget { .. }
+    ));
+
+    // Widening is not cropping; a non-positive width is not either.
+    assert_eq!(xwidget.cropped_to_visible_width(900.0).width, 600.0);
+    assert_eq!(xwidget.cropped_to_visible_width(0.0).width, 600.0);
+}

--- a/crates/neomacs-layout-engine/src/display_item_test.rs
+++ b/crates/neomacs-layout-engine/src/display_item_test.rs
@@ -325,51 +325,37 @@ fn replacement_source_keeps_non_text_kinds_with_covered_span() {
     );
 }
 
-/// GNU crops an image's slice along with its width (src/xdisp.c:32597), so
-/// the left part stays at scale; an xwidget keeps its content and is
-/// clipped when drawn (nsxwidget.m / xwidget.c `clip_right`).
+/// `produce_xwidget_glyph` crops the glyph's advance (`it->pixel_width -=
+/// crop`, src/xdisp.c:32579, emacs-31.0.90) and nothing else: the widget's
+/// own size still drives the native view, which
+/// `x_draw_xwidget_glyph_string` clips (src/xwidget.c:2841-2847).
 #[test]
-fn cropping_a_media_replacement_narrows_an_image_slice_but_not_an_xwidget() {
-    let image = DisplayMediaReplacement {
-        kind: DisplayMediaReplacementKind::Image {
-            image_id: 1,
-            source_rect: neomacs_display_protocol::ImageSourceRect::FULL,
-            margin_left: 0.0,
-            margin_right: 0.0,
-            margin_top: 0.0,
-            margin_bottom: 0.0,
-            opaque_background: None,
-        },
-        width: 400.0,
-        height: 100.0,
-        ascent: 100.0,
-        positive_box_line_width: 0.0,
-    };
-    let cropped = image.cropped_to_visible_width(100.0);
-    assert_eq!(cropped.width, 100.0);
-    assert_eq!(cropped.height, 100.0);
-    let DisplayMediaReplacementKind::Image { source_rect, .. } = cropped.kind else {
-        panic!("still an image");
-    };
-    assert!((source_rect.width() - 0.25).abs() < 1e-4, "{source_rect:?}");
-    assert_eq!(source_rect.x(), 0.0);
-    assert!((source_rect.height() - 1.0).abs() < 1e-4);
-
+fn cropping_an_xwidgets_advance_keeps_its_content_extent() {
     let xwidget = DisplayMediaReplacement::xwidget(DisplayXwidgetItem {
         xwidget_id: neomacs_display_protocol::XwidgetId::new(1),
         webview_id: neomacs_display_protocol::WebViewId::new(1),
         width: 600.0,
         height: 40.0,
     });
-    let cropped = xwidget.cropped_to_visible_width(304.0);
-    assert_eq!(cropped.width, 304.0);
+    let content = |media: DisplayMediaReplacement| match media.kind {
+        DisplayMediaReplacementKind::Xwidget { content, .. } => content,
+        other => panic!("still an xwidget, got {other:?}"),
+    };
+    assert_eq!(xwidget.width, 600.0);
+    assert_eq!(content(xwidget).width_px(), 600.0);
+    assert_eq!(content(xwidget).height_px(), 40.0);
+
+    let cropped = xwidget.xwidget_advance_cropped_to(304.0);
+    assert_eq!(cropped.width, 304.0, "the layout advance is cropped");
     assert_eq!(cropped.height, 40.0);
-    assert!(matches!(
-        cropped.kind,
-        DisplayMediaReplacementKind::Xwidget { .. }
-    ));
+    assert_eq!(
+        content(cropped).width_px(),
+        600.0,
+        "the widget's own width is not"
+    );
 
     // Widening is not cropping; a non-positive width is not either.
-    assert_eq!(xwidget.cropped_to_visible_width(900.0).width, 600.0);
-    assert_eq!(xwidget.cropped_to_visible_width(0.0).width, 600.0);
+    assert_eq!(xwidget.xwidget_advance_cropped_to(900.0).width, 600.0);
+    assert_eq!(xwidget.xwidget_advance_cropped_to(0.0).width, 600.0);
+    assert_eq!(xwidget.xwidget_advance_cropped_to(f32::NAN).width, 600.0);
 }

--- a/crates/neomacs-layout-engine/src/display_item_test.rs
+++ b/crates/neomacs-layout-engine/src/display_item_test.rs
@@ -328,7 +328,7 @@ fn replacement_source_keeps_non_text_kinds_with_covered_span() {
 /// `produce_xwidget_glyph` crops the glyph's advance (`it->pixel_width -=
 /// crop`, src/xdisp.c:32579, emacs-31.0.90) and nothing else: the widget's
 /// own size still drives the native view, which
-/// `x_draw_xwidget_glyph_string` clips (src/xwidget.c:2841-2847).
+/// `x_draw_xwidget_glyph_string` clips (src/xwidget.c:2841-2849).
 #[test]
 fn cropping_an_xwidgets_advance_keeps_its_content_extent() {
     let xwidget = DisplayMediaReplacement::xwidget(DisplayXwidgetItem {

--- a/crates/neomacs-layout-engine/src/display_row/append_context.rs
+++ b/crates/neomacs-layout-engine/src/display_row/append_context.rs
@@ -78,6 +78,17 @@ impl DisplayRowAppendArea {
         self.line_number_width
     }
 
+    /// Left edge of the complete TEXT_AREA, including a structural display
+    /// line-number prefix.  `content_x` is the ordinary buffer body's start,
+    /// so the prefix sits between the two.  This is the one place the append
+    /// context computes the edge: GNU's `it->current_x` counts the prefix
+    /// (it is produced as glyphs, `maybe_produce_line_number`,
+    /// src/xdisp.c:25701), so both hscroll truncation and the window-local
+    /// extent an overflowing glyph is measured against start here.
+    pub(crate) fn text_area_left(self) -> f32 {
+        self.content_x - self.line_number_width
+    }
+
     pub(crate) fn right_edge(self) -> f32 {
         self.content_x() + self.width()
     }
@@ -223,10 +234,9 @@ impl DisplayRowAppendSurface {
         self.area.content_x()
     }
 
-    /// Left edge of the complete TEXT_AREA, including a structural display
-    /// line-number prefix.  `content_x` is the ordinary buffer body's start.
+    /// See [`DisplayRowAppendArea::text_area_left`].
     pub(crate) fn text_area_left(&self) -> f32 {
-        self.area.content_x() - self.area.line_number_width()
+        self.area.text_area_left()
     }
 
     pub(crate) fn right_edge(&self) -> f32 {
@@ -692,9 +702,11 @@ pub(crate) struct DisplayRowAppendFrame {
     glyph_y: f32,
     geometry: DisplayRowGeometry,
     default_row_height: f32,
-    content_x: f32,
-    text_width: f32,
-    line_number_width: f32,
+    /// The text area this row is appended into, held whole so every
+    /// derived edge (`content_x`, the text-area origin, the right edge)
+    /// comes from one value and cannot drift from what hscroll
+    /// truncation reads through [`DisplayRowAppendSurface`].
+    area: DisplayRowAppendArea,
     margin_areas: DisplayRowMarginAreas,
     face_space_width: f32,
     image_scale_environment: ImageScaleEnvironment,
@@ -759,15 +771,15 @@ impl DisplayRowAppendFrame {
     }
 
     pub(crate) fn content_x(&self) -> f32 {
-        self.content_x
+        self.area.content_x()
     }
 
     pub(crate) fn text_width(&self) -> f32 {
-        self.text_width
+        self.area.text_width()
     }
 
     pub(crate) fn line_number_width(&self) -> f32 {
-        self.line_number_width
+        self.area.line_number_width()
     }
 
     pub(crate) fn face_space_width(&self) -> f32 {
@@ -786,12 +798,11 @@ impl DisplayRowAppendFrame {
         self.content_x() + self.geometry().width()
     }
 
-    /// The window's text area starts where the content does, less the
-    /// line-number prefix that `content_x` already skips: GNU's
-    /// `it->current_x` counts that prefix (it is produced as glyphs), so the
-    /// origin GNU measures from is the text area's own left edge.
+    /// The origin GNU's window-local `it->current_x` is measured from: the
+    /// text area's own left edge ([`DisplayRowAppendArea::text_area_left`]),
+    /// the same edge hscroll truncation uses.
     fn text_area_origin(&self) -> DisplayRowTextAreaOrigin {
-        DisplayRowTextAreaOrigin::at_frame_x(self.content_x() - self.line_number_width())
+        DisplayRowTextAreaOrigin::at_frame_x(self.area.text_area_left())
     }
 
     fn text_right_edge_excluding_line_number(&self) -> f32 {
@@ -818,9 +829,7 @@ impl DisplayRowAppendFrame {
                 tab_policy,
             ),
             default_row_height: metrics.fallback_metrics().row_height(),
-            content_x: area.content_x(),
-            text_width: area.text_width(),
-            line_number_width: area.line_number_width(),
+            area,
             margin_areas,
             face_space_width: metrics.space_width(),
             image_scale_environment,

--- a/crates/neomacs-layout-engine/src/display_row/append_context.rs
+++ b/crates/neomacs-layout-engine/src/display_row/append_context.rs
@@ -803,6 +803,7 @@ impl DisplayRowAppendFrame {
     /// the same edge hscroll truncation uses.
     fn text_area_origin(&self) -> DisplayRowTextAreaOrigin {
         DisplayRowTextAreaOrigin::at_frame_x(self.area.text_area_left())
+            .expect("a display-row text-area origin is finite")
     }
 
     fn text_right_edge_excluding_line_number(&self) -> f32 {

--- a/crates/neomacs-layout-engine/src/display_row/append_context.rs
+++ b/crates/neomacs-layout-engine/src/display_row/append_context.rs
@@ -6,7 +6,9 @@ use crate::display_row::builder::{
     DisplayRowAppendStartPolicy, DisplayRowPosition, DisplayTabPolicy,
 };
 use crate::display_row::face_state::DisplayRowActiveFaceState;
-use crate::display_row::geometry::{DisplayRowGeometry, DisplayRowGeometryState, DisplayRowMaxX};
+use crate::display_row::geometry::{
+    DisplayRowGeometry, DisplayRowGeometryState, DisplayRowMaxX, DisplayRowTextAreaOrigin,
+};
 use crate::display_row::metrics::{DisplayRowFallbackMetrics, DisplayRowMeasuredFaceMetrics};
 use crate::display_row::render_state::DisplayRowRenderBounds;
 use crate::display_row::text_output::TextRowOutput;
@@ -784,6 +786,14 @@ impl DisplayRowAppendFrame {
         self.content_x() + self.geometry().width()
     }
 
+    /// The window's text area starts where the content does, less the
+    /// line-number prefix that `content_x` already skips: GNU's
+    /// `it->current_x` counts that prefix (it is produced as glyphs), so the
+    /// origin GNU measures from is the text area's own left edge.
+    fn text_area_origin(&self) -> DisplayRowTextAreaOrigin {
+        DisplayRowTextAreaOrigin::at_frame_x(self.content_x() - self.line_number_width())
+    }
+
     fn text_right_edge_excluding_line_number(&self) -> f32 {
         self.content_x() + (self.text_width() - self.line_number_width()).max(0.0)
     }
@@ -859,7 +869,11 @@ impl DisplayRowAppendFrame {
             GlyphRowRole::Text,
         )
         .with_image_scale_environment(self.image_scale_environment)
-        .with_render_bounds(DisplayRowRenderBounds::new(position, kind.max_x(self)))
+        .with_render_bounds(DisplayRowRenderBounds::in_window_text_area(
+            position,
+            kind.max_x(self),
+            self.text_area_origin(),
+        ))
         .with_line_end_right_edge_x(self.text_right_edge_excluding_line_number())
     }
 

--- a/crates/neomacs-layout-engine/src/display_row/append_test.rs
+++ b/crates/neomacs-layout-engine/src/display_row/append_test.rs
@@ -11848,43 +11848,39 @@ fn display_replacement_append_context_installs_xwidget_replacements() {
             neomacs_display_protocol::frame_glyphs::FrameGlyph::Xwidget {
                 window_id,
                 row_role,
-                clip_rect,
                 slot_id,
                 xwidget_id,
-                x,
-                y,
-                width,
-                height,
+                presentation,
                 ..
-            } => Some((
-                *window_id,
-                *row_role,
-                *clip_rect,
-                *slot_id,
-                *xwidget_id,
-                *x,
-                *y,
-                *width,
-                *height,
-            )),
+            } => Some((*window_id, *row_role, *slot_id, *xwidget_id, *presentation)),
             _ => None,
         })
         .expect("xwidget materialized from its row glyph");
     assert_eq!(xwidget.0.get(), 77);
     assert_eq!(xwidget.1, GlyphRowRole::Text);
-    assert_eq!(xwidget.2, Some(text_bounds));
     assert_eq!(
-        xwidget.3,
+        xwidget.2,
         Some(neomacs_display_protocol::frame_glyphs::DisplaySlotId {
             window_id: neomacs_display_protocol::types::DisplayWindowId::new(77),
             row: 0,
             col: 2,
         })
     );
-    assert_eq!(xwidget.4.get(), 1234);
+    assert_eq!(xwidget.3.get(), 1234);
+    let slot = xwidget.4.layout_slot_rect();
     assert_eq!(
-        (xwidget.5, xwidget.6, xwidget.7, xwidget.8),
+        (slot.x(), slot.y(), slot.width(), slot.height()),
         (16.0, 24.0, 96.0, 54.0)
+    );
+    let clip = xwidget.4.clip_rect().expect("body-row text-area clip");
+    assert_eq!(
+        (clip.x(), clip.y(), clip.width(), clip.height()),
+        (
+            text_bounds.x,
+            text_bounds.y,
+            text_bounds.width,
+            text_bounds.height
+        )
     );
 }
 

--- a/crates/neomacs-layout-engine/src/display_row/builder.rs
+++ b/crates/neomacs-layout-engine/src/display_row/builder.rs
@@ -1716,31 +1716,28 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
                 // images have their own GNU rule (not ported), and margin
                 // lanes keep their own structural clip below.
                 let kind = match kind {
-                    DisplayItemKind::MediaReplacement(
-                        media @ DisplayMediaReplacement {
-                            kind: DisplayMediaReplacementKind::Xwidget { .. },
-                            ..
-                        },
-                    ) if self.writer.overflow_policy()
-                        == DisplayRowOverflowPolicy::RejectOverflowingGlyph =>
+                    DisplayItemKind::MediaReplacement(media)
+                        if self.writer.overflow_policy()
+                            == DisplayRowOverflowPolicy::RejectOverflowingGlyph =>
                     {
-                        let extent = WindowLocalRowExtent::from_frame_coordinates(
-                            self.text_area_origin,
-                            self.position.x_px(),
-                            self.max_x_px,
-                        );
-                        let action = DisplayXwidgetOverflowAction::for_xwidget(
-                            media.width,
-                            extent,
-                            before_len == 0,
-                        );
-                        DisplayItemKind::MediaReplacement(match action {
-                            DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
-                                visible_width_px,
-                            } => media.xwidget_advance_cropped_to(visible_width_px),
-                            DisplayXwidgetOverflowAction::Fits
-                            | DisplayXwidgetOverflowAction::LeaveWhole => media,
-                        })
+                        match media.into_xwidget() {
+                            Ok(xwidget) => {
+                                let extent = WindowLocalRowExtent::from_frame_coordinates(
+                                    self.text_area_origin,
+                                    self.position.x_px(),
+                                    self.max_x_px,
+                                );
+                                let action = DisplayXwidgetOverflowAction::for_xwidget(
+                                    xwidget.layout_advance(),
+                                    extent,
+                                    before_len == 0,
+                                );
+                                DisplayItemKind::MediaReplacement(
+                                    xwidget.apply_overflow(action).into_media(),
+                                )
+                            }
+                            Err(media) => DisplayItemKind::MediaReplacement(media),
+                        }
                     }
                     kind => kind,
                 };

--- a/crates/neomacs-layout-engine/src/display_row/builder.rs
+++ b/crates/neomacs-layout-engine/src/display_row/builder.rs
@@ -1716,10 +1716,13 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
                 // images have their own GNU rule (not ported), and margin
                 // lanes keep their own structural clip below.
                 let kind = match kind {
-                    DisplayItemKind::MediaReplacement(media)
-                        if matches!(media.kind, DisplayMediaReplacementKind::Xwidget { .. })
-                            && self.writer.overflow_policy()
-                                == DisplayRowOverflowPolicy::RejectOverflowingGlyph =>
+                    DisplayItemKind::MediaReplacement(
+                        media @ DisplayMediaReplacement {
+                            kind: DisplayMediaReplacementKind::Xwidget { .. },
+                            ..
+                        },
+                    ) if self.writer.overflow_policy()
+                        == DisplayRowOverflowPolicy::RejectOverflowingGlyph =>
                     {
                         let extent = WindowLocalRowExtent::from_frame_coordinates(
                             self.text_area_origin,

--- a/crates/neomacs-layout-engine/src/display_row/builder.rs
+++ b/crates/neomacs-layout-engine/src/display_row/builder.rs
@@ -1323,6 +1323,20 @@ enum DisplayRowOverflowPolicy {
     ClipToStructuralLane,
 }
 
+/// Per-item admission at the row's right edge.
+///
+/// GNU's `display_line` deliberately keeps an xwidget that
+/// `produce_xwidget_glyph` classified as `LeaveWhole`, even when its layout
+/// advance crosses a truncating row's boundary.  The native xwidget clip then
+/// limits what is presented.  Keeping this as an xwidget-branded capability
+/// prevents that exception from silently becoming the policy for images,
+/// videos, surfaces, or ordinary glyphs.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DisplayItemRightEdgeAdmission {
+    EnforceRowBoundary,
+    PreserveWholeXwidget,
+}
+
 pub(crate) struct DisplayRowProgressWriter<'layout, 'row, 'measurer> {
     writer: DisplayRowWriter<'layout, 'row, 'measurer>,
     position: DisplayRowPosition,
@@ -1715,7 +1729,7 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
                 // `DisplayXwidgetOverflowAction`.  Xwidgets in body text only:
                 // images have their own GNU rule (not ported), and margin
                 // lanes keep their own structural clip below.
-                let kind = match kind {
+                let (kind, right_edge_admission) = match kind {
                     DisplayItemKind::MediaReplacement(media)
                         if self.writer.overflow_policy()
                             == DisplayRowOverflowPolicy::RejectOverflowingGlyph =>
@@ -1732,14 +1746,29 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
                                     extent,
                                     before_len == 0,
                                 );
-                                DisplayItemKind::MediaReplacement(
-                                    xwidget.apply_overflow(action).into_media(),
+                                let admission = match action {
+                                    DisplayXwidgetOverflowAction::Fits
+                                    | DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
+                                        ..
+                                    } => DisplayItemRightEdgeAdmission::EnforceRowBoundary,
+                                    DisplayXwidgetOverflowAction::LeaveWhole => {
+                                        DisplayItemRightEdgeAdmission::PreserveWholeXwidget
+                                    }
+                                };
+                                (
+                                    DisplayItemKind::MediaReplacement(
+                                        xwidget.apply_overflow(action).into_media(),
+                                    ),
+                                    admission,
                                 )
                             }
-                            Err(media) => DisplayItemKind::MediaReplacement(media),
+                            Err(media) => (
+                                DisplayItemKind::MediaReplacement(media),
+                                DisplayItemRightEdgeAdmission::EnforceRowBoundary,
+                            ),
                         }
                     }
-                    kind => kind,
+                    kind => (kind, DisplayItemRightEdgeAdmission::EnforceRowBoundary),
                 };
                 let checkpoint = DisplayRowGlyphCheckpoint::capture(self.writer.row);
                 let mut written = self.writer.push_item(
@@ -1751,6 +1780,7 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
                 let mut status = DisplayRowAppendStatus::Complete;
                 if written.has_positive_width()
                     && self.position.x_px() + written.width_px() > self.max_x_px
+                    && right_edge_admission == DisplayItemRightEdgeAdmission::EnforceRowBoundary
                 {
                     let available_px = (self.max_x_px - self.position.x_px()).max(0.0);
                     match self.writer.overflow_policy() {

--- a/crates/neomacs-layout-engine/src/display_row/builder.rs
+++ b/crates/neomacs-layout-engine/src/display_row/builder.rs
@@ -14,9 +14,10 @@ use crate::display_row::append_context::{
     DisplayRowTextCharState, DisplayRowTextNaturalAdvanceKind, DisplayRowTextNaturalAdvancePolicy,
     DisplayRowTextNaturalAdvanceRequest,
 };
+use crate::display_row::geometry::DisplayRowTextAreaOrigin;
 #[cfg(test)]
 use crate::display_source::{DisplayItemSource, DisplaySourceContext};
-use crate::display_source_overflow::DisplayMediaReplacementOverflowAction;
+use crate::display_source_overflow::{DisplayXwidgetOverflowAction, WindowLocalRowExtent};
 use crate::glyph_row_writer;
 #[cfg(test)]
 use crate::output::builder::DisplayOutputBuilder;
@@ -1326,6 +1327,9 @@ pub(crate) struct DisplayRowProgressWriter<'layout, 'row, 'measurer> {
     writer: DisplayRowWriter<'layout, 'row, 'measurer>,
     position: DisplayRowPosition,
     max_x_px: f32,
+    /// Where `position` and `max_x_px` are measured from in GNU's
+    /// window-local terms; see `DisplayRowTextAreaOrigin`.
+    text_area_origin: DisplayRowTextAreaOrigin,
     text_run_measurement: Option<DisplayTextRunMeasurement>,
 }
 
@@ -1500,6 +1504,7 @@ impl<'layout, 'row> DisplayRowProgressWriter<'layout, 'row, '_> {
             writer,
             position,
             max_x_px,
+            text_area_origin: DisplayRowTextAreaOrigin::row_local(),
             text_run_measurement: None,
         }
     }
@@ -1539,17 +1544,20 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
             glyph_measurer,
             position,
             max_x_px,
+            DisplayRowTextAreaOrigin::row_local(),
             area,
             DisplayRowAppendStartPolicy::ReconcileWithRowTail,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn with_glyph_measurer_for_area_and_start_policy(
         layout: &'layout DisplayRowLayout,
         row: &'row mut GlyphRow,
         glyph_measurer: &'measurer mut dyn DisplayGlyphMeasurer,
         position: DisplayRowPosition,
         max_x_px: f32,
+        text_area_origin: DisplayRowTextAreaOrigin,
         area: GlyphArea,
         start_policy: DisplayRowAppendStartPolicy,
     ) -> Self {
@@ -1561,6 +1569,7 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
             writer,
             position,
             max_x_px,
+            text_area_origin,
             text_run_measurement: None,
         }
     }
@@ -1599,6 +1608,7 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
             writer,
             position,
             max_x_px,
+            text_area_origin: DisplayRowTextAreaOrigin::row_local(),
             text_run_measurement: Some(text_run_measurement),
         }
     }
@@ -1611,6 +1621,7 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
         glyph_measurer: &'measurer mut dyn DisplayGlyphMeasurer,
         position: DisplayRowPosition,
         max_x_px: f32,
+        text_area_origin: DisplayRowTextAreaOrigin,
         area: GlyphArea,
         start_policy: DisplayRowAppendStartPolicy,
     ) -> Self {
@@ -1622,6 +1633,7 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
             writer,
             position,
             max_x_px,
+            text_area_origin,
             text_run_measurement: Some(text_run_measurement),
         }
     }
@@ -1698,27 +1710,33 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
                 let slot_start = self.position;
                 let slot_source = span.start.clone();
                 let before_len = self.area_len();
-                // GNU crops a wide media glyph when it produces it, before
-                // `display_line` measures the row; see
-                // `DisplayMediaReplacementOverflowAction`.  Body text only:
-                // margin lanes keep their own structural clip below.
+                // GNU crops a wide xwidget's advance when it produces the
+                // glyph, before `display_line` measures the row; see
+                // `DisplayXwidgetOverflowAction`.  Xwidgets in body text only:
+                // images have their own GNU rule (not ported), and margin
+                // lanes keep their own structural clip below.
                 let kind = match kind {
                     DisplayItemKind::MediaReplacement(media)
-                        if self.writer.overflow_policy()
-                            == DisplayRowOverflowPolicy::RejectOverflowingGlyph =>
+                        if matches!(media.kind, DisplayMediaReplacementKind::Xwidget { .. })
+                            && self.writer.overflow_policy()
+                                == DisplayRowOverflowPolicy::RejectOverflowingGlyph =>
                     {
-                        let action = DisplayMediaReplacementOverflowAction::for_replacement(
-                            media.width,
+                        let extent = WindowLocalRowExtent::from_frame_coordinates(
+                            self.text_area_origin,
                             self.position.x_px(),
                             self.max_x_px,
+                        );
+                        let action = DisplayXwidgetOverflowAction::for_xwidget(
+                            media.width,
+                            extent,
                             before_len == 0,
                         );
                         DisplayItemKind::MediaReplacement(match action {
-                            DisplayMediaReplacementOverflowAction::CropToVisibleWidth {
+                            DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
                                 visible_width_px,
-                            } => media.cropped_to_visible_width(visible_width_px),
-                            DisplayMediaReplacementOverflowAction::Fits
-                            | DisplayMediaReplacementOverflowAction::LeaveWhole => media,
+                            } => media.xwidget_advance_cropped_to(visible_width_px),
+                            DisplayXwidgetOverflowAction::Fits
+                            | DisplayXwidgetOverflowAction::LeaveWhole => media,
                         })
                     }
                     kind => kind,
@@ -2669,10 +2687,12 @@ impl<'layout, 'row, 'measurer> DisplayRowWriter<'layout, 'row, 'measurer> {
             DisplayMediaReplacementKind::Xwidget {
                 xwidget_id,
                 webview_id,
+                content,
             } => GlyphType::Xwidget {
                 xwidget_id,
                 webview_id,
                 width_cols,
+                content,
             },
             DisplayMediaReplacementKind::Surface { surface_id } => GlyphType::Surface {
                 surface_id: surface_id as i32,

--- a/crates/neomacs-layout-engine/src/display_row/builder.rs
+++ b/crates/neomacs-layout-engine/src/display_row/builder.rs
@@ -16,6 +16,7 @@ use crate::display_row::append_context::{
 };
 #[cfg(test)]
 use crate::display_source::{DisplayItemSource, DisplaySourceContext};
+use crate::display_source_overflow::DisplayMediaReplacementOverflowAction;
 use crate::glyph_row_writer;
 #[cfg(test)]
 use crate::output::builder::DisplayOutputBuilder;
@@ -1697,6 +1698,31 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
                 let slot_start = self.position;
                 let slot_source = span.start.clone();
                 let before_len = self.area_len();
+                // GNU crops a wide media glyph when it produces it, before
+                // `display_line` measures the row; see
+                // `DisplayMediaReplacementOverflowAction`.  Body text only:
+                // margin lanes keep their own structural clip below.
+                let kind = match kind {
+                    DisplayItemKind::MediaReplacement(media)
+                        if self.writer.overflow_policy()
+                            == DisplayRowOverflowPolicy::RejectOverflowingGlyph =>
+                    {
+                        let action = DisplayMediaReplacementOverflowAction::for_replacement(
+                            media.width,
+                            self.position.x_px(),
+                            self.max_x_px,
+                            before_len == 0,
+                        );
+                        DisplayItemKind::MediaReplacement(match action {
+                            DisplayMediaReplacementOverflowAction::CropToVisibleWidth {
+                                visible_width_px,
+                            } => media.cropped_to_visible_width(visible_width_px),
+                            DisplayMediaReplacementOverflowAction::Fits
+                            | DisplayMediaReplacementOverflowAction::LeaveWhole => media,
+                        })
+                    }
+                    kind => kind,
+                };
                 let checkpoint = DisplayRowGlyphCheckpoint::capture(self.writer.row);
                 let mut written = self.writer.push_item(
                     DisplayItem::new(span, face, kind)

--- a/crates/neomacs-layout-engine/src/display_row/builder.rs
+++ b/crates/neomacs-layout-engine/src/display_row/builder.rs
@@ -1741,6 +1741,15 @@ impl<'layout, 'row, 'measurer> DisplayRowProgressWriter<'layout, 'row, 'measurer
                                     self.position.x_px(),
                                     self.max_x_px,
                                 );
+                                let Ok(extent) = extent else {
+                                    return DisplayRowAppendProgress::new(
+                                        start,
+                                        self.position,
+                                        metrics,
+                                        DisplayRowAppendStatus::Clipped,
+                                        slots,
+                                    );
+                                };
                                 let action = DisplayXwidgetOverflowAction::for_xwidget(
                                     xwidget.layout_advance(),
                                     extent,

--- a/crates/neomacs-layout-engine/src/display_row/builder_test.rs
+++ b/crates/neomacs-layout-engine/src/display_row/builder_test.rs
@@ -1526,6 +1526,7 @@ fn source_position_progress_counts_complex_run_growth_before_tab() {
             &mut glyph_advances,
             DisplayRowPosition::new(0.0, 0),
             1280.0,
+            crate::display_row::geometry::DisplayRowTextAreaOrigin::row_local(),
             GlyphArea::Text,
             DisplayRowAppendStartPolicy::SourcePosition,
         );

--- a/crates/neomacs-layout-engine/src/display_row/geometry.rs
+++ b/crates/neomacs-layout-engine/src/display_row/geometry.rs
@@ -31,6 +31,36 @@ impl DisplayRowMaxX {
     }
 }
 
+/// Where the window's text area starts, in the frame-absolute pixels the row
+/// writer positions glyphs in.
+///
+/// GNU measures `it->current_x` and `it->last_visible_x` from this edge
+/// (src/dispextern.h:2785-2791, emacs-31.0.90), so any rule ported from a
+/// `produce_*` function that compares against `last_visible_x` itself, not
+/// only against the difference of the two, has to subtract it first.  The
+/// line-number prefix lies inside the text area and is not subtracted.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct DisplayRowTextAreaOrigin {
+    x_px: f32,
+}
+
+impl DisplayRowTextAreaOrigin {
+    /// A row laid out in its own coordinates: the text area starts at 0.
+    /// Chrome rows, mock frames and unit tests build rows this way.
+    pub(crate) fn row_local() -> Self {
+        Self { x_px: 0.0 }
+    }
+
+    /// A row of a window whose text area starts at frame-absolute `x_px`.
+    pub(crate) fn at_frame_x(x_px: f32) -> Self {
+        Self { x_px }
+    }
+
+    pub(crate) fn window_local(self, frame_x_px: f32) -> f32 {
+        frame_x_px - self.x_px
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct DisplayRowGeometry {
     pub(crate) y: f32,

--- a/crates/neomacs-layout-engine/src/display_row/geometry.rs
+++ b/crates/neomacs-layout-engine/src/display_row/geometry.rs
@@ -9,6 +9,7 @@ use crate::window_output::{
     RowMetricsSnapshot,
 };
 use neomacs_display_protocol::frame_glyphs::GlyphRowRole;
+use neomacs_display_protocol::{GeometryError, LogicalPixels};
 
 /// Horizontal append limit for a display row.
 ///
@@ -41,23 +42,27 @@ impl DisplayRowMaxX {
 /// line-number prefix lies inside the text area and is not subtracted.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct DisplayRowTextAreaOrigin {
-    x_px: f32,
+    x_px: LogicalPixels,
 }
 
 impl DisplayRowTextAreaOrigin {
     /// A row laid out in its own coordinates: the text area starts at 0.
     /// Chrome rows, mock frames and unit tests build rows this way.
     pub(crate) fn row_local() -> Self {
-        Self { x_px: 0.0 }
+        Self {
+            x_px: LogicalPixels::default(),
+        }
     }
 
     /// A row of a window whose text area starts at frame-absolute `x_px`.
-    pub(crate) fn at_frame_x(x_px: f32) -> Self {
-        Self { x_px }
+    pub(crate) fn at_frame_x(x_px: f32) -> Result<Self, GeometryError> {
+        Ok(Self {
+            x_px: LogicalPixels::new(x_px)?,
+        })
     }
 
     pub(crate) fn window_local(self, frame_x_px: f32) -> f32 {
-        frame_x_px - self.x_px
+        frame_x_px - self.x_px.get()
     }
 }
 

--- a/crates/neomacs-layout-engine/src/display_row/mod.rs
+++ b/crates/neomacs-layout-engine/src/display_row/mod.rs
@@ -1165,6 +1165,7 @@ impl<'metrics> DisplayRowRenderer<'metrics> {
                             &mut glyph_measurer,
                             position,
                             render_bounds.max_x().to_f32(),
+                            render_bounds.text_area_origin(),
                             area,
                             append_start_policy,
                         );
@@ -1186,6 +1187,7 @@ impl<'metrics> DisplayRowRenderer<'metrics> {
                             &mut glyph_measurer,
                             position,
                             render_bounds.max_x().to_f32(),
+                            render_bounds.text_area_origin(),
                             area,
                             append_start_policy,
                         );

--- a/crates/neomacs-layout-engine/src/display_row/render_state.rs
+++ b/crates/neomacs-layout-engine/src/display_row/render_state.rs
@@ -6,7 +6,9 @@ use crate::display_row::builder::{
     apply_display_row_source_slot_bounds, merge_display_row_source_slot_bounds,
 };
 use crate::display_row::finalizer::{RowTrailingFaceFill, RowTrailingFaceFillResult};
-use crate::display_row::geometry::{DisplayRowGeometryState, DisplayRowMaxX};
+use crate::display_row::geometry::{
+    DisplayRowGeometryState, DisplayRowMaxX, DisplayRowTextAreaOrigin,
+};
 use crate::glyph_row_writer;
 use neomacs_display_protocol::face::Face;
 #[cfg(test)]
@@ -299,11 +301,33 @@ impl DisplayRowRenderIntoRowResult {
 pub(crate) struct DisplayRowRenderBounds {
     start: DisplayRowPosition,
     max_x: DisplayRowMaxX,
+    text_area_origin: DisplayRowTextAreaOrigin,
 }
 
 impl DisplayRowRenderBounds {
+    /// Bounds for a row laid out in its own coordinates (the text area
+    /// starts at 0): chrome rows, mock frames and unit tests.
     pub(crate) fn new(start: DisplayRowPosition, max_x: DisplayRowMaxX) -> Self {
-        Self { start, max_x }
+        Self {
+            start,
+            max_x,
+            text_area_origin: DisplayRowTextAreaOrigin::row_local(),
+        }
+    }
+
+    /// Bounds for a row of a window whose text area starts at a
+    /// frame-absolute x; the buffer text path uses this so window-local GNU
+    /// rules see window-local coordinates.
+    pub(crate) fn in_window_text_area(
+        start: DisplayRowPosition,
+        max_x: DisplayRowMaxX,
+        text_area_origin: DisplayRowTextAreaOrigin,
+    ) -> Self {
+        Self {
+            start,
+            max_x,
+            text_area_origin,
+        }
     }
 
     pub(crate) fn whole_row(width_px: f32) -> Self {
@@ -323,6 +347,10 @@ impl DisplayRowRenderBounds {
 
     pub(crate) fn max_x(self) -> DisplayRowMaxX {
         self.max_x
+    }
+
+    pub(crate) fn text_area_origin(self) -> DisplayRowTextAreaOrigin {
+        self.text_area_origin
     }
 }
 

--- a/crates/neomacs-layout-engine/src/display_row/test.rs
+++ b/crates/neomacs-layout-engine/src/display_row/test.rs
@@ -3995,44 +3995,40 @@ fn install_measured_display_row_clips_window_chrome_media_to_measured_row() {
             neomacs_display_protocol::frame_glyphs::FrameGlyph::Xwidget {
                 window_id,
                 row_role,
-                clip_rect,
                 slot_id,
                 xwidget_id,
-                x,
-                y,
-                width,
-                height,
+                presentation,
                 ..
-            } => Some((
-                *window_id,
-                *row_role,
-                *clip_rect,
-                *slot_id,
-                *xwidget_id,
-                *x,
-                *y,
-                *width,
-                *height,
-            )),
+            } => Some((*window_id, *row_role, *slot_id, *xwidget_id, *presentation)),
             _ => None,
         })
         .expect("xwidget materialized from row glyph");
     assert_eq!(xwidget.0.get(), 77);
     assert_eq!(xwidget.1, GlyphRowRole::TabLine);
-    assert_eq!(xwidget.2, Some(row_bounds));
     assert_eq!(
-        xwidget.3,
+        xwidget.2,
         Some(neomacs_display_protocol::frame_glyphs::DisplaySlotId {
             window_id: neomacs_display_protocol::types::DisplayWindowId::new(77),
             row: 0,
             col: 0,
         })
     );
-    assert_eq!(xwidget.4.get(), 1234);
-    assert_eq!(xwidget.5, 0.0);
-    assert_eq!(xwidget.6, 4.0);
-    assert_eq!(xwidget.7, 96.0);
-    assert_eq!(xwidget.8, 54.0);
+    assert_eq!(xwidget.3.get(), 1234);
+    let slot = xwidget.4.layout_slot_rect();
+    assert_eq!(
+        (slot.x(), slot.y(), slot.width(), slot.height()),
+        (0.0, 4.0, 96.0, 54.0)
+    );
+    let clip = xwidget.4.clip_rect().expect("tab-line row clip");
+    assert_eq!(
+        (clip.x(), clip.y(), clip.width(), clip.height()),
+        (
+            row_bounds.x,
+            row_bounds.y,
+            row_bounds.width,
+            row_bounds.height
+        )
+    );
 }
 
 #[test]

--- a/crates/neomacs-layout-engine/src/display_row/test.rs
+++ b/crates/neomacs-layout-engine/src/display_row/test.rs
@@ -3951,6 +3951,8 @@ fn install_measured_display_row_clips_window_chrome_media_to_measured_row() {
         xwidget_id: neomacs_display_protocol::XwidgetId::new(1234),
         webview_id: neomacs_display_protocol::WebViewId::new(5678),
         width_cols: 12,
+        content: neomacs_display_protocol::XwidgetContentExtent::new(96.0, 54.0)
+            .expect("content extent"),
     };
     row.glyphs[GlyphArea::Text.index()].push(xwidget);
     let rendered = RenderedDisplayRow::new(

--- a/crates/neomacs-layout-engine/src/display_source_overflow.rs
+++ b/crates/neomacs-layout-engine/src/display_source_overflow.rs
@@ -74,3 +74,55 @@ impl DisplaySourceSpecialCharOverflowAction {
         }
     }
 }
+
+/// What GNU does with a media replacement -- an image, video, xwidget or
+/// surface glyph -- that would extend past the right edge of the text area.
+///
+/// `produce_image_glyph` (src/xdisp.c:32582-32598) and
+/// `produce_xwidget_glyph` (:32700-32704) decide this at production time,
+/// before `display_line` measures the glyph:
+///
+/// ```c
+///   crop = it->pixel_width - (it->last_visible_x - it->current_x);
+///   if (crop > 0 && (it->hpos == 0 || it->pixel_width > it->last_visible_x / 4))
+///     it->pixel_width -= crop;
+/// ```
+///
+/// A glyph that starts the row, or is wider than a quarter of the visible
+/// width, is cropped so it fits exactly and is shown partially rather than
+/// not at all -- `display_line` then keeps it (:26254-26310) and the row's
+/// clip does the rest.  A narrower glyph in the middle of a row is left
+/// whole for `display_line`'s continuation or truncation handling.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum DisplayMediaReplacementOverflowAction {
+    Fits,
+    CropToVisibleWidth {
+        visible_width_px: f32,
+    },
+    /// GNU leaves the glyph whole; the row's overflow policy decides.
+    LeaveWhole,
+}
+
+impl DisplayMediaReplacementOverflowAction {
+    pub(crate) fn for_replacement(
+        width_px: f32,
+        x_px: f32,
+        right_edge_px: f32,
+        at_row_start: bool,
+    ) -> Self {
+        let visible_width_px = right_edge_px - x_px;
+        let crop = width_px - visible_width_px;
+        if crop <= 0.0 {
+            return Self::Fits;
+        }
+        if visible_width_px > 0.0 && (at_row_start || width_px > right_edge_px / 4.0) {
+            Self::CropToVisibleWidth { visible_width_px }
+        } else {
+            Self::LeaveWhole
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "display_source_overflow_test.rs"]
+mod tests;

--- a/crates/neomacs-layout-engine/src/display_source_overflow.rs
+++ b/crates/neomacs-layout-engine/src/display_source_overflow.rs
@@ -139,15 +139,6 @@ impl WindowLocalRowExtent {
 ///
 /// What this port does NOT do, relative to the GNU function:
 ///
-/// - **`LeaveWhole` drops the glyph.** In GNU a narrow mid-row widget that
-///   does not fit is continued onto the next row or truncated by
-///   `display_line` (the test at src/xdisp.c:26221-26224, the branch that
-///   restores the position and emits the continuation glyph at
-///   :26416-26434); this row builder has no
-///   remainder for a media replacement, so the row's
-///   `RejectOverflowingGlyph` policy consumes the covered text and emits
-///   nothing.  The pre-existing behavior, narrowed by this rule to widgets
-///   GNU would also leave whole.
 /// - **No room at all.** With `hpos == 0` GNU still crops when nothing of
 ///   the row is left, producing a glyph of zero or negative width
 ///   (`clip_to_bounds (-1, …)`, :32600); here `visible_width_px > 0.0`

--- a/crates/neomacs-layout-engine/src/display_source_overflow.rs
+++ b/crates/neomacs-layout-engine/src/display_source_overflow.rs
@@ -1,3 +1,4 @@
+use crate::display_row::geometry::DisplayRowTextAreaOrigin;
 use crate::display_row::transition::{DisplayRowOverflowTransitionPlan, VisualWrapBreak};
 use crate::display_row::walk_state::{
     DisplayRowTextOverflowDecision, SpecialTextRowOverflowDecision, TextRowTransitionStatePolicy,
@@ -75,48 +76,94 @@ impl DisplaySourceSpecialCharOverflowAction {
     }
 }
 
-/// What GNU does with a media replacement -- an image, video, xwidget or
-/// surface glyph -- that would extend past the right edge of the text area.
+/// GNU `it->current_x` and `it->last_visible_x` for one `produce_*` call.
 ///
-/// `produce_image_glyph` (src/xdisp.c:32582-32598) and
-/// `produce_xwidget_glyph` (:32700-32704) decide this at production time,
-/// before `display_line` measures the glyph:
+/// Both are window-local: pixels from the left edge of the window's text
+/// area, not from the frame's (src/dispextern.h:2785-2791, emacs-31.0.90:
+/// "last_visible_x == pixel width of W + first_visible_x").  The row writer
+/// keeps frame-absolute positions, so the conversion happens here, once,
+/// through [`DisplayRowTextAreaOrigin`]; a policy that compared against a
+/// frame-absolute edge would be wrong in every window but the leftmost.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct WindowLocalRowExtent {
+    current_x_px: f32,
+    last_visible_x_px: f32,
+}
+
+impl WindowLocalRowExtent {
+    pub(crate) fn from_frame_coordinates(
+        origin: DisplayRowTextAreaOrigin,
+        x_px: f32,
+        right_edge_px: f32,
+    ) -> Self {
+        Self {
+            current_x_px: origin.window_local(x_px),
+            last_visible_x_px: origin.window_local(right_edge_px),
+        }
+    }
+
+    pub(crate) fn current_x_px(self) -> f32 {
+        self.current_x_px
+    }
+
+    pub(crate) fn last_visible_x_px(self) -> f32 {
+        self.last_visible_x_px
+    }
+
+    /// `it->last_visible_x - it->current_x`: how much of the row is left.
+    pub(crate) fn remaining_px(self) -> f32 {
+        self.last_visible_x_px - self.current_x_px
+    }
+}
+
+/// What GNU does with an xwidget glyph that would extend past the right
+/// edge of the text area.
+///
+/// `produce_xwidget_glyph` (src/xdisp.c:32575-32579, emacs-31.0.90) decides
+/// this at production time, before `display_line` measures the glyph:
 ///
 /// ```c
+///   /* Automatically crop wide image glyphs at right edge so we can
+///      draw the cursor on same display row.  */
 ///   crop = it->pixel_width - (it->last_visible_x - it->current_x);
 ///   if (crop > 0 && (it->hpos == 0 || it->pixel_width > it->last_visible_x / 4))
 ///     it->pixel_width -= crop;
 /// ```
 ///
-/// A glyph that starts the row, or is wider than a quarter of the visible
-/// width, is cropped so it fits exactly and is shown partially rather than
-/// not at all -- `display_line` then keeps it (:26254-26310) and the row's
-/// clip does the rest.  A narrower glyph in the middle of a row is left
-/// whole for `display_line`'s continuation or truncation handling.
+/// A glyph that starts the row, or is wider than a quarter of the window's
+/// visible width, has its layout advance cropped so it fits exactly and is
+/// shown partially rather than not at all -- `display_line` then keeps it
+/// and `x_draw_xwidget_glyph_string` clips the widget, whose own size is
+/// untouched (src/xwidget.c:2841-2847).  A narrower glyph in the middle of a
+/// row is left whole for `display_line`'s continuation or truncation
+/// handling.
+///
+/// This is the xwidget rule only.  `produce_image_glyph` has its own
+/// (src/xdisp.c:32457-32473), which also weighs word wrap, the line-number
+/// prefix and the frame's column width, and it is not ported here.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) enum DisplayMediaReplacementOverflowAction {
+pub(crate) enum DisplayXwidgetOverflowAction {
     Fits,
-    CropToVisibleWidth {
+    CropAdvanceToVisibleWidth {
         visible_width_px: f32,
     },
     /// GNU leaves the glyph whole; the row's overflow policy decides.
     LeaveWhole,
 }
 
-impl DisplayMediaReplacementOverflowAction {
-    pub(crate) fn for_replacement(
+impl DisplayXwidgetOverflowAction {
+    pub(crate) fn for_xwidget(
         width_px: f32,
-        x_px: f32,
-        right_edge_px: f32,
+        extent: WindowLocalRowExtent,
         at_row_start: bool,
     ) -> Self {
-        let visible_width_px = right_edge_px - x_px;
+        let visible_width_px = extent.remaining_px();
         let crop = width_px - visible_width_px;
         if crop <= 0.0 {
             return Self::Fits;
         }
-        if visible_width_px > 0.0 && (at_row_start || width_px > right_edge_px / 4.0) {
-            Self::CropToVisibleWidth { visible_width_px }
+        if visible_width_px > 0.0 && (at_row_start || width_px > extent.last_visible_x_px() / 4.0) {
+            Self::CropAdvanceToVisibleWidth { visible_width_px }
         } else {
             Self::LeaveWhole
         }

--- a/crates/neomacs-layout-engine/src/display_source_overflow.rs
+++ b/crates/neomacs-layout-engine/src/display_source_overflow.rs
@@ -140,7 +140,9 @@ impl WindowLocalRowExtent {
 ///
 /// - **`LeaveWhole` drops the glyph.** In GNU a narrow mid-row widget that
 ///   does not fit is continued onto the next row or truncated by
-///   `display_line` (src/xdisp.c:26223-26310); this row builder has no
+///   `display_line` (the test at src/xdisp.c:26221-26224, the branch that
+///   restores the position and emits the continuation glyph at
+///   :26416-26434); this row builder has no
 ///   remainder for a media replacement, so the row's
 ///   `RejectOverflowingGlyph` policy consumes the covered text and emits
 ///   nothing.  The pre-existing behavior, narrowed by this rule to widgets
@@ -150,7 +152,7 @@ impl WindowLocalRowExtent {
 ///   (`clip_to_bounds (-1, …)`, :32600); here `visible_width_px > 0.0`
 ///   guards the crop and such a glyph is dropped instead.
 /// - **Box line widths.** GNU adds `box_vertical_line_width` to
-///   `it->pixel_width` before computing `crop` (:32556-32570); the width
+///   `it->pixel_width` before computing `crop` (:32557-32571); the width
 ///   passed here is the widget's, so a boxed widget's threshold and advance
 ///   are narrower than GNU's by the box.  Xwidgets have no positive-box
 ///   expansion in this port yet (only images do).
@@ -158,7 +160,22 @@ impl WindowLocalRowExtent {
 ///   carry `first_visible_x` (src/xdisp.c:3507); this port scrolls by
 ///   skipping columns, so [`WindowLocalRowExtent`] is hscroll-free.  The
 ///   remaining width agrees; the quarter-width threshold is smaller than
-///   GNU's by a quarter of the scrolled-off pixels.
+///   GNU's by a quarter of the scrolled-off pixels.  A widget that
+///   straddles `first_visible_x` is produced by GNU and kept with a
+///   negative `row->x`; here the skip phase consumes the character that
+///   carries it as a plain glyph (`consume_step_char` in
+///   `buffer_source/row_lifecycle.rs`), so it never reaches this rule and
+///   is not shown at all.
+/// - **`it->hpos == 0` under horizontal scrolling.** GNU's `hpos` counts
+///   only glyphs past `first_visible_x` (`maybe_produce_line_number`,
+///   :25705-25706); `at_row_start` here means "nothing written before this
+///   glyph", which agrees only because the skip phase writes nothing before
+///   the first visible glyph.
+/// - **Ascent and descent.** The same GNU function splits the widget's
+///   height evenly (`it->ascent = it->descent = xw->height/2`,
+///   :32546-32547); this port gives a media replacement a full-height
+///   ascent (`display_replacement_ascent`).  Not a crop matter, listed
+///   because it is in the function this rule is taken from.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum DisplayXwidgetOverflowAction {
     Fits,

--- a/crates/neomacs-layout-engine/src/display_source_overflow.rs
+++ b/crates/neomacs-layout-engine/src/display_source_overflow.rs
@@ -4,7 +4,7 @@ use crate::display_row::walk_state::{
     DisplayRowTextOverflowDecision, SpecialTextRowOverflowDecision, TextRowTransitionStatePolicy,
     WordWrapBreakCandidate,
 };
-use neomacs_display_protocol::{Px, XwidgetLayoutAdvance};
+use neomacs_display_protocol::{GeometryError, LogicalPixels, Px, XwidgetLayoutAdvance};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum DisplaySourceTextCharOverflowAction {
@@ -87,8 +87,8 @@ impl DisplaySourceSpecialCharOverflowAction {
 /// frame-absolute edge would be wrong in every window but the leftmost.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct WindowLocalRowExtent {
-    current_x_px: f32,
-    last_visible_x_px: f32,
+    current_x_px: LogicalPixels,
+    last_visible_x_px: LogicalPixels,
 }
 
 impl WindowLocalRowExtent {
@@ -96,20 +96,29 @@ impl WindowLocalRowExtent {
         origin: DisplayRowTextAreaOrigin,
         x_px: f32,
         right_edge_px: f32,
-    ) -> Self {
-        Self {
-            current_x_px: origin.window_local(x_px),
-            last_visible_x_px: origin.window_local(right_edge_px),
+    ) -> Result<Self, GeometryError> {
+        let current_x_px = LogicalPixels::new(origin.window_local(x_px))?;
+        let last_visible_x_px = LogicalPixels::new(origin.window_local(right_edge_px))?;
+        if current_x_px.get() < 0.0 || current_x_px.get() > last_visible_x_px.get() {
+            return Err(GeometryError::InvalidGeometry);
         }
+        Ok(Self {
+            current_x_px,
+            last_visible_x_px,
+        })
     }
 
     pub(crate) fn last_visible_x_px(self) -> f32 {
-        self.last_visible_x_px
+        self.last_visible_x_px.get()
     }
 
     /// `it->last_visible_x - it->current_x`: how much of the row is left.
     pub(crate) fn remaining_px(self) -> f32 {
-        self.last_visible_x_px - self.current_x_px
+        self.last_visible_x_px.get() - self.current_x_px.get()
+    }
+
+    fn remaining_advance(self) -> Option<XwidgetLayoutAdvance> {
+        XwidgetLayoutAdvance::new(Px(self.remaining_px()))
     }
 }
 
@@ -190,9 +199,9 @@ impl DisplayXwidgetOverflowAction {
         if crop <= 0.0 {
             return Self::Fits;
         }
-        if visible_width_px > 0.0 && (at_row_start || width_px > extent.last_visible_x_px() / 4.0) {
-            let advance = XwidgetLayoutAdvance::new(Px(visible_width_px))
-                .expect("a positive finite row remainder is a valid xwidget advance");
+        if (at_row_start || width_px > extent.last_visible_x_px() / 4.0)
+            && let Some(advance) = extent.remaining_advance()
+        {
             Self::CropAdvanceToVisibleWidth { advance }
         } else {
             Self::LeaveWhole

--- a/crates/neomacs-layout-engine/src/display_source_overflow.rs
+++ b/crates/neomacs-layout-engine/src/display_source_overflow.rs
@@ -102,10 +102,6 @@ impl WindowLocalRowExtent {
         }
     }
 
-    pub(crate) fn current_x_px(self) -> f32 {
-        self.current_x_px
-    }
-
     pub(crate) fn last_visible_x_px(self) -> f32 {
         self.last_visible_x_px
     }
@@ -134,13 +130,35 @@ impl WindowLocalRowExtent {
 /// visible width, has its layout advance cropped so it fits exactly and is
 /// shown partially rather than not at all -- `display_line` then keeps it
 /// and `x_draw_xwidget_glyph_string` clips the widget, whose own size is
-/// untouched (src/xwidget.c:2841-2847).  A narrower glyph in the middle of a
-/// row is left whole for `display_line`'s continuation or truncation
-/// handling.
+/// untouched (src/xwidget.c:2841-2849).
 ///
 /// This is the xwidget rule only.  `produce_image_glyph` has its own
 /// (src/xdisp.c:32457-32473), which also weighs word wrap, the line-number
 /// prefix and the frame's column width, and it is not ported here.
+///
+/// What this port does NOT do, relative to the GNU function:
+///
+/// - **`LeaveWhole` drops the glyph.** In GNU a narrow mid-row widget that
+///   does not fit is continued onto the next row or truncated by
+///   `display_line` (src/xdisp.c:26223-26310); this row builder has no
+///   remainder for a media replacement, so the row's
+///   `RejectOverflowingGlyph` policy consumes the covered text and emits
+///   nothing.  The pre-existing behavior, narrowed by this rule to widgets
+///   GNU would also leave whole.
+/// - **No room at all.** With `hpos == 0` GNU still crops when nothing of
+///   the row is left, producing a glyph of zero or negative width
+///   (`clip_to_bounds (-1, …)`, :32600); here `visible_width_px > 0.0`
+///   guards the crop and such a glyph is dropped instead.
+/// - **Box line widths.** GNU adds `box_vertical_line_width` to
+///   `it->pixel_width` before computing `crop` (:32556-32570); the width
+///   passed here is the widget's, so a boxed widget's threshold and advance
+///   are narrower than GNU's by the box.  Xwidgets have no positive-box
+///   expansion in this port yet (only images do).
+/// - **Horizontal scrolling.** GNU's `current_x` and `last_visible_x` both
+///   carry `first_visible_x` (src/xdisp.c:3507); this port scrolls by
+///   skipping columns, so [`WindowLocalRowExtent`] is hscroll-free.  The
+///   remaining width agrees; the quarter-width threshold is smaller than
+///   GNU's by a quarter of the scrolled-off pixels.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum DisplayXwidgetOverflowAction {
     Fits,

--- a/crates/neomacs-layout-engine/src/display_source_overflow.rs
+++ b/crates/neomacs-layout-engine/src/display_source_overflow.rs
@@ -4,6 +4,7 @@ use crate::display_row::walk_state::{
     DisplayRowTextOverflowDecision, SpecialTextRowOverflowDecision, TextRowTransitionStatePolicy,
     WordWrapBreakCandidate,
 };
+use neomacs_display_protocol::{Px, XwidgetLayoutAdvance};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum DisplaySourceTextCharOverflowAction {
@@ -180,7 +181,7 @@ impl WindowLocalRowExtent {
 pub(crate) enum DisplayXwidgetOverflowAction {
     Fits,
     CropAdvanceToVisibleWidth {
-        visible_width_px: f32,
+        advance: XwidgetLayoutAdvance,
     },
     /// GNU leaves the glyph whole; the row's overflow policy decides.
     LeaveWhole,
@@ -188,17 +189,20 @@ pub(crate) enum DisplayXwidgetOverflowAction {
 
 impl DisplayXwidgetOverflowAction {
     pub(crate) fn for_xwidget(
-        width_px: f32,
+        layout_advance: XwidgetLayoutAdvance,
         extent: WindowLocalRowExtent,
         at_row_start: bool,
     ) -> Self {
+        let width_px = layout_advance.px().get();
         let visible_width_px = extent.remaining_px();
         let crop = width_px - visible_width_px;
         if crop <= 0.0 {
             return Self::Fits;
         }
         if visible_width_px > 0.0 && (at_row_start || width_px > extent.last_visible_x_px() / 4.0) {
-            Self::CropAdvanceToVisibleWidth { visible_width_px }
+            let advance = XwidgetLayoutAdvance::new(Px(visible_width_px))
+                .expect("a positive finite row remainder is a valid xwidget advance");
+            Self::CropAdvanceToVisibleWidth { advance }
         } else {
             Self::LeaveWhole
         }

--- a/crates/neomacs-layout-engine/src/display_source_overflow_test.rs
+++ b/crates/neomacs-layout-engine/src/display_source_overflow_test.rs
@@ -1,43 +1,100 @@
-use super::DisplayMediaReplacementOverflowAction;
+use super::{DisplayXwidgetOverflowAction, WindowLocalRowExtent};
+use crate::display_row::geometry::DisplayRowTextAreaOrigin;
 
-/// GNU `produce_xwidget_glyph` (src/xdisp.c:32700-32704): the crop applies
-/// to a glyph that starts the row, or one wider than a quarter of the
-/// visible width; anything narrower mid-row is left for `display_line`.
+/// A window at the frame's left edge: window-local and frame-absolute
+/// coordinates coincide, so this pins the rule itself.
+fn leftmost_window(x_px: f32, right_edge_px: f32) -> WindowLocalRowExtent {
+    WindowLocalRowExtent::from_frame_coordinates(
+        DisplayRowTextAreaOrigin::row_local(),
+        x_px,
+        right_edge_px,
+    )
+}
+
+/// `produce_xwidget_glyph`, src/xdisp.c:32577-32579 (emacs-31.0.90), with
+/// GNU's numbers: a 320 px TTY frame with one reserved column has
+/// `last_visible_x` 312, and the widget after a one-cell "a" sits at 8.
 #[test]
-fn media_wider_than_the_remaining_row_is_cropped_by_gnus_rule() {
-    // Fits: no crop needed.
+fn an_xwidget_wider_than_the_remaining_row_is_cropped_by_gnus_rule() {
     assert_eq!(
-        DisplayMediaReplacementOverflowAction::for_replacement(100.0, 8.0, 312.0, false),
-        DisplayMediaReplacementOverflowAction::Fits
+        DisplayXwidgetOverflowAction::for_xwidget(100.0, leftmost_window(8.0, 312.0), false),
+        DisplayXwidgetOverflowAction::Fits
     );
     assert_eq!(
-        DisplayMediaReplacementOverflowAction::for_replacement(304.0, 8.0, 312.0, false),
-        DisplayMediaReplacementOverflowAction::Fits,
-        "exactly filling the row is a fit"
+        DisplayXwidgetOverflowAction::for_xwidget(304.0, leftmost_window(8.0, 312.0), false),
+        DisplayXwidgetOverflowAction::Fits,
+        "crop == 0 is not a crop"
     );
-    // Wider than a quarter of the visible width: cropped to what is left.
+    // Mid-row, wider than a quarter of the visible width: crop = 600 - 304.
     assert_eq!(
-        DisplayMediaReplacementOverflowAction::for_replacement(600.0, 8.0, 312.0, false),
-        DisplayMediaReplacementOverflowAction::CropToVisibleWidth {
+        DisplayXwidgetOverflowAction::for_xwidget(600.0, leftmost_window(8.0, 312.0), false),
+        DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
             visible_width_px: 304.0
         }
     );
-    // Starts the row: cropped however narrow it is.
+    // At hpos 0 the width does not matter.
     assert_eq!(
-        DisplayMediaReplacementOverflowAction::for_replacement(40.0, 300.0, 312.0, true),
-        DisplayMediaReplacementOverflowAction::CropToVisibleWidth {
+        DisplayXwidgetOverflowAction::for_xwidget(40.0, leftmost_window(300.0, 312.0), true),
+        DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
             visible_width_px: 12.0
         }
     );
-    // Narrow and mid-row: GNU does not crop (`display_line` continues the
-    // line instead).
+    // Narrow (40 <= 312 / 4) and mid-row: GNU leaves it whole.
     assert_eq!(
-        DisplayMediaReplacementOverflowAction::for_replacement(40.0, 300.0, 312.0, false),
-        DisplayMediaReplacementOverflowAction::LeaveWhole
+        DisplayXwidgetOverflowAction::for_xwidget(40.0, leftmost_window(300.0, 312.0), false),
+        DisplayXwidgetOverflowAction::LeaveWhole
     );
-    // Nothing visible at all: nothing to crop to.
+    // Nothing of the row is left; a zero-width crop would produce no glyph.
     assert_eq!(
-        DisplayMediaReplacementOverflowAction::for_replacement(600.0, 312.0, 312.0, true),
-        DisplayMediaReplacementOverflowAction::LeaveWhole
+        DisplayXwidgetOverflowAction::for_xwidget(600.0, leftmost_window(312.0, 312.0), true),
+        DisplayXwidgetOverflowAction::LeaveWhole
+    );
+}
+
+/// GNU's quarter-width predicate compares against `it->last_visible_x`,
+/// which is window-local (src/dispextern.h:2785-2791).  In a right-hand
+/// split the frame-absolute right edge is about twice the window's width,
+/// so comparing against it would leave a 300 px widget whole (300 <= 1592/4)
+/// where GNU crops it (300 > 792/4).
+#[test]
+fn the_quarter_width_rule_uses_the_windows_own_width_in_a_right_hand_split() {
+    // Right window of a 1600 px frame: text area at frame x 800, one
+    // reserved column, so `last_visible_x` is 792 window-local; the widget
+    // follows 70 cells of text and sits at window-local 560.
+    let right_window = WindowLocalRowExtent::from_frame_coordinates(
+        DisplayRowTextAreaOrigin::at_frame_x(800.0),
+        1360.0,
+        1592.0,
+    );
+    assert_eq!(right_window.current_x_px(), 560.0);
+    assert_eq!(right_window.last_visible_x_px(), 792.0);
+    assert_eq!(right_window.remaining_px(), 232.0);
+
+    assert_eq!(
+        DisplayXwidgetOverflowAction::for_xwidget(300.0, right_window, false),
+        DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
+            visible_width_px: 232.0
+        }
+    );
+    // The same widget at the same window-local place in the leftmost window
+    // gets the same answer: the rule does not know where the window is.
+    assert_eq!(
+        DisplayXwidgetOverflowAction::for_xwidget(300.0, leftmost_window(560.0, 792.0), false),
+        DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
+            visible_width_px: 232.0
+        }
+    );
+}
+
+/// The line-number prefix is inside GNU's text area (`it->current_x` counts
+/// it), so the origin is the text area's left edge, not the content's.
+#[test]
+fn the_text_area_origin_is_not_moved_by_a_line_number_prefix() {
+    let origin = DisplayRowTextAreaOrigin::at_frame_x(100.0);
+    // content_x = 100 + 32 px of line numbers; the pen is 8 px past that.
+    assert_eq!(origin.window_local(140.0), 40.0);
+    assert_eq!(
+        DisplayRowTextAreaOrigin::row_local().window_local(140.0),
+        140.0
     );
 }

--- a/crates/neomacs-layout-engine/src/display_source_overflow_test.rs
+++ b/crates/neomacs-layout-engine/src/display_source_overflow_test.rs
@@ -66,9 +66,8 @@ fn the_quarter_width_rule_uses_the_windows_own_width_in_a_right_hand_split() {
         1360.0,
         1592.0,
     );
-    assert_eq!(right_window.current_x_px(), 560.0);
     assert_eq!(right_window.last_visible_x_px(), 792.0);
-    assert_eq!(right_window.remaining_px(), 232.0);
+    assert_eq!(right_window.remaining_px(), 232.0, "current_x is 560");
 
     assert_eq!(
         DisplayXwidgetOverflowAction::for_xwidget(300.0, right_window, false),

--- a/crates/neomacs-layout-engine/src/display_source_overflow_test.rs
+++ b/crates/neomacs-layout-engine/src/display_source_overflow_test.rs
@@ -1,5 +1,10 @@
 use super::{DisplayXwidgetOverflowAction, WindowLocalRowExtent};
 use crate::display_row::geometry::DisplayRowTextAreaOrigin;
+use neomacs_display_protocol::{Px, XwidgetLayoutAdvance};
+
+fn advance(px: f32) -> XwidgetLayoutAdvance {
+    XwidgetLayoutAdvance::new(Px(px)).expect("positive finite layout advance")
+}
 
 /// A window at the frame's left edge: window-local and frame-absolute
 /// coordinates coincide, so this pins the rule itself.
@@ -17,36 +22,60 @@ fn leftmost_window(x_px: f32, right_edge_px: f32) -> WindowLocalRowExtent {
 #[test]
 fn an_xwidget_wider_than_the_remaining_row_is_cropped_by_gnus_rule() {
     assert_eq!(
-        DisplayXwidgetOverflowAction::for_xwidget(100.0, leftmost_window(8.0, 312.0), false),
+        DisplayXwidgetOverflowAction::for_xwidget(
+            advance(100.0),
+            leftmost_window(8.0, 312.0),
+            false,
+        ),
         DisplayXwidgetOverflowAction::Fits
     );
     assert_eq!(
-        DisplayXwidgetOverflowAction::for_xwidget(304.0, leftmost_window(8.0, 312.0), false),
+        DisplayXwidgetOverflowAction::for_xwidget(
+            advance(304.0),
+            leftmost_window(8.0, 312.0),
+            false,
+        ),
         DisplayXwidgetOverflowAction::Fits,
         "crop == 0 is not a crop"
     );
     // Mid-row, wider than a quarter of the visible width: crop = 600 - 304.
     assert_eq!(
-        DisplayXwidgetOverflowAction::for_xwidget(600.0, leftmost_window(8.0, 312.0), false),
+        DisplayXwidgetOverflowAction::for_xwidget(
+            advance(600.0),
+            leftmost_window(8.0, 312.0),
+            false,
+        ),
         DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
-            visible_width_px: 304.0
+            advance: advance(304.0)
         }
     );
     // At hpos 0 the width does not matter.
     assert_eq!(
-        DisplayXwidgetOverflowAction::for_xwidget(40.0, leftmost_window(300.0, 312.0), true),
+        DisplayXwidgetOverflowAction::for_xwidget(
+            advance(40.0),
+            leftmost_window(300.0, 312.0),
+            true,
+        ),
         DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
-            visible_width_px: 12.0
+            advance: advance(12.0)
         }
     );
     // Narrow (40 <= 312 / 4) and mid-row: GNU leaves it whole.
     assert_eq!(
-        DisplayXwidgetOverflowAction::for_xwidget(40.0, leftmost_window(300.0, 312.0), false),
+        DisplayXwidgetOverflowAction::for_xwidget(
+            advance(40.0),
+            leftmost_window(300.0, 312.0),
+            false,
+        ),
         DisplayXwidgetOverflowAction::LeaveWhole
     );
     // Nothing of the row is left; a zero-width crop would produce no glyph.
     assert_eq!(
-        DisplayXwidgetOverflowAction::for_xwidget(600.0, leftmost_window(312.0, 312.0), true),
+        DisplayXwidgetOverflowAction::for_xwidget(
+            advance(600.0),
+            leftmost_window(312.0, 312.0),
+            true,
+        ),
         DisplayXwidgetOverflowAction::LeaveWhole
     );
 }
@@ -70,17 +99,21 @@ fn the_quarter_width_rule_uses_the_windows_own_width_in_a_right_hand_split() {
     assert_eq!(right_window.remaining_px(), 232.0, "current_x is 560");
 
     assert_eq!(
-        DisplayXwidgetOverflowAction::for_xwidget(300.0, right_window, false),
+        DisplayXwidgetOverflowAction::for_xwidget(advance(300.0), right_window, false),
         DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
-            visible_width_px: 232.0
+            advance: advance(232.0)
         }
     );
     // The same widget at the same window-local place in the leftmost window
     // gets the same answer: the rule does not know where the window is.
     assert_eq!(
-        DisplayXwidgetOverflowAction::for_xwidget(300.0, leftmost_window(560.0, 792.0), false),
+        DisplayXwidgetOverflowAction::for_xwidget(
+            advance(300.0),
+            leftmost_window(560.0, 792.0),
+            false,
+        ),
         DisplayXwidgetOverflowAction::CropAdvanceToVisibleWidth {
-            visible_width_px: 232.0
+            advance: advance(232.0)
         }
     );
 }

--- a/crates/neomacs-layout-engine/src/display_source_overflow_test.rs
+++ b/crates/neomacs-layout-engine/src/display_source_overflow_test.rs
@@ -1,0 +1,43 @@
+use super::DisplayMediaReplacementOverflowAction;
+
+/// GNU `produce_xwidget_glyph` (src/xdisp.c:32700-32704): the crop applies
+/// to a glyph that starts the row, or one wider than a quarter of the
+/// visible width; anything narrower mid-row is left for `display_line`.
+#[test]
+fn media_wider_than_the_remaining_row_is_cropped_by_gnus_rule() {
+    // Fits: no crop needed.
+    assert_eq!(
+        DisplayMediaReplacementOverflowAction::for_replacement(100.0, 8.0, 312.0, false),
+        DisplayMediaReplacementOverflowAction::Fits
+    );
+    assert_eq!(
+        DisplayMediaReplacementOverflowAction::for_replacement(304.0, 8.0, 312.0, false),
+        DisplayMediaReplacementOverflowAction::Fits,
+        "exactly filling the row is a fit"
+    );
+    // Wider than a quarter of the visible width: cropped to what is left.
+    assert_eq!(
+        DisplayMediaReplacementOverflowAction::for_replacement(600.0, 8.0, 312.0, false),
+        DisplayMediaReplacementOverflowAction::CropToVisibleWidth {
+            visible_width_px: 304.0
+        }
+    );
+    // Starts the row: cropped however narrow it is.
+    assert_eq!(
+        DisplayMediaReplacementOverflowAction::for_replacement(40.0, 300.0, 312.0, true),
+        DisplayMediaReplacementOverflowAction::CropToVisibleWidth {
+            visible_width_px: 12.0
+        }
+    );
+    // Narrow and mid-row: GNU does not crop (`display_line` continues the
+    // line instead).
+    assert_eq!(
+        DisplayMediaReplacementOverflowAction::for_replacement(40.0, 300.0, 312.0, false),
+        DisplayMediaReplacementOverflowAction::LeaveWhole
+    );
+    // Nothing visible at all: nothing to crop to.
+    assert_eq!(
+        DisplayMediaReplacementOverflowAction::for_replacement(600.0, 312.0, 312.0, true),
+        DisplayMediaReplacementOverflowAction::LeaveWhole
+    );
+}

--- a/crates/neomacs-layout-engine/src/display_source_overflow_test.rs
+++ b/crates/neomacs-layout-engine/src/display_source_overflow_test.rs
@@ -14,6 +14,7 @@ fn leftmost_window(x_px: f32, right_edge_px: f32) -> WindowLocalRowExtent {
         x_px,
         right_edge_px,
     )
+    .expect("valid leftmost-window extent")
 }
 
 /// `produce_xwidget_glyph`, src/xdisp.c:32577-32579 (emacs-31.0.90), with
@@ -91,10 +92,11 @@ fn the_quarter_width_rule_uses_the_windows_own_width_in_a_right_hand_split() {
     // reserved column, so `last_visible_x` is 792 window-local; the widget
     // follows 70 cells of text and sits at window-local 560.
     let right_window = WindowLocalRowExtent::from_frame_coordinates(
-        DisplayRowTextAreaOrigin::at_frame_x(800.0),
+        DisplayRowTextAreaOrigin::at_frame_x(800.0).expect("finite text-area origin"),
         1360.0,
         1592.0,
-    );
+    )
+    .expect("valid right-window extent");
     assert_eq!(right_window.last_visible_x_px(), 792.0);
     assert_eq!(right_window.remaining_px(), 232.0, "current_x is 560");
 
@@ -122,11 +124,21 @@ fn the_quarter_width_rule_uses_the_windows_own_width_in_a_right_hand_split() {
 /// it), so the origin is the text area's left edge, not the content's.
 #[test]
 fn the_text_area_origin_is_not_moved_by_a_line_number_prefix() {
-    let origin = DisplayRowTextAreaOrigin::at_frame_x(100.0);
+    let origin = DisplayRowTextAreaOrigin::at_frame_x(100.0).expect("finite text-area origin");
     // content_x = 100 + 32 px of line numbers; the pen is 8 px past that.
     assert_eq!(origin.window_local(140.0), 40.0);
     assert_eq!(
         DisplayRowTextAreaOrigin::row_local().window_local(140.0),
         140.0
     );
+}
+
+#[test]
+fn row_extent_rejects_non_finite_and_inverted_frame_geometry() {
+    assert!(DisplayRowTextAreaOrigin::at_frame_x(f32::NAN).is_err());
+
+    let origin = DisplayRowTextAreaOrigin::at_frame_x(100.0).expect("finite text-area origin");
+    assert!(WindowLocalRowExtent::from_frame_coordinates(origin, f32::INFINITY, 180.0).is_err());
+    assert!(WindowLocalRowExtent::from_frame_coordinates(origin, 181.0, 180.0).is_err());
+    assert!(WindowLocalRowExtent::from_frame_coordinates(origin, 99.0, 180.0).is_err());
 }

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -14039,7 +14039,7 @@ fn inline_xwidget_glyph_in_frame(
     frame_height: u32,
     width: i32,
     height: i32,
-) -> Option<(f32, f32, f32, Option<neomacs_display_protocol::Rect>)> {
+) -> Option<InlineXwidgetGlyph> {
     let mut eval = Context::new();
     eval.set_display_host(Box::new(RecordingImageDisplayHost {
         requests: Arc::new(Mutex::new(Vec::new())),
@@ -14097,38 +14097,202 @@ fn inline_xwidget_glyph_in_frame(
                 x,
                 width,
                 height,
+                content,
                 clip_rect,
                 ..
-            } => Some((*x, *width, *height, *clip_rect)),
+            } => Some(InlineXwidgetGlyph {
+                x: *x,
+                width: *width,
+                height: *height,
+                content: *content,
+                clip_rect: *clip_rect,
+            }),
             _ => None,
         })
 }
 
-/// GNU `produce_xwidget_glyph` (src/xdisp.c:32659-32707) never declines to
-/// produce the glyph.  It crops a wide widget at the right edge of the text
-/// area -- `crop = pixel_width - (last_visible_x - current_x)`, applied when
-/// the glyph starts the row or is wider than a quarter of the visible width
-/// (:32704-32706) -- so the widget is shown partially, which is what
-/// `x_draw_xwidget_glyph_string`'s `clip_*` machinery exists for.  Issue 301:
-/// this port emitted nothing, and the window showed an empty background
+/// The three extents of a materialized xwidget glyph: the slot (`x`,
+/// `width`, `height`), the widget's own size (`content`), and the visible
+/// clip.
+#[derive(Clone, Copy, Debug)]
+struct InlineXwidgetGlyph {
+    x: f32,
+    width: f32,
+    height: f32,
+    content: neomacs_display_protocol::XwidgetContentExtent,
+    clip_rect: Option<neomacs_display_protocol::Rect>,
+}
+
+/// Lay out `prefix` + an xwidget + "b" in the right-hand window of a
+/// horizontally split frame and return that window's xwidget glyph.
+fn inline_xwidget_glyph_in_right_split(
+    frame_width: u32,
+    frame_height: u32,
+    prefix: &str,
+    width: i32,
+    height: i32,
+) -> Option<InlineXwidgetGlyph> {
+    let mut eval = Context::new();
+    eval.set_display_host(Box::new(RecordingImageDisplayHost {
+        requests: Arc::new(Mutex::new(Vec::new())),
+        video_requests: Arc::new(Mutex::new(Vec::new())),
+        webkit_requests: Arc::new(Mutex::new(Vec::new())),
+        surface_requests: Arc::new(Mutex::new(Vec::new())),
+    }));
+    let left_buf_id = eval
+        .buffer_manager()
+        .current_buffer()
+        .expect("current buffer")
+        .id();
+    let right_buf_id = eval.buffer_manager_mut().create_buffer("*right*");
+    let xwidget = Value::make_xwidget(
+        Value::symbol("webkit"),
+        Value::string("Title"),
+        Value::make_buffer(right_buf_id),
+        width,
+        height,
+        4322,
+        neomacs_display_protocol::WebViewId::new(8766),
+    );
+    let prefix_chars = prefix.chars().count();
+    {
+        let buf = eval
+            .buffer_manager_mut()
+            .get_mut(right_buf_id)
+            .expect("right buffer");
+        buf.insert(&format!("{prefix}Xb"));
+        buf.goto_emacs_byte_pos(neovm_core::buffer::EmacsBytePos::new(1));
+        buf.put_text_property(
+            prefix_chars + 1,
+            prefix_chars + 2,
+            Value::symbol("display"),
+            Value::list(vec![
+                Value::symbol("xwidget"),
+                Value::keyword("xwidget"),
+                xwidget,
+            ]),
+        );
+    }
+    let frame_id = eval.frame_manager_mut().create_frame(
+        "layout-oversized-xwidget-split",
+        frame_width,
+        frame_height,
+        left_buf_id,
+    );
+    let selected_window = eval
+        .frame_manager()
+        .get(frame_id)
+        .expect("frame")
+        .selected_window;
+    let right_window = eval
+        .frame_manager_mut()
+        .split_window(
+            frame_id,
+            selected_window,
+            neovm_core::window::SplitDirection::Horizontal,
+            right_buf_id,
+            None,
+            neovm_core::window::SplitPlacement::AfterTarget,
+        )
+        .expect("split window");
+    let mut engine = LayoutEngine::new();
+    engine.layout_frame_rust(&mut eval, frame_id);
+    let state = engine
+        .last_frame_display_state
+        .as_ref()
+        .expect("frame display state");
+    state
+        .materialize()
+        .glyphs
+        .iter()
+        .find_map(|glyph| match glyph {
+            FrameGlyph::Xwidget {
+                window_id,
+                x,
+                width,
+                height,
+                content,
+                clip_rect,
+                ..
+            } if window_id.get() == right_window.0 as i64 => Some(InlineXwidgetGlyph {
+                x: *x,
+                width: *width,
+                height: *height,
+                content: *content,
+                clip_rect: *clip_rect,
+            }),
+            _ => None,
+        })
+}
+
+/// GNU `produce_xwidget_glyph` (src/xdisp.c:32534-32620, emacs-31.0.90)
+/// never declines to produce the glyph.  It crops a wide widget's advance at
+/// the right edge of the text area -- `crop = pixel_width - (last_visible_x
+/// - current_x)`, applied when the glyph starts the row or is wider than a
+/// quarter of the visible width (:32577-32579) -- so the widget is shown
+/// partially, which is what `x_draw_xwidget_glyph_string`'s `clip_*`
+/// machinery exists for (src/xwidget.c:2841-2847).  Issue 301: this port
+/// emitted nothing, and the window showed an empty background
 /// indistinguishable from a page that failed to load.
 #[test]
 fn layout_frame_rust_crops_an_xwidget_wider_than_its_window_like_gnu() {
     let fits = inline_xwidget_glyph_in_frame(320, 120, 96, 40).expect("fitting xwidget glyph");
-    assert_eq!(fits.1, 96.0);
+    assert_eq!(fits.width, 96.0);
+    assert_eq!(fits.content.width_px(), 96.0);
 
-    let (x, width, height, _clip) = inline_xwidget_glyph_in_frame(320, 120, 600, 40)
+    let cropped = inline_xwidget_glyph_in_frame(320, 120, 600, 40)
         .expect("a wide xwidget is cropped, not dropped");
-    assert_eq!(height, 40.0);
+    assert_eq!(cropped.height, 40.0);
     assert_eq!(
-        x, fits.0,
+        cropped.x, fits.x,
         "cropping changes the width, not where the glyph starts"
     );
     // The test frame is a TTY frame: 8 px cells, no fringes, and one column
     // reserved at the right edge, so `last_visible_x` is 312 and the widget
     // after the one-cell "a" starts at 8: GNU's crop = 600 - (312 - 8).
-    assert_eq!(x, 8.0);
-    assert_eq!(width, 304.0, "GNU: pixel_width -= crop");
+    assert_eq!(cropped.x, 8.0, "{cropped:?}");
+    assert_eq!(
+        cropped.width, 304.0,
+        "GNU: pixel_width -= crop; {cropped:?}"
+    );
+    // The crop narrows the glyph, not the widget: the native view is still
+    // sized from `xww->width` and clipped to the text area.
+    assert_eq!(cropped.content.width_px(), 600.0);
+    assert_eq!(cropped.content.height_px(), 40.0);
+    let clip = cropped
+        .clip_rect
+        .expect("body rows carry the text-area clip");
+    assert!(
+        clip.x <= 8.0 && clip.x + clip.width >= 312.0,
+        "the clip is the window's text area: {clip:?}"
+    );
+}
+
+/// The quarter-width predicate is `pixel_width > last_visible_x / 4` with
+/// `last_visible_x` window-local (src/dispextern.h:2785-2791).  In the
+/// right-hand window of a 1600 px frame the frame-absolute edge is 1592, so
+/// a 300 px widget compared against that (300 <= 398) would be left whole
+/// and then rejected by the row; GNU compares against 792 and crops it.
+#[test]
+fn layout_frame_rust_crops_an_xwidget_in_a_right_hand_split_by_the_windows_width() {
+    let prefix = "a".repeat(70);
+    let glyph = inline_xwidget_glyph_in_right_split(1600, 120, &prefix, 300, 40)
+        .expect("the right window's xwidget is cropped, not dropped");
+    // Right window: 8 px cells, its text starts at frame x 808 (the column
+    // at 800 is the vertical border) and one column is reserved at the
+    // right edge, so `last_visible_x` is frame x 1592 and the widget after
+    // 70 cells sits at 1368: crop = 300 - (1592 - 1368).  Against the
+    // window's own width (1592 - 808 = 784, a quarter of which is 196) the
+    // 300 px widget is wide enough to crop; against the frame-absolute edge
+    // (1592 / 4 = 398) it would not have been.
+    assert_eq!(glyph.x, 1368.0, "{glyph:?}");
+    assert_eq!(glyph.width, 224.0, "GNU: pixel_width -= crop; {glyph:?}");
+    assert_eq!(glyph.content.width_px(), 300.0);
+    let clip = glyph.clip_rect.expect("body rows carry the text-area clip");
+    assert!(
+        clip.x >= 800.0 && clip.x <= 808.0 && clip.x + clip.width >= 1592.0,
+        "the clip is the right window's text area: {clip:?}"
+    );
 }
 
 /// A widget taller than the window becomes a partially visible row in GNU
@@ -14137,14 +14301,17 @@ fn layout_frame_rust_crops_an_xwidget_wider_than_its_window_like_gnu() {
 /// full height and the presentation carries the clip.
 #[test]
 fn layout_frame_rust_keeps_an_xwidget_taller_than_its_window_partially_visible() {
-    let (_x, width, height, clip) = inline_xwidget_glyph_in_frame(320, 120, 96, 900)
+    let glyph = inline_xwidget_glyph_in_frame(320, 120, 96, 900)
         .expect("a tall xwidget is clipped, not dropped");
-    assert_eq!(width, 96.0);
+    assert_eq!(glyph.width, 96.0);
     assert_eq!(
-        height, 900.0,
+        glyph.height, 900.0,
         "GNU keeps the widget's height; drawing clips"
     );
-    let clip = clip.expect("a partially visible row carries its clip");
+    assert_eq!(glyph.content.height_px(), 900.0);
+    let clip = glyph
+        .clip_rect
+        .expect("a partially visible row carries its clip");
     assert!(
         clip.height < 900.0 && clip.height <= 120.0,
         "the clip is bounded by the window: {clip:?}"

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -14031,6 +14031,126 @@ fn layout_frame_rust_emits_inline_webkit_glyphs_for_display_webkit_specs() {
     assert_eq!(requests[0].height, 45);
 }
 
+/// Lay out a buffer whose second character is replaced by an xwidget of
+/// `width`x`height` pixels in a `frame_width`x`frame_height` frame, and return
+/// the presented xwidget glyph (`x`, `width`, `height`, `clip_rect`) if any.
+fn inline_xwidget_glyph_in_frame(
+    frame_width: u32,
+    frame_height: u32,
+    width: i32,
+    height: i32,
+) -> Option<(f32, f32, f32, Option<neomacs_display_protocol::Rect>)> {
+    let mut eval = Context::new();
+    eval.set_display_host(Box::new(RecordingImageDisplayHost {
+        requests: Arc::new(Mutex::new(Vec::new())),
+        video_requests: Arc::new(Mutex::new(Vec::new())),
+        webkit_requests: Arc::new(Mutex::new(Vec::new())),
+        surface_requests: Arc::new(Mutex::new(Vec::new())),
+    }));
+    let buf_id = eval
+        .buffer_manager()
+        .current_buffer()
+        .expect("current buffer")
+        .id();
+    let xwidget = Value::make_xwidget(
+        Value::symbol("webkit"),
+        Value::string("Title"),
+        Value::make_buffer(buf_id),
+        width,
+        height,
+        4321,
+        neomacs_display_protocol::WebViewId::new(8765),
+    );
+    {
+        let buf = eval.buffer_manager_mut().get_mut(buf_id).expect("buffer");
+        buf.insert("aXb");
+        buf.goto_emacs_byte_pos(neovm_core::buffer::EmacsBytePos::new(1));
+        buf.put_text_property(
+            1,
+            2,
+            Value::symbol("display"),
+            Value::list(vec![
+                Value::symbol("xwidget"),
+                Value::keyword("xwidget"),
+                xwidget,
+            ]),
+        );
+    }
+    let frame_id = eval.frame_manager_mut().create_frame(
+        "layout-oversized-xwidget",
+        frame_width,
+        frame_height,
+        buf_id,
+    );
+    let mut engine = LayoutEngine::new();
+    engine.layout_frame_rust(&mut eval, frame_id);
+    let state = engine
+        .last_frame_display_state
+        .as_ref()
+        .expect("frame display state");
+    state
+        .materialize()
+        .glyphs
+        .iter()
+        .find_map(|glyph| match glyph {
+            FrameGlyph::Xwidget {
+                x,
+                width,
+                height,
+                clip_rect,
+                ..
+            } => Some((*x, *width, *height, *clip_rect)),
+            _ => None,
+        })
+}
+
+/// GNU `produce_xwidget_glyph` (src/xdisp.c:32659-32707) never declines to
+/// produce the glyph.  It crops a wide widget at the right edge of the text
+/// area -- `crop = pixel_width - (last_visible_x - current_x)`, applied when
+/// the glyph starts the row or is wider than a quarter of the visible width
+/// (:32704-32706) -- so the widget is shown partially, which is what
+/// `x_draw_xwidget_glyph_string`'s `clip_*` machinery exists for.  Issue 301:
+/// this port emitted nothing, and the window showed an empty background
+/// indistinguishable from a page that failed to load.
+#[test]
+fn layout_frame_rust_crops_an_xwidget_wider_than_its_window_like_gnu() {
+    let fits = inline_xwidget_glyph_in_frame(320, 120, 96, 40).expect("fitting xwidget glyph");
+    assert_eq!(fits.1, 96.0);
+
+    let (x, width, height, _clip) = inline_xwidget_glyph_in_frame(320, 120, 600, 40)
+        .expect("a wide xwidget is cropped, not dropped");
+    assert_eq!(height, 40.0);
+    assert_eq!(
+        x, fits.0,
+        "cropping changes the width, not where the glyph starts"
+    );
+    // The test frame is a TTY frame: 8 px cells, no fringes, and one column
+    // reserved at the right edge, so `last_visible_x` is 312 and the widget
+    // after the one-cell "a" starts at 8: GNU's crop = 600 - (312 - 8).
+    assert_eq!(x, 8.0);
+    assert_eq!(width, 304.0, "GNU: pixel_width -= crop");
+}
+
+/// A widget taller than the window becomes a partially visible row in GNU
+/// (`display_line` keeps the row; drawing clips it, src/xdisp.c:32703 and
+/// `x_draw_xwidget_glyph_string`'s clip_top/clip_bottom).  The glyph keeps its
+/// full height and the presentation carries the clip.
+#[test]
+fn layout_frame_rust_keeps_an_xwidget_taller_than_its_window_partially_visible() {
+    let (_x, width, height, clip) = inline_xwidget_glyph_in_frame(320, 120, 96, 900)
+        .expect("a tall xwidget is clipped, not dropped");
+    assert_eq!(width, 96.0);
+    assert_eq!(
+        height, 900.0,
+        "GNU keeps the widget's height; drawing clips"
+    );
+    let clip = clip.expect("a partially visible row carries its clip");
+    assert!(
+        clip.height < 900.0 && clip.height <= 120.0,
+        "the clip is bounded by the window: {clip:?}"
+    );
+}
+
 #[test]
 fn layout_frame_rust_emits_inline_xwidget_glyphs_for_gnu_display_xwidget_specs() {
     let mut eval = Context::new();

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -14319,8 +14319,9 @@ fn layout_frame_rust_measures_the_quarter_width_rule_from_the_text_area_not_the_
         "the line-number prefix moves the glyph right: {cropped:?}"
     );
     // The layout pen reaches the widget at frame x 1456 (text area at 800,
-    // the border cell, four line-number cells, 75 cells of text), so GNU's
-    // crop is 200 - (1592 - 1456).
+    // the border cell, the six-cell line-number prefix -- two digits plus
+    // GNU's `lnum_width + 2` padding -- and 75 cells of text: 82 cells of
+    // 8 px), so GNU's crop is 200 - (1592 - 1456).
     assert_eq!(
         cropped.width, 136.0,
         "GNU: pixel_width -= crop; {cropped:?}"

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -14322,8 +14322,7 @@ fn layout_frame_rust_measures_the_quarter_width_rule_from_the_text_area_not_the_
     // the border cell, four line-number cells, 75 cells of text), so GNU's
     // crop is 200 - (1592 - 1456).
     assert_eq!(
-        cropped.width,
-        136.0,
+        cropped.width, 136.0,
         "GNU: pixel_width -= crop; {cropped:?}"
     );
     assert_eq!(cropped.content.width_px(), 200.0);

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -14129,6 +14129,7 @@ fn inline_xwidget_glyph_in_right_split(
     frame_width: u32,
     frame_height: u32,
     prefix: &str,
+    line_numbers: bool,
     width: i32,
     height: i32,
 ) -> Option<InlineXwidgetGlyph> {
@@ -14161,6 +14162,9 @@ fn inline_xwidget_glyph_in_right_split(
             .get_mut(right_buf_id)
             .expect("right buffer");
         buf.insert(&format!("{prefix}Xb"));
+        if line_numbers {
+            buf.set_buffer_local("display-line-numbers", Value::T);
+        }
         buf.goto_emacs_byte_pos(neovm_core::buffer::EmacsBytePos::new(1));
         buf.put_text_property(
             prefix_chars + 1,
@@ -14225,15 +14229,15 @@ fn inline_xwidget_glyph_in_right_split(
         })
 }
 
-/// GNU `produce_xwidget_glyph` (src/xdisp.c:32534-32620, emacs-31.0.90)
+/// GNU `produce_xwidget_glyph` (src/xdisp.c:32534-32637, emacs-31.0.90)
 /// never declines to produce the glyph.  It crops a wide widget's advance at
-/// the right edge of the text area -- `crop = pixel_width - (last_visible_x
-/// - current_x)`, applied when the glyph starts the row or is wider than a
-/// quarter of the visible width (:32577-32579) -- so the widget is shown
-/// partially, which is what `x_draw_xwidget_glyph_string`'s `clip_*`
-/// machinery exists for (src/xwidget.c:2841-2847).  Issue 301: this port
-/// emitted nothing, and the window showed an empty background
-/// indistinguishable from a page that failed to load.
+/// the right edge of the text area, `crop = pixel_width - (last_visible_x -
+/// current_x)`, when the glyph starts the row or is wider than a quarter of
+/// the visible width (:32577-32579), so the widget is shown partially, which
+/// is what `x_draw_xwidget_glyph_string`'s `clip_*` machinery exists for
+/// (src/xwidget.c:2841-2849).  Issue 301: this port emitted nothing, and the
+/// window showed an empty background indistinguishable from a page that
+/// failed to load.
 #[test]
 fn layout_frame_rust_crops_an_xwidget_wider_than_its_window_like_gnu() {
     let fits = inline_xwidget_glyph_in_frame(320, 120, 96, 40).expect("fitting xwidget glyph");
@@ -14276,7 +14280,7 @@ fn layout_frame_rust_crops_an_xwidget_wider_than_its_window_like_gnu() {
 #[test]
 fn layout_frame_rust_crops_an_xwidget_in_a_right_hand_split_by_the_windows_width() {
     let prefix = "a".repeat(70);
-    let glyph = inline_xwidget_glyph_in_right_split(1600, 120, &prefix, 300, 40)
+    let glyph = inline_xwidget_glyph_in_right_split(1600, 120, &prefix, false, 300, 40)
         .expect("the right window's xwidget is cropped, not dropped");
     // Right window: 8 px cells, its text starts at frame x 808 (the column
     // at 800 is the vertical border) and one column is reserved at the
@@ -14295,9 +14299,49 @@ fn layout_frame_rust_crops_an_xwidget_in_a_right_hand_split_by_the_windows_width
     );
 }
 
-/// A widget taller than the window becomes a partially visible row in GNU
-/// (`display_line` keeps the row; drawing clips it, src/xdisp.c:32703 and
-/// `x_draw_xwidget_glyph_string`'s clip_top/clip_bottom).  The glyph keeps its
+/// The line-number prefix lies inside GNU's text area: `it->current_x`
+/// counts it and `it->last_visible_x` is still measured from the text
+/// area's left edge (`maybe_produce_line_number`, src/xdisp.c:25705-25706;
+/// src/dispextern.h:2785-2791).  So the window-local origin is the text
+/// area's edge, not the content edge after the prefix; measuring from the
+/// content edge would shrink `last_visible_x / 4` by a quarter of the prefix
+/// and crop a widget GNU leaves whole.
+#[test]
+fn layout_frame_rust_measures_the_quarter_width_rule_from_the_text_area_not_the_line_numbers() {
+    let prefix = "a".repeat(75);
+    // A 200 px widget after 75 cells overflows and is wider than a quarter
+    // of the window (784 / 4 = 196): cropped to what is left of the row,
+    // with the prefix's width showing in where the glyph starts.
+    let cropped = inline_xwidget_glyph_in_right_split(1600, 120, &prefix, true, 200, 40)
+        .expect("a wide xwidget after line numbers is cropped, not dropped");
+    assert!(
+        cropped.x > 808.0 + 600.0,
+        "the line-number prefix moves the glyph right: {cropped:?}"
+    );
+    // The layout pen reaches the widget at frame x 1456 (text area at 800,
+    // the border cell, four line-number cells, 75 cells of text), so GNU's
+    // crop is 200 - (1592 - 1456).
+    assert_eq!(
+        cropped.width,
+        136.0,
+        "GNU: pixel_width -= crop; {cropped:?}"
+    );
+    assert_eq!(cropped.content.width_px(), 200.0);
+
+    // 195 px is not wider than a quarter of the window measured from the
+    // text area (195 <= 196), so GNU leaves it whole and this port drops it.
+    // Measured from the content edge the quarter would be smaller than 195
+    // and the widget would have been cropped instead.
+    assert!(
+        inline_xwidget_glyph_in_right_split(1600, 120, &prefix, true, 195, 40).is_none(),
+        "the quarter-width threshold is the text area's, prefix included"
+    );
+}
+
+/// A widget taller than the window becomes a partially visible row in GNU:
+/// `produce_xwidget_glyph` crops only the width (src/xdisp.c:32577-32579,
+/// emacs-31.0.90) and `x_draw_xwidget_glyph_string` clips the height
+/// (`clip_top`/`clip_bottom`, src/xwidget.c:2847-2849).  The glyph keeps its
 /// full height and the presentation carries the clip.
 #[test]
 fn layout_frame_rust_keeps_an_xwidget_taller_than_its_window_partially_visible() {
@@ -14313,7 +14357,7 @@ fn layout_frame_rust_keeps_an_xwidget_taller_than_its_window_partially_visible()
         .clip_rect
         .expect("a partially visible row carries its clip");
     assert!(
-        clip.height < 900.0 && clip.height <= 120.0,
+        clip.height <= 120.0,
         "the clip is bounded by the window: {clip:?}"
     );
 }

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -14004,23 +14004,22 @@ fn layout_frame_rust_emits_inline_webkit_glyphs_for_display_webkit_specs() {
         .as_ref()
         .expect("frame display state");
     let presentation = state.materialize();
-    let (xwidget_id, width, height, slot_id) = presentation
+    let (xwidget_id, geometry, slot_id) = presentation
         .glyphs
         .iter()
         .find_map(|glyph| match glyph {
             FrameGlyph::Xwidget {
                 xwidget_id,
-                width,
-                height,
+                presentation,
                 slot_id,
                 ..
-            } => Some((*xwidget_id, *width, *height, *slot_id)),
+            } => Some((*xwidget_id, *presentation, *slot_id)),
             _ => None,
         })
         .expect("inline xwidget glyph");
     assert_eq!(xwidget_id.get(), 99);
-    assert_eq!(width, 80.0);
-    assert_eq!(height, 45.0);
+    assert_eq!(geometry.layout_advance().px().get(), 80.0);
+    assert_eq!(geometry.content_extent().height_px(), 45.0);
     let replacement = assert_replacement_slot_between_neighbors(&eval, frame_id, 2, 80);
     let slot_id = slot_id.expect("webkit slot id");
     assert_eq!(i64::from(slot_id.col), replacement.col);
@@ -14093,20 +14092,24 @@ fn inline_xwidget_glyph_in_frame(
         .glyphs
         .iter()
         .find_map(|glyph| match glyph {
-            FrameGlyph::Xwidget {
-                x,
-                width,
-                height,
-                content,
-                clip_rect,
-                ..
-            } => Some(InlineXwidgetGlyph {
-                x: *x,
-                width: *width,
-                height: *height,
-                content: *content,
-                clip_rect: *clip_rect,
-            }),
+            FrameGlyph::Xwidget { presentation, .. } => {
+                let slot = presentation.layout_slot_rect();
+                let clip_rect = presentation.clip_rect().map(|clip| {
+                    neomacs_display_protocol::Rect::new(
+                        clip.x(),
+                        clip.y(),
+                        clip.width(),
+                        clip.height(),
+                    )
+                });
+                Some(InlineXwidgetGlyph {
+                    x: slot.x(),
+                    width: slot.width(),
+                    height: slot.height(),
+                    content: presentation.content_extent(),
+                    clip_rect,
+                })
+            }
             _ => None,
         })
 }
@@ -14212,19 +14215,26 @@ fn inline_xwidget_glyph_in_right_split(
         .find_map(|glyph| match glyph {
             FrameGlyph::Xwidget {
                 window_id,
-                x,
-                width,
-                height,
-                content,
-                clip_rect,
+                presentation,
                 ..
-            } if window_id.get() == right_window.0 as i64 => Some(InlineXwidgetGlyph {
-                x: *x,
-                width: *width,
-                height: *height,
-                content: *content,
-                clip_rect: *clip_rect,
-            }),
+            } if window_id.get() == right_window.0 as i64 => {
+                let slot = presentation.layout_slot_rect();
+                let clip_rect = presentation.clip_rect().map(|clip| {
+                    neomacs_display_protocol::Rect::new(
+                        clip.x(),
+                        clip.y(),
+                        clip.width(),
+                        clip.height(),
+                    )
+                });
+                Some(InlineXwidgetGlyph {
+                    x: slot.x(),
+                    width: slot.width(),
+                    height: slot.height(),
+                    content: presentation.content_extent(),
+                    clip_rect,
+                })
+            }
             _ => None,
         })
 }
@@ -14414,23 +14424,22 @@ fn layout_frame_rust_emits_inline_xwidget_glyphs_for_gnu_display_xwidget_specs()
         .as_ref()
         .expect("frame display state");
     let presentation = state.materialize();
-    let (xwidget_id, width, height, slot_id) = presentation
+    let (xwidget_id, geometry, slot_id) = presentation
         .glyphs
         .iter()
         .find_map(|glyph| match glyph {
             FrameGlyph::Xwidget {
                 xwidget_id,
-                width,
-                height,
+                presentation,
                 slot_id,
                 ..
-            } => Some((*xwidget_id, *width, *height, *slot_id)),
+            } => Some((*xwidget_id, *presentation, *slot_id)),
             _ => None,
         })
         .expect("inline xwidget glyph");
     assert_eq!(xwidget_id.get(), 1234);
-    assert_eq!(width, 96.0);
-    assert_eq!(height, 54.0);
+    assert_eq!(geometry.layout_advance().px().get(), 96.0);
+    assert_eq!(geometry.content_extent().height_px(), 54.0);
     let replacement = assert_replacement_slot_between_neighbors(&eval, frame_id, 2, 96);
     let slot_id = slot_id.expect("xwidget slot id");
     assert_eq!(i64::from(slot_id.col), replacement.col);

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -14339,12 +14339,19 @@ fn layout_frame_rust_measures_the_quarter_width_rule_from_the_text_area_not_the_
     assert_eq!(cropped.content.width_px(), 200.0);
 
     // 195 px is not wider than a quarter of the window measured from the
-    // text area (195 <= 196), so GNU leaves it whole and this port drops it.
-    // Measured from the content edge the quarter would be smaller than 195
-    // and the widget would have been cropped instead.
-    assert!(
-        inline_xwidget_glyph_in_right_split(1600, 120, &prefix, true, 195, 40).is_none(),
-        "the quarter-width threshold is the text area's, prefix included"
+    // text area (195 <= 196), so GNU leaves its layout advance whole.  With
+    // truncation enabled, `display_line` retains that glyph past the right
+    // edge and `x_draw_xwidget_glyph_string` clips the native widget to the
+    // text area.  Measured from the content edge the quarter would be smaller
+    // than 195 and the widget would have been cropped instead.
+    let whole = inline_xwidget_glyph_in_right_split(1600, 120, &prefix, true, 195, 40)
+        .expect("GNU retains a narrow overflowing xwidget and clips its presentation");
+    assert_eq!(whole.x, cropped.x, "the two widgets start at the same pen");
+    assert_eq!(whole.width, 195.0, "GNU leaves the layout advance whole");
+    assert_eq!(whole.content.width_px(), 195.0);
+    assert_eq!(
+        whole.clip_rect, cropped.clip_rect,
+        "both presentations are clipped by the same window text area"
     );
 }
 

--- a/crates/neomacs-renderer-wgpu/src/renderer/content.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/content.rs
@@ -1737,11 +1737,15 @@ impl WgpuRenderer {
                         webview_id,
                         x,
                         y,
-                        width,
-                        height,
+                        content,
                         ..
                     } = glyph
                     {
+                        // The texture is the widget at its own size; the
+                        // glyph slot may be narrower after the right-edge
+                        // crop and must not squeeze it.
+                        let width = content.width_px();
+                        let height = content.height_px();
                         let view_id = *webview_id;
                         if self.caches.webview.get(view_id).is_some() {
                             let wx = *x + offset_x;
@@ -1757,7 +1761,7 @@ impl WgpuRenderer {
                             webkit_quads.push(MediaQuad {
                                 id: view_id,
                                 vertices: super::layer_media::textured_quad_vertices(
-                                    wx, wy, *width, *height, 0.0, 1.0,
+                                    wx, wy, width, height, 0.0, 1.0,
                                 ),
                             });
                         }

--- a/crates/neomacs-renderer-wgpu/src/renderer/content.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/content.rs
@@ -1738,30 +1738,53 @@ impl WgpuRenderer {
                         x,
                         y,
                         content,
+                        clip_rect,
                         ..
                     } = glyph
                     {
                         // The texture is the widget at its own size; the
                         // glyph slot may be narrower after the right-edge
-                        // crop and must not squeeze it.
+                        // crop and must not squeeze it.  What the slot no
+                        // longer covers is cut away by the text-area clip,
+                        // through the same helper the image branch above
+                        // uses, so the widget cannot spill into the next
+                        // window of this child frame.
                         let width = content.width_px();
                         let height = content.height_px();
                         let view_id = *webview_id;
                         if self.caches.webview.get(view_id).is_some() {
-                            let wx = *x + offset_x;
-                            let wy = *y + offset_y;
+                            let Some(clipped) = super::layer_media::clipped_media_rect(
+                                *x,
+                                *y,
+                                width,
+                                height,
+                                clip_rect.as_ref(),
+                            ) else {
+                                continue;
+                            };
+                            let wx = clipped.draw_x + offset_x;
+                            let wy = clipped.draw_y + offset_y;
                             tracing::debug!(
-                                "render_frame_content: webkit {} at ({:.1},{:.1}) size {:.1}x{:.1}",
+                                "render_frame_content: webkit {} at ({:.1},{:.1}) size {:.1}x{:.1} (clipped to {:.1}x{:.1})",
                                 webview_id,
                                 wx,
                                 wy,
                                 width,
                                 height,
+                                clipped.draw_width,
+                                clipped.draw_height,
                             );
                             webkit_quads.push(MediaQuad {
                                 id: view_id,
-                                vertices: super::layer_media::textured_quad_vertices(
-                                    wx, wy, width, height, 0.0, 1.0,
+                                vertices: super::layer_media::textured_quad_vertices_uv(
+                                    wx,
+                                    wy,
+                                    clipped.draw_width,
+                                    clipped.draw_height,
+                                    clipped.u_min,
+                                    clipped.u_max,
+                                    clipped.v_min,
+                                    clipped.v_max,
                                 ),
                             });
                         }

--- a/crates/neomacs-renderer-wgpu/src/renderer/content.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/content.rs
@@ -19,6 +19,8 @@ use super::cursor_presentation::{
     ResolvedCursorPaint,
 };
 use super::frame_pass::{BoxSpan, collect_frame_box_spans};
+#[cfg(all(feature = "webview", target_os = "linux"))]
+use super::layer_media::inline_webview_quad;
 use super::layer_media::{MediaQuad, clipped_media_rect, textured_quad_vertices_uv};
 use cosmic_text::SubpixelBin;
 use neomacs_display_protocol::DeviceScale;
@@ -1733,61 +1735,10 @@ impl WgpuRenderer {
 
                 let mut webkit_quads = Vec::new();
                 for glyph in &frame.glyphs {
-                    if let FrameGlyph::Xwidget {
-                        webview_id,
-                        x,
-                        y,
-                        content,
-                        clip_rect,
-                        ..
-                    } = glyph
+                    if let Some(quad) = inline_webview_quad(glyph, offset_x, offset_y)
+                        && self.caches.webview.get(quad.id).is_some()
                     {
-                        // The texture is the widget at its own size; the
-                        // glyph slot may be narrower after the right-edge
-                        // crop and must not squeeze it.  What the slot no
-                        // longer covers is cut away by the text-area clip,
-                        // through the same helper the image branch above
-                        // uses, so the widget cannot spill into the next
-                        // window of this child frame.
-                        let width = content.width_px();
-                        let height = content.height_px();
-                        let view_id = *webview_id;
-                        if self.caches.webview.get(view_id).is_some() {
-                            let Some(clipped) = super::layer_media::clipped_media_rect(
-                                *x,
-                                *y,
-                                width,
-                                height,
-                                clip_rect.as_ref(),
-                            ) else {
-                                continue;
-                            };
-                            let wx = clipped.draw_x + offset_x;
-                            let wy = clipped.draw_y + offset_y;
-                            tracing::debug!(
-                                "render_frame_content: webkit {} at ({:.1},{:.1}) size {:.1}x{:.1} (clipped to {:.1}x{:.1})",
-                                webview_id,
-                                wx,
-                                wy,
-                                width,
-                                height,
-                                clipped.draw_width,
-                                clipped.draw_height,
-                            );
-                            webkit_quads.push(MediaQuad {
-                                id: view_id,
-                                vertices: super::layer_media::textured_quad_vertices_uv(
-                                    wx,
-                                    wy,
-                                    clipped.draw_width,
-                                    clipped.draw_height,
-                                    clipped.u_min,
-                                    clipped.u_max,
-                                    clipped.v_min,
-                                    clipped.v_max,
-                                ),
-                            });
-                        }
+                        webkit_quads.push(quad);
                     }
                 }
                 let webkit_vertices: Vec<GlyphVertex> = webkit_quads

--- a/crates/neomacs-renderer-wgpu/src/renderer/layer_media.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/layer_media.rs
@@ -512,66 +512,14 @@ impl WgpuRenderer {
                     // `xww->width` x `xww->height`); the glyph slot may have
                     // been cropped at the right edge, so draw the content
                     // extent and cut it to the text-area clip on all four
-                    // sides, the way the image path does.
+                    // sides through the helper the image path uses.
                     let width = content.width_px();
                     let height = content.height_px();
-                    let (draw_x, draw_y, clipped_width, clipped_height, u0, u1, v0, v1) =
-                        if let Some(clip) = clip_rect {
-                            let mut x0 = *x;
-                            let mut y0 = *y;
-                            let mut w0 = width;
-                            let mut h0 = height;
-                            let mut u0 = 0.0_f32;
-                            let mut u1 = 1.0_f32;
-                            let mut v0 = 0.0_f32;
-                            let mut v1 = 1.0_f32;
-                            let left = clip.x;
-                            let right = clip.x + clip.width;
-                            let top = clip.y;
-                            let bottom = clip.y + clip.height;
-                            if x0 < left {
-                                let cut = left - x0;
-                                if cut >= w0 {
-                                    continue;
-                                }
-                                x0 = left;
-                                w0 -= cut;
-                                u0 += cut / width;
-                            }
-                            if x0 + w0 > right {
-                                let cut = (x0 + w0) - right;
-                                if cut >= w0 {
-                                    continue;
-                                }
-                                w0 -= cut;
-                                u1 -= cut / width;
-                            }
-                            if y0 < top {
-                                let cut = top - y0;
-                                if cut >= h0 {
-                                    continue;
-                                }
-                                y0 = top;
-                                h0 -= cut;
-                                v0 += cut / height;
-                            }
-                            if y0 + h0 > bottom {
-                                let cut = (y0 + h0) - bottom;
-                                if cut >= h0 {
-                                    continue;
-                                }
-                                h0 -= cut;
-                                v1 -= cut / height;
-                            }
-                            (x0, y0, w0, h0, u0, u1, v0, v1)
-                        } else {
-                            (*x, *y, width, height, 0.0, 1.0, 0.0, 1.0)
-                        };
-
-                    // Skip if fully clipped
-                    if clipped_width <= 0.0 || clipped_height <= 0.0 {
+                    let Some(clipped) =
+                        clipped_media_rect(*x, *y, width, height, clip_rect.as_ref())
+                    else {
                         continue;
-                    }
+                    };
 
                     let view_id = inline_webview_id(glyph)
                         .expect("the glyph was exhaustively matched as an xwidget");
@@ -586,21 +534,21 @@ impl WgpuRenderer {
                             y,
                             width,
                             height,
-                            clipped_width,
-                            clipped_height
+                            clipped.draw_width,
+                            clipped.draw_height
                         );
                         // Create vertices for webkit quad (white color = no tinting)
                         quads.push(MediaQuad {
                             id: view_id,
                             vertices: textured_quad_vertices_uv(
-                                draw_x,
-                                draw_y,
-                                clipped_width,
-                                clipped_height,
-                                u0,
-                                u1,
-                                v0,
-                                v1,
+                                clipped.draw_x,
+                                clipped.draw_y,
+                                clipped.draw_width,
+                                clipped.draw_height,
+                                clipped.u_min,
+                                clipped.u_max,
+                                clipped.v_min,
+                                clipped.v_max,
                             ),
                         });
                     } else {

--- a/crates/neomacs-renderer-wgpu/src/renderer/layer_media.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/layer_media.rs
@@ -20,12 +20,43 @@ pub(super) struct MediaQuad<Id> {
     pub(super) vertices: [GlyphVertex; 6],
 }
 
+/// Resolve one portable xwidget presentation into the GPU quad used by the
+/// Linux composited-webview backend.
+///
+/// Root and child frames deliberately share this adapter: frame offsets move
+/// only the destination vertices, while clipping and texture coordinates are
+/// derived once from the protocol's intrinsic-content/layout/clip contract.
 #[cfg(all(feature = "webview", target_os = "linux"))]
-pub(super) const fn inline_webview_id(glyph: &FrameGlyph) -> Option<WebViewId> {
-    match glyph {
-        FrameGlyph::Xwidget { webview_id, .. } => Some(*webview_id),
-        _ => None,
-    }
+pub(super) fn inline_webview_quad(
+    glyph: &FrameGlyph,
+    offset_x: f32,
+    offset_y: f32,
+) -> Option<MediaQuad<WebViewId>> {
+    let FrameGlyph::Xwidget {
+        webview_id,
+        presentation,
+        ..
+    } = glyph
+    else {
+        return None;
+    };
+    let visible = presentation.resolve_visible(None).ok()??;
+    let draw = visible.visible_rect();
+    let [u_min, u_max, v_min, v_max] = visible.texture_coordinates().as_array();
+
+    Some(MediaQuad {
+        id: *webview_id,
+        vertices: textured_quad_vertices_uv(
+            draw.x() + offset_x,
+            draw.y() + offset_y,
+            draw.width(),
+            draw.height(),
+            u_min,
+            u_max,
+            v_min,
+            v_max,
+        ),
+    })
 }
 
 #[cfg(feature = "video")]
@@ -499,60 +530,15 @@ impl WgpuRenderer {
         {
             let mut quads = Vec::new();
             for glyph in &frame_glyphs.glyphs {
-                if let FrameGlyph::Xwidget {
-                    webview_id,
-                    x,
-                    y,
-                    content,
-                    clip_rect,
-                    ..
-                } = glyph
-                {
-                    // The texture is the widget at its own size (GNU
-                    // `xww->width` x `xww->height`); the glyph slot may have
-                    // been cropped at the right edge, so draw the content
-                    // extent and cut it to the text-area clip on all four
-                    // sides through the helper the image path uses.
-                    let width = content.width_px();
-                    let height = content.height_px();
-                    let Some(clipped) =
-                        clipped_media_rect(*x, *y, width, height, clip_rect.as_ref())
-                    else {
-                        continue;
-                    };
-
-                    let view_id = inline_webview_id(glyph)
-                        .expect("the glyph was exhaustively matched as an xwidget");
+                if let Some(quad) = inline_webview_quad(glyph, 0.0, 0.0) {
+                    let view_id = quad.id;
                     // Check if webkit texture is ready
                     if self.caches.webview.get(view_id).is_some() {
                         self.media_budget
                             .touch(crate::media_budget::MediaType::WebKit, view_id.get());
-                        tracing::debug!(
-                            "Rendering webkit {} at ({}, {}) size {}x{} (clipped to {}x{})",
-                            webview_id,
-                            x,
-                            y,
-                            width,
-                            height,
-                            clipped.draw_width,
-                            clipped.draw_height
-                        );
-                        // Create vertices for webkit quad (white color = no tinting)
-                        quads.push(MediaQuad {
-                            id: view_id,
-                            vertices: textured_quad_vertices_uv(
-                                clipped.draw_x,
-                                clipped.draw_y,
-                                clipped.draw_width,
-                                clipped.draw_height,
-                                clipped.u_min,
-                                clipped.u_max,
-                                clipped.v_min,
-                                clipped.v_max,
-                            ),
-                        });
+                        quads.push(quad);
                     } else {
-                        tracing::debug!("WebView {} not found in cache", webview_id);
+                        tracing::debug!("WebView {} not found in cache", view_id);
                     }
                 }
             }

--- a/crates/neomacs-renderer-wgpu/src/renderer/layer_media.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/layer_media.rs
@@ -503,20 +503,49 @@ impl WgpuRenderer {
                     webview_id,
                     x,
                     y,
-                    width,
-                    height,
+                    content,
                     clip_rect,
                     ..
                 } = glyph
                 {
-                    let (draw_y, clipped_height, tex_v_min, tex_v_max) =
+                    // The texture is the widget at its own size (GNU
+                    // `xww->width` x `xww->height`); the glyph slot may have
+                    // been cropped at the right edge, so draw the content
+                    // extent and cut it to the text-area clip on all four
+                    // sides, the way the image path does.
+                    let width = content.width_px();
+                    let height = content.height_px();
+                    let (draw_x, draw_y, clipped_width, clipped_height, u0, u1, v0, v1) =
                         if let Some(clip) = clip_rect {
+                            let mut x0 = *x;
                             let mut y0 = *y;
-                            let mut h0 = *height;
+                            let mut w0 = width;
+                            let mut h0 = height;
+                            let mut u0 = 0.0_f32;
+                            let mut u1 = 1.0_f32;
                             let mut v0 = 0.0_f32;
                             let mut v1 = 1.0_f32;
+                            let left = clip.x;
+                            let right = clip.x + clip.width;
                             let top = clip.y;
                             let bottom = clip.y + clip.height;
+                            if x0 < left {
+                                let cut = left - x0;
+                                if cut >= w0 {
+                                    continue;
+                                }
+                                x0 = left;
+                                w0 -= cut;
+                                u0 += cut / width;
+                            }
+                            if x0 + w0 > right {
+                                let cut = (x0 + w0) - right;
+                                if cut >= w0 {
+                                    continue;
+                                }
+                                w0 -= cut;
+                                u1 -= cut / width;
+                            }
                             if y0 < top {
                                 let cut = top - y0;
                                 if cut >= h0 {
@@ -524,9 +553,7 @@ impl WgpuRenderer {
                                 }
                                 y0 = top;
                                 h0 -= cut;
-                                if *height > 0.0 {
-                                    v0 += cut / *height;
-                                }
+                                v0 += cut / height;
                             }
                             if y0 + h0 > bottom {
                                 let cut = (y0 + h0) - bottom;
@@ -534,17 +561,15 @@ impl WgpuRenderer {
                                     continue;
                                 }
                                 h0 -= cut;
-                                if *height > 0.0 {
-                                    v1 -= cut / *height;
-                                }
+                                v1 -= cut / height;
                             }
-                            (y0, h0, v0, v1)
+                            (x0, y0, w0, h0, u0, u1, v0, v1)
                         } else {
-                            (*y, *height, 0.0, 1.0)
+                            (*x, *y, width, height, 0.0, 1.0, 0.0, 1.0)
                         };
 
                     // Skip if fully clipped
-                    if clipped_height <= 0.0 {
+                    if clipped_width <= 0.0 || clipped_height <= 0.0 {
                         continue;
                     }
 
@@ -555,24 +580,27 @@ impl WgpuRenderer {
                         self.media_budget
                             .touch(crate::media_budget::MediaType::WebKit, view_id.get());
                         tracing::debug!(
-                            "Rendering webkit {} at ({}, {}) size {}x{} (clipped to {})",
+                            "Rendering webkit {} at ({}, {}) size {}x{} (clipped to {}x{})",
                             webview_id,
                             x,
                             y,
                             width,
                             height,
+                            clipped_width,
                             clipped_height
                         );
                         // Create vertices for webkit quad (white color = no tinting)
                         quads.push(MediaQuad {
                             id: view_id,
-                            vertices: textured_quad_vertices(
-                                *x,
+                            vertices: textured_quad_vertices_uv(
+                                draw_x,
                                 draw_y,
-                                *width,
+                                clipped_width,
                                 clipped_height,
-                                tex_v_min,
-                                tex_v_max,
+                                u0,
+                                u1,
+                                v0,
+                                v1,
                             ),
                         });
                     } else {

--- a/crates/neomacs-renderer-wgpu/src/renderer/layer_media_test.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/layer_media_test.rs
@@ -8,13 +8,15 @@ use super::video_quad_vertices;
 #[test]
 fn inline_webview_uses_the_explicit_browser_identity() {
     let mut glyphs = neomacs_display_protocol::FrameGlyphBuffer::new();
+    let content = neomacs_display_protocol::XwidgetContentExtent::new(320.0, 200.0)
+        .expect("valid xwidget content extent");
     glyphs.add_xwidget(
         neomacs_display_protocol::XwidgetId::new(7),
         neomacs_display_protocol::WebViewId::new(91),
         0.0,
         0.0,
+        content,
         320.0,
-        200.0,
     );
 
     assert_eq!(

--- a/crates/neomacs-renderer-wgpu/src/renderer/layer_media_test.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/layer_media_test.rs
@@ -6,22 +6,57 @@ use super::video_quad_vertices;
 
 #[cfg(all(feature = "webview", target_os = "linux"))]
 #[test]
-fn inline_webview_uses_the_explicit_browser_identity() {
+fn inline_webview_preserves_content_crop_and_child_frame_offset() {
+    use neomacs_display_protocol::{
+        FrameSpace, GeometryPoint, LogicalPixels, Px, Rect, XwidgetLayoutAdvance,
+        XwidgetPresentationGeometry,
+    };
+
     let mut glyphs = neomacs_display_protocol::FrameGlyphBuffer::new();
-    let content = neomacs_display_protocol::XwidgetContentExtent::new(320.0, 200.0)
+    glyphs.set_draw_context(
+        neomacs_display_protocol::DisplayWindowId::new(1),
+        neomacs_display_protocol::GlyphRowRole::Text,
+        Some(Rect::new(0.0, 0.0, 312.0, 120.0)),
+    );
+    let content = neomacs_display_protocol::XwidgetContentExtent::new(600.0, 40.0)
         .expect("valid xwidget content extent");
+    let presentation = XwidgetPresentationGeometry::new(
+        GeometryPoint::<FrameSpace, LogicalPixels>::from_px(8.0, 16.0).expect("valid origin"),
+        content,
+        XwidgetLayoutAdvance::new(Px(304.0)).expect("valid cropped advance"),
+        None,
+    );
     glyphs.add_xwidget(
         neomacs_display_protocol::XwidgetId::new(7),
         neomacs_display_protocol::WebViewId::new(91),
-        0.0,
-        0.0,
-        content,
-        320.0,
+        presentation,
     );
 
+    let quad = super::inline_webview_quad(&glyphs.glyphs[0], 100.0, 50.0)
+        .expect("the visible xwidget produces a quad");
+
+    assert_eq!(quad.id, neomacs_display_protocol::WebViewId::new(91));
     assert_eq!(
-        super::inline_webview_id(&glyphs.glyphs[0]),
-        Some(neomacs_display_protocol::WebViewId::new(91))
+        quad.vertices.map(|vertex| vertex.position),
+        [
+            [108.0, 66.0],
+            [412.0, 66.0],
+            [412.0, 106.0],
+            [108.0, 66.0],
+            [412.0, 106.0],
+            [108.0, 106.0],
+        ]
+    );
+    assert_eq!(
+        quad.vertices.map(|vertex| vertex.tex_coords),
+        [
+            [0.0, 0.0],
+            [304.0 / 600.0, 0.0],
+            [304.0 / 600.0, 1.0],
+            [0.0, 0.0],
+            [304.0 / 600.0, 1.0],
+            [0.0, 1.0],
+        ]
     );
 }
 

--- a/crates/neomacs-webview/build.rs
+++ b/crates/neomacs-webview/build.rs
@@ -155,7 +155,6 @@ fn generate_wpe_platform_bindings(out_dir: &Path) {
         // GObject/GLib functions we need
         .allowlist_function("g_object_unref")
         .allowlist_function("g_object_ref")
-        .allowlist_function("g_error_free")
         .allowlist_function("g_bytes_get_data")
         .allowlist_function("g_signal_connect_data")
         .allowlist_function("g_type_check_instance_is_a")

--- a/crates/neomacs-webview/build.rs
+++ b/crates/neomacs-webview/build.rs
@@ -157,8 +157,6 @@ fn generate_wpe_platform_bindings(out_dir: &Path) {
         .allowlist_function("g_object_ref")
         .allowlist_function("g_error_free")
         .allowlist_function("g_bytes_get_data")
-        .allowlist_function("g_bytes_unref")
-        .allowlist_function("g_bytes_get_size")
         .allowlist_function("g_signal_connect_data")
         .allowlist_function("g_type_check_instance_is_a")
         // GObject/GLib types we need

--- a/crates/neomacs-webview/src/backend.rs
+++ b/crates/neomacs-webview/src/backend.rs
@@ -82,8 +82,9 @@ impl PlatformCreateRequest {
     }
 }
 
-// Linux and macOS create synchronously; Windows uses `Pending` until a host
-// placement supplies the HWND required by its composition controller.
+// Linux and Windows create asynchronously; macOS currently creates inline.
+// Windows may additionally wait for a host placement that supplies the HWND
+// required by its composition controller.
 #[allow(dead_code)]
 pub(crate) enum CreateOutcome<V, C> {
     Ready(V),

--- a/crates/neomacs-webview/src/platform/linux/display.rs
+++ b/crates/neomacs-webview/src/platform/linux/display.rs
@@ -16,10 +16,10 @@
 //! ```
 
 use std::ffi::CString;
-use std::ptr;
 use tracing::{debug, info, warn};
 
 use super::error::{DisplayError, DisplayResult};
+use super::glib_error::GlibErrorSlot;
 use super::native;
 use super::sys::platform as plat;
 
@@ -66,18 +66,13 @@ impl WpePlatformDisplay {
             let delegate = if let Some(path) = device_path {
                 let c_path = CString::new(path)
                     .map_err(|_| DisplayError::WebKit("Invalid device path".into()))?;
-                let mut error: *mut plat::GError = ptr::null_mut();
-                let d = plat::wpe_display_headless_new_for_device(c_path.as_ptr(), &mut error);
+                let mut error = GlibErrorSlot::new();
+                let d = plat::wpe_display_headless_new_for_device(
+                    c_path.as_ptr(),
+                    error.out_ptr().cast(),
+                );
                 if d.is_null() {
-                    let error_msg = if !error.is_null() {
-                        let msg = std::ffi::CStr::from_ptr((*error).message)
-                            .to_string_lossy()
-                            .into_owned();
-                        plat::g_error_free(error);
-                        msg
-                    } else {
-                        "Unknown error".into()
-                    };
+                    let error_msg = error.into_message("Unknown error");
                     return Err(DisplayError::WebKit(format!(
                         "Failed to create WPE headless display for device {}: {}",
                         path, error_msg
@@ -107,18 +102,10 @@ impl WpePlatformDisplay {
             );
 
             // Connect the display
-            let mut error: *mut plat::GError = ptr::null_mut();
-            let connected = plat::wpe_display_connect(display, &mut error);
+            let mut error = GlibErrorSlot::new();
+            let connected = plat::wpe_display_connect(display, error.out_ptr().cast());
             if connected == 0 {
-                let error_msg = if !error.is_null() {
-                    let msg = std::ffi::CStr::from_ptr((*error).message)
-                        .to_string_lossy()
-                        .into_owned();
-                    plat::g_error_free(error);
-                    msg
-                } else {
-                    "Unknown error".into()
-                };
+                let error_msg = error.into_message("Unknown error");
                 plat::g_object_unref(display as *mut _);
                 return Err(DisplayError::WebKit(format!(
                     "Failed to connect WPE display: {}",
@@ -128,18 +115,10 @@ impl WpePlatformDisplay {
             info!("WpePlatformDisplay: Display connected");
 
             // Get EGL display from WPE Platform
-            let mut error: *mut plat::GError = ptr::null_mut();
-            let egl_display = plat::wpe_display_get_egl_display(display, &mut error);
+            let mut error = GlibErrorSlot::new();
+            let egl_display = plat::wpe_display_get_egl_display(display, error.out_ptr().cast());
             if egl_display.is_null() {
-                let error_msg = if !error.is_null() {
-                    let msg = std::ffi::CStr::from_ptr((*error).message)
-                        .to_string_lossy()
-                        .into_owned();
-                    plat::g_error_free(error);
-                    msg
-                } else {
-                    "Unknown error".into()
-                };
+                let error_msg = error.into_message("Unknown error");
                 warn!(
                     "WpePlatformDisplay: Failed to get EGL display: {}",
                     error_msg

--- a/crates/neomacs-webview/src/platform/linux/glib_error.rs
+++ b/crates/neomacs-webview/src/platform/linux/glib_error.rs
@@ -1,0 +1,84 @@
+//! Owning adapter for GLib's nullable `GError **` convention.
+//!
+//! Native APIs write a full-transfer `GError` into the slot on failure. Keeping
+//! that pointer private makes message access and destruction the responsibility
+//! of `glib::Error` instead of duplicating unchecked field dereferences at each
+//! call site.
+
+use std::{mem, ptr};
+
+use glib::translate::from_glib_full;
+
+pub(super) struct GlibErrorSlot {
+    raw: *mut glib::ffi::GError,
+}
+
+impl GlibErrorSlot {
+    pub(super) const fn new() -> Self {
+        Self {
+            raw: ptr::null_mut(),
+        }
+    }
+
+    /// Returns the storage address expected by a GLib `GError **` parameter.
+    pub(super) fn out_ptr(&mut self) -> *mut *mut glib::ffi::GError {
+        ptr::from_mut(&mut self.raw)
+    }
+
+    pub(super) fn is_set(&self) -> bool {
+        !self.raw.is_null()
+    }
+
+    pub(super) fn into_message(mut self, fallback: &str) -> String {
+        self.take()
+            .map(|error| error.to_string())
+            .unwrap_or_else(|| fallback.to_owned())
+    }
+
+    fn take(&mut self) -> Option<glib::Error> {
+        let raw = mem::replace(&mut self.raw, ptr::null_mut());
+        if raw.is_null() {
+            None
+        } else {
+            // SAFETY: GLib error out-parameters return a newly allocated,
+            // full-transfer GError. `take` clears the slot before constructing
+            // the sole owning wrapper, so it cannot be converted or freed twice.
+            Some(unsafe { from_glib_full(raw) })
+        }
+    }
+}
+
+impl Drop for GlibErrorSlot {
+    fn drop(&mut self) {
+        let _ = self.take();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use glib::translate::IntoGlibPtr;
+
+    use super::GlibErrorSlot;
+
+    #[test]
+    fn empty_error_slot_uses_the_callers_fallback() {
+        let slot = GlibErrorSlot::new();
+
+        assert_eq!(
+            slot.into_message("native call failed"),
+            "native call failed"
+        );
+    }
+
+    #[test]
+    fn error_slot_owns_and_formats_the_error_returned_by_glib() {
+        let mut slot = GlibErrorSlot::new();
+        let error = glib::Error::new(glib::FileError::Failed, "native failure");
+
+        unsafe {
+            *slot.out_ptr() = error.into_glib_ptr();
+        }
+
+        assert_eq!(slot.into_message("fallback"), "native failure");
+    }
+}

--- a/crates/neomacs-webview/src/platform/linux/mod.rs
+++ b/crates/neomacs-webview/src/platform/linux/mod.rs
@@ -26,6 +26,8 @@ mod display;
 
 mod engine;
 
+mod glib_error;
+
 mod native;
 
 mod reactor;

--- a/crates/neomacs-webview/src/platform/linux/view.rs
+++ b/crates/neomacs-webview/src/platform/linux/view.rs
@@ -106,6 +106,171 @@ pub(super) enum CapturedFrame {
     DmaBuf(DmaBufData),
 }
 
+const MAX_WPE_BUFFER_DIMENSION: u32 = 8_192;
+const SOFTWARE_PIXEL_BYTES_PER_PIXEL: usize = 4;
+const MAX_SOFTWARE_FRAME_BYTES: usize = MAX_WPE_BUFFER_DIMENSION as usize
+    * MAX_WPE_BUFFER_DIMENSION as usize
+    * SOFTWARE_PIXEL_BYTES_PER_PIXEL;
+
+/// Validated memory layout for a software frame borrowed from WPE.
+///
+/// WPE's DMA-BUF fallback may pad each row, so imported bytes are not assumed
+/// to be tightly packed. The constructor validates every value derived from
+/// foreign metadata before Rust creates a slice or allocates a destination.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SoftwarePixelLayout {
+    width: usize,
+    height: usize,
+    stride: usize,
+    packed_len: usize,
+}
+
+impl SoftwarePixelLayout {
+    fn new(width: u32, height: u32, byte_len: usize) -> Result<Self, SoftwarePixelLayoutError> {
+        let width = width as usize;
+        let height = height as usize;
+
+        if byte_len > MAX_SOFTWARE_FRAME_BYTES {
+            return Err(SoftwarePixelLayoutError::ExceedsFrameLimit {
+                actual: byte_len,
+                maximum: MAX_SOFTWARE_FRAME_BYTES,
+            });
+        }
+        if height == 0 {
+            return Err(SoftwarePixelLayoutError::PartialRow { byte_len, height });
+        }
+        if !byte_len.is_multiple_of(height) {
+            return Err(SoftwarePixelLayoutError::PartialRow { byte_len, height });
+        }
+
+        let stride = byte_len / height;
+        let minimum_stride = width
+            .checked_mul(SOFTWARE_PIXEL_BYTES_PER_PIXEL)
+            .ok_or(SoftwarePixelLayoutError::DimensionOverflow)?;
+        if stride < minimum_stride {
+            return Err(SoftwarePixelLayoutError::StrideTooShort {
+                actual: stride,
+                minimum: minimum_stride,
+            });
+        }
+
+        let packed_len = minimum_stride
+            .checked_mul(height)
+            .ok_or(SoftwarePixelLayoutError::DimensionOverflow)?;
+        Ok(Self {
+            width,
+            height,
+            stride,
+            packed_len,
+        })
+    }
+
+    const fn stride(self) -> usize {
+        self.stride
+    }
+
+    const fn packed_len(self) -> usize {
+        self.packed_len
+    }
+
+    fn copy_bgra_opaque(self, source: &[u8]) -> Vec<u8> {
+        debug_assert_eq!(source.len(), self.stride * self.height);
+
+        let mut packed = Vec::with_capacity(self.packed_len());
+        for row in source.chunks_exact(self.stride).take(self.height) {
+            for pixel in row[..self.width * SOFTWARE_PIXEL_BYTES_PER_PIXEL].chunks_exact(4) {
+                packed.extend_from_slice(&[pixel[0], pixel[1], pixel[2], 255]);
+            }
+        }
+        packed
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+enum SoftwarePixelLayoutError {
+    #[error("software pixel dimensions overflow addressable memory")]
+    DimensionOverflow,
+    #[error("software pixel import has {actual} bytes; supported frames use at most {maximum}")]
+    ExceedsFrameLimit { actual: usize, maximum: usize },
+    #[error("software pixel import length {byte_len} does not contain {height} complete rows")]
+    PartialRow { byte_len: usize, height: usize },
+    #[error("software pixel row stride {actual} is shorter than {minimum}")]
+    StrideTooShort { actual: usize, minimum: usize },
+}
+
+/// A WPE buffer borrowed from the native render callback.
+///
+/// This is a pointer token rather than `&WPEBuffer`: importing pixels may
+/// mutate WPE's internal cache, so representing the foreign object as a Rust
+/// shared reference would promise an aliasing guarantee that the C API does
+/// not make.
+struct BorrowedWpeBuffer(NonNull<plat::WPEBuffer>);
+
+impl BorrowedWpeBuffer {
+    unsafe fn from_render_callback(buffer: *mut plat::WPEBuffer) -> Self {
+        Self(NonNull::new_unchecked(buffer))
+    }
+
+    unsafe fn import_pixels(
+        &self,
+        width: u32,
+        height: u32,
+    ) -> Result<BorrowedWpePixels<'_>, SoftwarePixelImportError> {
+        let mut error: *mut plat::GError = ptr::null_mut();
+        let bytes = plat::wpe_buffer_import_to_pixels(self.0.as_ptr(), &mut error);
+
+        if bytes.is_null() {
+            let message = if error.is_null() {
+                "pixel import failed without an error".to_owned()
+            } else {
+                let message = CStr::from_ptr((*error).message)
+                    .to_string_lossy()
+                    .into_owned();
+                plat::g_error_free(error);
+                message
+            };
+            return Err(SoftwarePixelImportError::Native(message));
+        }
+
+        let mut byte_len: plat::gsize = 0;
+        let data = plat::g_bytes_get_data(bytes, &mut byte_len);
+        if data.is_null() || byte_len == 0 {
+            return Err(SoftwarePixelImportError::Empty);
+        }
+
+        let byte_len = byte_len as usize;
+        let layout = SoftwarePixelLayout::new(width, height, byte_len)?;
+        let bytes = std::slice::from_raw_parts(data.cast(), byte_len);
+        Ok(BorrowedWpePixels { bytes, layout })
+    }
+}
+
+/// Pixels borrowed from a WPE buffer for the duration of the render callback.
+///
+/// `wpe_buffer_import_to_pixels` returns `(transfer none)`: the `GBytes` and
+/// its storage remain owned by `WPEBuffer`. Binding the resulting Rust slice
+/// to [`BorrowedWpeBuffer`] prevents it from escaping that borrow.
+struct BorrowedWpePixels<'buffer> {
+    bytes: &'buffer [u8],
+    layout: SoftwarePixelLayout,
+}
+
+impl<'buffer> BorrowedWpePixels<'buffer> {
+    fn into_bgra_opaque(self) -> Vec<u8> {
+        self.layout.copy_bgra_opaque(self.bytes)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum SoftwarePixelImportError {
+    #[error("{0}")]
+    Native(String),
+    #[error("software pixel import returned no data")]
+    Empty,
+    #[error(transparent)]
+    Layout(#[from] SoftwarePixelLayoutError),
+}
+
 /// Reactor-local acknowledgement for one buffer accepted by our custom
 /// `WPEView::render_buffer` implementation.
 ///
@@ -964,7 +1129,11 @@ unsafe fn capture_render_buffer(
     let width = plat::wpe_buffer_get_width(buffer) as u32;
     let height = plat::wpe_buffer_get_height(buffer) as u32;
 
-    if width == 0 || height == 0 || width > 8192 || height > 8192 {
+    if width == 0
+        || height == 0
+        || width > MAX_WPE_BUFFER_DIMENSION
+        || height > MAX_WPE_BUFFER_DIMENSION
+    {
         tracing::warn!(
             "render_buffer_callback: invalid dimensions {}x{}",
             width,
@@ -1064,91 +1233,26 @@ unsafe fn capture_pixels(
 ) -> Option<CapturedFrame> {
     tracing::trace!("render_buffer_callback: capturing software pixels");
 
-    let mut error: *mut plat::GError = ptr::null_mut();
-    let bytes = plat::wpe_buffer_import_to_pixels(buffer, &mut error);
-
-    if bytes.is_null() {
-        if !error.is_null() {
-            let msg = std::ffi::CStr::from_ptr((*error).message).to_string_lossy();
-            tracing::warn!("render_buffer_callback: pixel import failed: {}", msg);
-            plat::g_error_free(error);
-        } else {
-            tracing::warn!("render_buffer_callback: pixel import failed without an error");
+    let borrowed_buffer = BorrowedWpeBuffer::from_render_callback(buffer);
+    let imported = match borrowed_buffer.import_pixels(width, height) {
+        Ok(imported) => imported,
+        Err(error) => {
+            tracing::warn!("render_buffer_callback: {error}");
+            return None;
         }
-        return None;
-    }
-
-    let mut size: plat::gsize = 0;
-    let data = plat::g_bytes_get_data(bytes, &mut size);
-
-    if data.is_null() || size == 0 {
-        tracing::warn!("render_buffer_callback: empty pixel data");
-        plat::g_bytes_unref(bytes);
-        return None;
-    }
-
-    let size = size as usize;
-    let expected_size = (width * height * 4) as usize;
-    if size < expected_size {
-        tracing::warn!(
-            "render_buffer_callback: pixel data too small {} < {} for {}x{}",
-            size,
-            expected_size,
-            width,
-            height
-        );
-        plat::g_bytes_unref(bytes);
-        return None;
-    }
-
-    // Copy pixel data before callback returns
-    let pixel_data: Vec<u8> = std::slice::from_raw_parts(data as *const u8, size).to_vec();
-    plat::g_bytes_unref(bytes);
-
-    // Calculate actual stride from buffer size.
-    // wpe_buffer_import_to_pixels may return data with GPU-aligned stride
-    // (e.g., 832*4=3328 for a 784px-wide image padded to 64-pixel alignment).
-    let actual_stride = size / (height as usize);
-    let min_stride = (width as usize) * 4;
-    if actual_stride < min_stride {
-        tracing::warn!(
-            "render_buffer_callback: stride {} < min {} for width {}",
-            actual_stride,
-            min_stride,
-            width
-        );
-        return None;
-    }
+    };
     tracing::debug!(
         "render_buffer_callback: pixel data size={}, {}x{}, stride={} (min={})",
-        size,
+        imported.bytes.len(),
         width,
         height,
-        actual_stride,
-        min_stride
+        imported.layout.stride(),
+        width as usize * SOFTWARE_PIXEL_BYTES_PER_PIXEL
     );
 
     // Cairo ARGB32 / XRGB8888 format: bytes in memory [B, G, R, A/X] on little-endian.
     // Target: BGRA for wgpu Bgra8UnormSrgb — same byte order, just force alpha=255.
-    let mut pixels_with_alpha: Vec<u8> = Vec::with_capacity(expected_size);
-    for row in 0..(height as usize) {
-        let row_start = row * actual_stride;
-        for col in 0..(width as usize) {
-            let offset = row_start + col * 4;
-            if offset + 3 >= pixel_data.len() {
-                tracing::warn!(
-                    "render_buffer_callback: pixel data underflow at row={} col={}",
-                    row,
-                    col
-                );
-                return None;
-            }
-            pixels_with_alpha.push(pixel_data[offset]); // B
-            pixels_with_alpha.push(pixel_data[offset + 1]); // G
-            pixels_with_alpha.push(pixel_data[offset + 2]); // R
-            pixels_with_alpha.push(255); // A (force opaque)
-        }
-    }
+    let pixels_with_alpha = imported.into_bgra_opaque();
 
     Some(CapturedFrame::Pixels(RawFrameData {
         pixels: pixels_with_alpha,
@@ -1289,5 +1393,62 @@ mod guard_tests {
         // Exercises the String (owned) payload downcast branch.
         let neutral = guard_wpe_callback("test", -1, || panic!("{}", String::from("dynamic")));
         assert_eq!(neutral, -1);
+    }
+}
+
+#[cfg(test)]
+mod software_pixel_tests {
+    use super::{SoftwarePixelLayout, SoftwarePixelLayoutError};
+
+    #[test]
+    fn pixel_layout_accepts_padded_rows() {
+        let layout = SoftwarePixelLayout::new(784, 2, 6_656).unwrap();
+
+        assert_eq!(layout.stride(), 3_328);
+        assert_eq!(layout.packed_len(), 6_272);
+    }
+
+    #[test]
+    fn pixel_copy_discards_row_padding_and_forces_opaque_alpha() {
+        let layout = SoftwarePixelLayout::new(1, 2, 16).unwrap();
+        let imported = [1, 2, 3, 4, 90, 91, 92, 93, 5, 6, 7, 8, 94, 95, 96, 97];
+
+        assert_eq!(
+            layout.copy_bgra_opaque(&imported),
+            [1, 2, 3, 255, 5, 6, 7, 255]
+        );
+    }
+
+    #[test]
+    fn pixel_layout_rejects_an_import_larger_than_any_supported_frame() {
+        assert_eq!(
+            SoftwarePixelLayout::new(1_280, 1_122, 1_342_003_188_534_479_329),
+            Err(SoftwarePixelLayoutError::ExceedsFrameLimit {
+                actual: 1_342_003_188_534_479_329,
+                maximum: 268_435_456,
+            })
+        );
+    }
+
+    #[test]
+    fn pixel_layout_rejects_partial_rows() {
+        assert_eq!(
+            SoftwarePixelLayout::new(2, 2, 17),
+            Err(SoftwarePixelLayoutError::PartialRow {
+                byte_len: 17,
+                height: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn pixel_layout_rejects_short_rows() {
+        assert_eq!(
+            SoftwarePixelLayout::new(2, 2, 8),
+            Err(SoftwarePixelLayoutError::StrideTooShort {
+                actual: 4,
+                minimum: 8,
+            })
+        );
     }
 }

--- a/crates/neomacs-webview/src/platform/linux/view.rs
+++ b/crates/neomacs-webview/src/platform/linux/view.rs
@@ -13,6 +13,7 @@ use std::rc::Rc;
 use super::error::{DisplayError, DisplayResult};
 
 use super::display::{WpePlatformDisplay, buffer_dmabuf_info};
+use super::glib_error::GlibErrorSlot;
 use super::native;
 use super::sys::platform as plat;
 use super::sys::webkit as wk;
@@ -216,19 +217,11 @@ impl BorrowedWpeBuffer {
         width: u32,
         height: u32,
     ) -> Result<BorrowedWpePixels<'_>, SoftwarePixelImportError> {
-        let mut error: *mut plat::GError = ptr::null_mut();
-        let bytes = plat::wpe_buffer_import_to_pixels(self.0.as_ptr(), &mut error);
+        let mut error = GlibErrorSlot::new();
+        let bytes = plat::wpe_buffer_import_to_pixels(self.0.as_ptr(), error.out_ptr().cast());
 
         if bytes.is_null() {
-            let message = if error.is_null() {
-                "pixel import failed without an error".to_owned()
-            } else {
-                let message = CStr::from_ptr((*error).message)
-                    .to_string_lossy()
-                    .into_owned();
-                plat::g_error_free(error);
-                message
-            };
+            let message = error.into_message("pixel import failed without an error");
             return Err(SoftwarePixelImportError::Native(message));
         }
 
@@ -1025,19 +1018,13 @@ unsafe fn finish_script(
     web_view: *mut wk::WebKitWebView,
     result: *mut wk::GAsyncResult,
 ) -> Result<WebValue, ScriptError> {
-    let mut error = ptr::null_mut();
-    let value = wk::webkit_web_view_evaluate_javascript_finish(web_view, result, &mut error);
-    if !error.is_null() {
-        let glib_error = error.cast::<plat::GError>();
-        let message = if (*glib_error).message.is_null() {
-            "WebKit rejected script evaluation".to_owned()
-        } else {
-            CStr::from_ptr((*glib_error).message)
-                .to_string_lossy()
-                .into_owned()
-        };
-        plat::g_error_free(glib_error);
-        return Err(ScriptError::Rejected(message));
+    let mut error = GlibErrorSlot::new();
+    let value =
+        wk::webkit_web_view_evaluate_javascript_finish(web_view, result, error.out_ptr().cast());
+    if error.is_set() {
+        return Err(ScriptError::Rejected(
+            error.into_message("WebKit rejected script evaluation"),
+        ));
     }
     if value.is_null() {
         return Err(ScriptError::ProcessFailed);

--- a/crates/neomacs-webview/src/system.rs
+++ b/crates/neomacs-webview/src/system.rs
@@ -42,11 +42,49 @@ impl DesiredWebView {
     fn set_navigation(&mut self, navigation: NavigationTarget) {
         self.create.initial_navigation = Some(navigation);
     }
+
+    fn mutable_state(&self) -> MutableWebViewState {
+        MutableWebViewState {
+            model_size: self.create.initial_size,
+            navigation: self.create.initial_navigation.clone(),
+        }
+    }
+}
+
+/// The declarative fields that may change while native creation is in flight.
+///
+/// Native creation receives a snapshot of this state. Keeping that snapshot
+/// beside the pending handle lets completion converge to the latest desired
+/// state before clients can observe `Ready`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MutableWebViewState {
+    model_size: WebContentSize,
+    navigation: Option<NavigationTarget>,
+}
+
+impl MutableWebViewState {
+    fn submitted(request: &PlatformCreateRequest) -> Self {
+        Self {
+            model_size: request.size(),
+            navigation: request.navigation().cloned(),
+        }
+    }
+}
+
+struct PendingViewCreate<C> {
+    handle: C,
+    submitted: MutableWebViewState,
+}
+
+#[derive(Clone, Copy)]
+enum CreationPresentationState {
+    NeedsConvergence,
+    AppliedByActivation,
 }
 
 enum Lifecycle<P: Platform> {
     Waiting(MissingPrerequisites),
-    Creating(P::PendingCreate),
+    Creating(PendingViewCreate<P::PendingCreate>),
     Ready(P::View),
     Failed(String),
     Closing,
@@ -243,11 +281,22 @@ impl<P: Platform> WebViewSystemImpl<P> {
         generation: WebViewGeneration,
         request: PlatformCreateRequest,
     ) -> Lifecycle<P> {
+        let submitted = MutableWebViewState::submitted(&request);
         match self.platform.begin_create(request) {
-            Ok(CreateOutcome::Ready(view)) => self.accept_created_view(id, generation, view),
+            Ok(CreateOutcome::Ready(view)) => self.accept_created_view(
+                id,
+                generation,
+                view,
+                submitted.clone(),
+                submitted,
+                CreationPresentationState::NeedsConvergence,
+            ),
             Ok(CreateOutcome::Pending(mut pending)) => {
                 let Some((host, placement)) = self.active_placement(id) else {
-                    return Lifecycle::Creating(pending);
+                    return Lifecycle::Creating(PendingViewCreate {
+                        handle: pending,
+                        submitted,
+                    });
                 };
                 match self.platform.activate_pending(
                     generation,
@@ -257,8 +306,18 @@ impl<P: Platform> WebViewSystemImpl<P> {
                         placement: &placement,
                     },
                 ) {
-                    Ok(Some(view)) => self.accept_created_view(id, generation, view),
-                    Ok(None) => Lifecycle::Creating(pending),
+                    Ok(Some(view)) => self.accept_created_view(
+                        id,
+                        generation,
+                        view,
+                        submitted.clone(),
+                        submitted,
+                        CreationPresentationState::AppliedByActivation,
+                    ),
+                    Ok(None) => Lifecycle::Creating(PendingViewCreate {
+                        handle: pending,
+                        submitted,
+                    }),
                     Err(error) => self.failed_lifecycle(id, generation, error),
                 }
             }
@@ -286,8 +345,16 @@ impl<P: Platform> WebViewSystemImpl<P> {
         id: WebViewId,
         generation: WebViewGeneration,
         mut view: P::View,
+        submitted: MutableWebViewState,
+        desired: MutableWebViewState,
+        presentation: CreationPresentationState,
     ) -> Lifecycle<P> {
-        if let Some((host, placement)) = self.active_placement(id)
+        if let Err(error) = self.converge_created_view(id, &mut view, &submitted, &desired) {
+            self.platform.close(view);
+            return self.failed_lifecycle(id, generation, error);
+        }
+        if matches!(presentation, CreationPresentationState::NeedsConvergence)
+            && let Some((host, placement)) = self.active_placement(id)
             && let Err(error) = self.platform.present(
                 generation,
                 &mut view,
@@ -302,6 +369,28 @@ impl<P: Platform> WebViewSystemImpl<P> {
         }
         self.events.push(WebViewEvent::Ready { id, generation });
         Lifecycle::Ready(view)
+    }
+
+    fn converge_created_view(
+        &mut self,
+        id: WebViewId,
+        view: &mut P::View,
+        submitted: &MutableWebViewState,
+        desired: &MutableWebViewState,
+    ) -> Result<(), String> {
+        if desired.model_size != submitted.model_size {
+            self.platform
+                .update(view, PlatformUpdate::ModelSize(desired.model_size))
+                .map_err(|error| format!("failed to apply latest model size to {id:?}: {error}"))?;
+        }
+        if desired.navigation != submitted.navigation
+            && let Some(target) = desired.navigation.as_ref()
+        {
+            self.platform
+                .update(view, PlatformUpdate::Navigation(target))
+                .map_err(|error| format!("failed to apply latest navigation to {id:?}: {error}"))?;
+        }
+        Ok(())
     }
 
     fn failed_lifecycle(
@@ -511,26 +600,33 @@ impl<P: Platform> WebViewSystemImpl<P> {
                         view: *view_id,
                         error,
                     })?,
-                Lifecycle::Creating(pending) => {
-                    match self
-                        .platform
-                        .activate_pending(record.generation, pending, presentation)
-                    {
-                        Ok(Some(view)) => {
-                            record.lifecycle = Lifecycle::Ready(view);
-                            self.events.push(WebViewEvent::Ready {
-                                id: *view_id,
-                                generation: record.generation,
-                            });
-                        }
-                        Ok(None) => {}
-                        Err(error) => {
-                            record.lifecycle = Lifecycle::Failed(error.clone());
-                            self.events.push(WebViewEvent::Failed {
-                                id: *view_id,
-                                generation: record.generation,
-                                error: error.clone(),
-                            });
+                Lifecycle::Creating(creating) => match self.platform.activate_pending(
+                    record.generation,
+                    &mut creating.handle,
+                    presentation,
+                ) {
+                    Ok(Some(view)) => {
+                        let generation = record.generation;
+                        let submitted = creating.submitted.clone();
+                        let desired = record.desired.mutable_state();
+                        let _ = record;
+                        let lifecycle = self.accept_created_view(
+                            *view_id,
+                            generation,
+                            view,
+                            submitted,
+                            desired,
+                            CreationPresentationState::AppliedByActivation,
+                        );
+                        let failure = match &lifecycle {
+                            Lifecycle::Failed(error) => Some(error.clone()),
+                            _ => None,
+                        };
+                        self.views
+                            .get_mut(view_id)
+                            .expect("the activated create is still current")
+                            .lifecycle = lifecycle;
+                        if let Some(error) = failure {
                             return Err(WebViewPresentationError::Backend {
                                 host,
                                 view: *view_id,
@@ -538,7 +634,21 @@ impl<P: Platform> WebViewSystemImpl<P> {
                             });
                         }
                     }
-                }
+                    Ok(None) => {}
+                    Err(error) => {
+                        record.lifecycle = Lifecycle::Failed(error.clone());
+                        self.events.push(WebViewEvent::Failed {
+                            id: *view_id,
+                            generation: record.generation,
+                            error: error.clone(),
+                        });
+                        return Err(WebViewPresentationError::Backend {
+                            host,
+                            view: *view_id,
+                            error,
+                        });
+                    }
+                },
                 Lifecycle::Waiting(_) | Lifecycle::Failed(_) | Lifecycle::Closing => {}
             }
         }
@@ -710,18 +820,30 @@ impl<P: Platform> WebViewSystemImpl<P> {
         generation: WebViewGeneration,
         result: Result<P::View, String>,
     ) {
-        let is_current_create = self.views.get(&id).is_some_and(|record| {
-            record.generation == generation && matches!(record.lifecycle, Lifecycle::Creating(_))
-        });
-        if !is_current_create {
+        let Some((submitted, desired)) = self.views.get(&id).and_then(|record| {
+            if record.generation != generation {
+                return None;
+            }
+            let Lifecycle::Creating(creating) = &record.lifecycle else {
+                return None;
+            };
+            Some((creating.submitted.clone(), record.desired.mutable_state()))
+        }) else {
             if let Ok(view) = result {
                 self.platform.close(view);
             }
             return;
-        }
+        };
 
         let lifecycle = match result {
-            Ok(view) => self.accept_created_view(id, generation, view),
+            Ok(view) => self.accept_created_view(
+                id,
+                generation,
+                view,
+                submitted,
+                desired,
+                CreationPresentationState::NeedsConvergence,
+            ),
             Err(error) => self.failed_lifecycle(id, generation, error),
         };
         self.views

--- a/crates/neomacs-webview/src/system_test.rs
+++ b/crates/neomacs-webview/src/system_test.rs
@@ -27,6 +27,13 @@ struct FakePlatform {
     inputs: Vec<(WebViewGeneration, WebViewInput)>,
     presentations: Vec<(WebViewGeneration, Option<WebViewOccurrenceId>)>,
     presented_host_identities: Vec<u64>,
+    updates: Vec<FakeUpdate>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum FakeUpdate {
+    ModelSize(WebContentSize),
+    Navigation(NavigationTarget),
 }
 
 #[derive(Debug)]
@@ -103,6 +110,25 @@ impl Platform for FakePlatform {
         input: WebViewInput,
     ) -> Result<(), String> {
         self.inputs.push((generation, input));
+        Ok(())
+    }
+
+    fn update(
+        &mut self,
+        _view: &mut Self::View,
+        update: crate::backend::PlatformUpdate<'_>,
+    ) -> Result<(), String> {
+        match update {
+            crate::backend::PlatformUpdate::ModelSize(size) => {
+                self.updates.push(FakeUpdate::ModelSize(size));
+            }
+            crate::backend::PlatformUpdate::Navigation(target) => {
+                self.updates.push(FakeUpdate::Navigation(target.clone()));
+            }
+            crate::backend::PlatformUpdate::History(_)
+            | crate::backend::PlatformUpdate::EvaluateScript(_)
+            | crate::backend::PlatformUpdate::Focus(_) => {}
+        }
         Ok(())
     }
 
@@ -268,6 +294,47 @@ fn pre_ready_state_converges_before_native_creation() {
             id,
             generation: WebViewGeneration::new(1),
         }]
+    );
+}
+
+#[test]
+fn desired_state_changed_during_native_creation_converges_before_ready() {
+    let id = WebViewId::new(19);
+    let host = HostWindowId::new(1);
+    let mut platform = FakePlatform {
+        asynchronous: true,
+        ..FakePlatform::default()
+    };
+    platform.hosts.insert(host);
+    let mut system = WebViewSystemImpl::new(platform);
+
+    system.command(WebViewCommand::Create(create(id))).unwrap();
+    system
+        .command(WebViewCommand::SetModelSize {
+            id,
+            size: WebContentSize::new(800, 600).unwrap(),
+        })
+        .unwrap();
+    system
+        .command(WebViewCommand::Navigate {
+            id,
+            target: NavigationTarget::Uri("https://latest.invalid/".into()),
+        })
+        .unwrap();
+
+    system
+        .platform_mut()
+        .complete(id, WebViewGeneration::new(1));
+    system.service();
+
+    assert_eq!(system.state(id), Some(WebViewState::Ready));
+    assert_eq!(
+        system.platform().updates,
+        vec![
+            FakeUpdate::ModelSize(WebContentSize::new(800, 600).unwrap()),
+            FakeUpdate::Navigation(NavigationTarget::Uri("https://latest.invalid/".into())),
+        ],
+        "a view must observe the latest declarative state before Ready"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #301. An xwidget wider than the room remaining in a row was produced, then removed by the body row's generic overflow rollback while its source character was still consumed. The result contained no `FrameGlyph::Xwidget`, so every backend correctly hid the view and showed only the buffer background.

GNU Emacs handles xwidgets specially in `produce_xwidget_glyph`: it may crop the glyph's layout advance to the remaining row width, while `x_draw_xwidget_glyph_string` keeps the native widget at its intrinsic size and clips its presentation to the window text area. Narrow mid-row xwidgets are left whole; `display_line` retains them in truncating rows and the presentation clip limits visibility.

## Design

- `DisplayXwidgetOverflowAction` is xwidget-only. Images, videos, and shader surfaces retain their existing behavior; GNU's distinct image policy is not generalized here.
- `XwidgetPresentationGeometry<Space>` carries three separate concepts through layout, frame materialization, child-frame translation, rendering, native placement, and pointer hit-testing:
  - intrinsic `XwidgetContentExtent`;
  - typed `XwidgetLayoutAdvance`;
  - the visible clip in a branded coordinate space.
- `WindowLocalRowExtent` converts frame coordinates once, validates finite ordered geometry, and implements GNU's window-local quarter-width predicate. Invalid intervals cannot reach the crop policy.
- `DisplayItemRightEdgeAdmission::PreserveWholeXwidget` is the typed, exhaustive exception that permits only GNU's `LeaveWhole` xwidget case past the row boundary. Frame materialization preserves that whole advance instead of replacing it with the visible slice.
- Renderer composition and pointer dispatch resolve the same presentation geometry, preventing viewport, pixels, and hit targets from drifting apart.

## WebView reliability found by the strict GUI test

The end-to-end test initially exposed two independent Linux backend defects that prevented reliable pixel verification:

- desired navigation/visibility state submitted while native creation was asynchronous was not reconciled before `Ready`;
- WPE pixel imports are borrowed, but Neomacs unreferenced the cached `GBytes`, causing use-after-free behavior on later callbacks.

The lifecycle now converges through typed pending/desired state, and the WPE boundary uses borrowed wrappers plus validated software pixel layouts. The incorrect unref is no longer available in the generated binding surface.

## Tests

- Red-first layout regressions cover an oversized xwidget, a right-hand split, line-number-origin semantics, GNU's narrow `LeaveWhole` case, tall clipping, and invalid row geometry.
- Protocol/runtime/renderer tests cover content-vs-advance-vs-clip preservation, coordinate translation, composition, and hit-testing.
- A Linux real-GUI test loads a deterministic magenta `data:` page in an xwidget twice the live text-area size, asserts the semantic glyph geometry, and verifies actual pixels in the PNG. It passed 5 consecutive Wayland runs and 3 consecutive X11 runs.
- All 12 focused layout xwidget/geometry tests pass; all 52 `neomacs-webview` tests pass.

Known GNU gaps are documented next to the policy: zero-room glyphs, positive box-line widths, horizontal scrolling across `first_visible_x`, and GNU's ascent/descent split.
