### PR TITLE
Keep cursor and page motion out of folded Org drawers

### DIFF
--- a/crates/neomacs-layout-engine/src/buffer_source/window_source.rs
+++ b/crates/neomacs-layout-engine/src/buffer_source/window_source.rs
@@ -1,6 +1,6 @@
 //! Buffer window source read bounds and text extraction.
 
-use crate::neovm_bridge::{LayoutBufferView, RustBufferAccess};
+use crate::neovm_bridge::{LayoutBufferView, RustBufferAccess, RustTextPropAccess};
 use crate::scroll_policy::{
     ForwardScroll, ScrollPolicy, count_lines_bounded, last_usable_row, line_start_above,
     line_start_below, top_margin,
@@ -190,9 +190,79 @@ impl BufferWindowSourceRequest {
         self,
         access: &RustBufferAccess<'_, B>,
     ) -> ResolvedWindowStart {
+        let requested = self
+            .requested_window_start
+            .clamp(self.accessible_start, self.accessible_end);
+        if self.point_fits_visible_budget_through_folds(requested, access) {
+            return ResolvedWindowStart(requested);
+        }
         ResolvedWindowStart(
             self.resolve_window_start(|charpos| access.byte_at(access.charpos_to_bytepos(charpos))),
         )
+    }
+
+    /// Whether POINT still fits in the current viewport once invisible source
+    /// runs are elided.  The ordinary source preflight counts logical newlines;
+    /// a large folded Org drawer therefore looks hundreds of rows tall and can
+    /// recenter the window into the hidden LOGBOOK even though point is only a
+    /// few DISPLAY rows below the current start.  GNU makes this decision with
+    /// its display iterator, which skips the fold.  Keep the requested start
+    /// when a bounded display-aware scan proves point still fits.
+    fn point_fits_visible_budget_through_folds<B: LayoutBufferView>(
+        self,
+        window_start: i64,
+        access: &RustBufferAccess<'_, B>,
+    ) -> bool {
+        if self.point_charpos < window_start || self.point_charpos > self.accessible_end {
+            return false;
+        }
+        let row_budget = last_usable_row(self.max_rows, self.scroll_margin).max(1);
+        let props = RustTextPropAccess::new(access.view());
+        let mut pos = window_start;
+        let mut row = 0i64;
+        let mut col = 0i64;
+        let mut crossed_fold = false;
+
+        while pos < self.point_charpos && row <= row_budget {
+            let (status, next_visible) = props.check_invisible(pos);
+            if status.hidden {
+                crossed_fold = true;
+                if status.ellipsis {
+                    col += 3;
+                    row += col / self.visible_cols;
+                    col %= self.visible_cols;
+                }
+                pos = next_visible.max(pos + 1).min(self.accessible_end);
+                continue;
+            }
+
+            match access.byte_at(access.charpos_to_bytepos(pos)) {
+                Some(b'\n') => {
+                    row += 1;
+                    col = 0;
+                }
+                Some(b'\t') => {
+                    // The request deliberately has no full tab-stop state;
+                    // charging a whole conventional tab stop is safer than
+                    // treating a tab as one ordinary glyph in this preflight.
+                    col += 8;
+                    row += col / self.visible_cols;
+                    col %= self.visible_cols;
+                }
+                Some(_) => {
+                    // Two columns is conservative for ordinary wide glyphs;
+                    // if that already fits, the hidden logical lines cannot be
+                    // a valid reason to recenter into the fold.
+                    col += 2;
+                    row += col / self.visible_cols;
+                    col %= self.visible_cols;
+                }
+                None => break,
+            }
+            pos += 1;
+        }
+
+        crossed_fold && row <= row_budget
     }
 
     /// Treat the requested start as authoritative, clamped only to the live

--- a/crates/neomacs-layout-engine/src/buffer_source/window_source.rs
+++ b/crates/neomacs-layout-engine/src/buffer_source/window_source.rs
@@ -1,6 +1,6 @@
 //! Buffer window source read bounds and text extraction.
 
-use crate::neovm_bridge::{LayoutBufferView, RustBufferAccess, RustTextPropAccess};
+use crate::neovm_bridge::{ForwardScrollMeasurement, LayoutBufferView, RustBufferAccess};
 use crate::scroll_policy::{
     ForwardScroll, ScrollPolicy, count_lines_bounded, last_usable_row, line_start_above,
     line_start_below, top_margin,
@@ -56,7 +56,6 @@ pub(crate) struct BufferWindowSourceRequest {
     accessible_start: i64,
     accessible_end: i64,
     max_rows: usize,
-    visible_cols: i64,
     kind: WindowKind,
     scroll_policy: ScrollPolicy,
     scroll_margin: i64,
@@ -114,7 +113,6 @@ impl BufferWindowSourceRequest {
             params.accessible_start_charpos().get(),
             params.accessible_end_charpos().get(),
             max_rows,
-            visible_cols_for_window_params(params),
             params.kind,
             ScrollPolicy::from_window_params(params),
             params.scroll_margin,
@@ -143,7 +141,6 @@ impl BufferWindowSourceRequest {
         accessible_start: i64,
         accessible_end: i64,
         max_rows: usize,
-        visible_cols: i64,
         kind: WindowKind,
         scroll_policy: ScrollPolicy,
         scroll_margin: i64,
@@ -159,7 +156,6 @@ impl BufferWindowSourceRequest {
             accessible_start,
             accessible_end,
             max_rows,
-            visible_cols: visible_cols.max(1),
             kind,
             scroll_policy,
             scroll_margin,
@@ -193,76 +189,33 @@ impl BufferWindowSourceRequest {
         let requested = self
             .requested_window_start
             .clamp(self.accessible_start, self.accessible_end);
-        if self.point_fits_visible_budget_through_folds(requested, access) {
-            return ResolvedWindowStart(requested);
-        }
-        ResolvedWindowStart(
-            self.resolve_window_start(|charpos| access.byte_at(access.charpos_to_bytepos(charpos))),
-        )
+        let measurement = self.forward_scroll_measurement(requested, access);
+        ResolvedWindowStart(self.resolve_window_start_with_measurement(
+            |charpos| access.byte_at(access.charpos_to_bytepos(charpos)),
+            measurement,
+        ))
     }
 
-    /// Whether POINT still fits in the current viewport once invisible source
-    /// runs are elided.  The ordinary source preflight counts logical newlines;
-    /// a large folded Org drawer therefore looks hundreds of rows tall and can
-    /// recenter the window into the hidden LOGBOOK even though point is only a
-    /// few DISPLAY rows below the current start.  GNU makes this decision with
-    /// its display iterator, which skips the fold.  Keep the requested start
-    /// when a bounded display-aware scan proves point still fits.
-    fn point_fits_visible_budget_through_folds<B: LayoutBufferView>(
+    fn forward_scroll_measurement<B: LayoutBufferView>(
         self,
         window_start: i64,
         access: &RustBufferAccess<'_, B>,
-    ) -> bool {
-        if self.point_charpos < window_start || self.point_charpos > self.accessible_end {
-            return false;
-        }
-        let row_budget = last_usable_row(self.max_rows, self.scroll_margin).max(1);
-        let props = RustTextPropAccess::new(access.view());
-        let mut pos = window_start;
-        let mut row = 0i64;
-        let mut col = 0i64;
-        let mut crossed_fold = false;
-
-        while pos < self.point_charpos && row <= row_budget {
-            let (status, next_visible) = props.check_invisible(pos);
-            if status.hidden {
-                crossed_fold = true;
-                if status.ellipsis {
-                    col += 3;
-                    row += col / self.visible_cols;
-                    col %= self.visible_cols;
-                }
-                pos = next_visible.max(pos + 1).min(self.accessible_end);
-                continue;
+    ) -> ForwardScrollMeasurement {
+        let scan_start = match self.previous_viewport_point_relation() {
+            PreviousViewportPointRelation::Visible
+            | PreviousViewportPointRelation::NeedsMeasuredLayout => {
+                return ForwardScrollMeasurement::SourceLineEstimate;
             }
-
-            match access.byte_at(access.charpos_to_bytepos(pos)) {
-                Some(b'\n') => {
-                    row += 1;
-                    col = 0;
-                }
-                Some(b'\t') => {
-                    // The request deliberately has no full tab-stop state;
-                    // charging a whole conventional tab stop is safer than
-                    // treating a tab as one ordinary glyph in this preflight.
-                    col += 8;
-                    row += col / self.visible_cols;
-                    col %= self.visible_cols;
-                }
-                Some(_) => {
-                    // Two columns is conservative for ordinary wide glyphs;
-                    // if that already fits, the hidden logical lines cannot be
-                    // a valid reason to recenter into the fold.
-                    col += 2;
-                    row += col / self.visible_cols;
-                    col %= self.visible_cols;
-                }
-                None => break,
-            }
-            pos += 1;
+            PreviousViewportPointRelation::Below {
+                visible_end_exclusive,
+            } => visible_end_exclusive,
+            PreviousViewportPointRelation::Unknown => window_start,
+        };
+        if self.point_charpos <= scan_start {
+            return ForwardScrollMeasurement::SourceLineEstimate;
         }
 
-        crossed_fold && row <= row_budget
+        access.forward_scroll_measurement(scan_start, self.point_charpos)
     }
 
     /// Treat the requested start as authoritative, clamped only to the live
@@ -346,7 +299,19 @@ impl BufferWindowSourceRequest {
         }
     }
 
+    #[cfg(test)]
     fn resolve_window_start(self, byte_at_charpos: impl Fn(i64) -> Option<u8>) -> i64 {
+        self.resolve_window_start_with_measurement(
+            byte_at_charpos,
+            ForwardScrollMeasurement::SourceLineEstimate,
+        )
+    }
+
+    fn resolve_window_start_with_measurement(
+        self,
+        byte_at_charpos: impl Fn(i64) -> Option<u8>,
+        forward_measurement: ForwardScrollMeasurement,
+    ) -> i64 {
         let mut window_start = self.requested_window_start.max(self.accessible_start);
 
         if window_start > self.accessible_start {
@@ -371,7 +336,9 @@ impl BufferWindowSourceRequest {
             return adjusted;
         }
 
-        if let Some(adjusted) = self.forward_scroll_window_start(window_start, &byte_at_charpos) {
+        if let Some(adjusted) =
+            self.forward_scroll_window_start(window_start, forward_measurement, &byte_at_charpos)
+        {
             tracing::debug!(
                 "layout_window_rust: forward-adjusted window_start {} -> {} (point={})",
                 self.requested_window_start,
@@ -442,6 +409,7 @@ impl BufferWindowSourceRequest {
     fn forward_scroll_window_start(
         self,
         window_start: i64,
+        measurement: ForwardScrollMeasurement,
         byte_at_charpos: &impl Fn(i64) -> Option<u8>,
     ) -> Option<i64> {
         if self.kind.is_minibuffer() {
@@ -469,6 +437,9 @@ impl BufferWindowSourceRequest {
             PreviousViewportPointRelation::Below {
                 visible_end_exclusive: end,
             } => {
+                if measurement == ForwardScrollMeasurement::DisplayRowsRequired {
+                    return None;
+                }
                 let (extra_lines, bounded) = count_lines_bounded(
                     end,
                     self.point_charpos,
@@ -477,12 +448,17 @@ impl BufferWindowSourceRequest {
                 );
                 (self.max_rows as i64 + extra_lines, bounded)
             }
-            PreviousViewportPointRelation::Unknown => count_lines_bounded(
-                window_start,
-                self.point_charpos,
-                bottom_row + self.scroll_policy.search_limit_lines(),
-                byte_at_charpos,
-            ),
+            PreviousViewportPointRelation::Unknown => {
+                if measurement == ForwardScrollMeasurement::DisplayRowsRequired {
+                    return None;
+                }
+                count_lines_bounded(
+                    window_start,
+                    self.point_charpos,
+                    bottom_row + self.scroll_policy.search_limit_lines(),
+                    byte_at_charpos,
+                )
+            }
         };
         // GNU's `dy`: how far point falls past the last row the bottom
         // scroll-margin leaves usable (xdisp.c:19443). `<= 0` means point is
@@ -519,13 +495,6 @@ impl BufferWindowSourceRequest {
             byte_at_charpos,
         )
     }
-}
-
-fn visible_cols_for_window_params(params: &WindowParams) -> i64 {
-    let char_width = params.char_width.max(1.0);
-    (params.text_bounds.width.max(1.0) / char_width)
-        .floor()
-        .max(1.0) as i64
 }
 
 #[cfg(test)]

--- a/crates/neomacs-layout-engine/src/buffer_source/window_source_test.rs
+++ b/crates/neomacs-layout-engine/src/buffer_source/window_source_test.rs
@@ -1,7 +1,10 @@
 use super::*;
+use crate::neovm_bridge::RustBufferAccess;
 use crate::scroll_policy::ScrollPolicy;
 use crate::types::{DisplayLineNumbersMode, LineWrapMode, WindowKind, WindowParams};
 use neomacs_display_protocol::types::Rect;
+use neovm_core::buffer::{EmacsBytePos, EmacsByteRange};
+use neovm_core::emacs_core::{Context, Value};
 
 fn window_params() -> WindowParams {
     WindowParams {
@@ -95,7 +98,6 @@ fn request(
         0,
         accessible_end,
         max_rows,
-        20,
         kind,
         scroll_policy,
         0,
@@ -116,7 +118,6 @@ fn source_request_from_window_params_carries_source_bounds() {
     assert_eq!(request.accessible_start, 3);
     assert_eq!(request.accessible_end, 80);
     assert_eq!(request.max_rows, 6);
-    assert_eq!(request.visible_cols, 20);
     assert!(!request.kind.is_minibuffer());
 }
 
@@ -132,15 +133,107 @@ fn source_request_from_window_params_resolves_the_scroll_policy() {
 }
 
 #[test]
-fn source_request_from_window_params_uses_text_bounds_columns() {
-    let mut params = window_params();
-    params.bounds.width = 1000.0;
-    params.text_bounds.width = 48.0;
-    params.char_width = 12.0;
+fn source_request_defers_folded_row_visibility_to_the_display_walk() {
+    let mut eval = Context::new();
+    let buffer_id = eval
+        .buffer_manager()
+        .current_buffer()
+        .expect("current buffer")
+        .id();
+    let hidden = (0..80)
+        .map(|index| format!("hidden state {index}\n"))
+        .collect::<String>();
+    let text = format!("{}\n{hidden}after\n", "x".repeat(30));
+    let hidden_start = 31;
+    let point = text.find("after").expect("point after fold");
+    {
+        let buffer = eval
+            .buffer_manager_mut()
+            .get_mut(buffer_id)
+            .expect("current buffer");
+        buffer.insert(&text);
+        buffer.set_buffer_local(
+            "buffer-invisibility-spec",
+            Value::list(vec![Value::cons(Value::symbol("folded"), Value::T)]),
+        );
+        assert!(buffer.text_props_put_property_in_emacs_byte_range(
+            EmacsByteRange::new(EmacsBytePos::new(hidden_start), EmacsBytePos::new(point)),
+            Value::symbol("invisible"),
+            Value::symbol("folded"),
+        ));
+    }
 
-    let request = BufferWindowSourceRequest::from_window_params(&params, 6);
+    let request = BufferWindowSourceRequest::new(
+        0,
+        None,
+        point as i64,
+        0,
+        text.len() as i64,
+        4,
+        WindowKind::Main,
+        ScrollPolicy::Recenter,
+        0,
+    );
+    let buffer = eval
+        .buffer_manager()
+        .get(buffer_id)
+        .expect("current buffer");
 
-    assert_eq!(request.visible_cols, 4);
+    assert_eq!(
+        request.resolve(&RustBufferAccess::new(buffer)).get(),
+        0,
+        "folded source lines must be measured by the canonical display walk before scrolling"
+    );
+}
+
+#[test]
+fn source_request_defers_replacing_display_spans_to_the_display_walk() {
+    let mut eval = Context::new();
+    let buffer_id = eval
+        .buffer_manager()
+        .current_buffer()
+        .expect("current buffer")
+        .id();
+    let replaced = (0..80)
+        .map(|index| format!("replaced source line {index}\n"))
+        .collect::<String>();
+    let text = format!("{}\n{replaced}after\n", "x".repeat(30));
+    let replaced_start = 31;
+    let point = text.find("after").expect("point after replacement");
+    {
+        let buffer = eval
+            .buffer_manager_mut()
+            .get_mut(buffer_id)
+            .expect("current buffer");
+        buffer.insert(&text);
+        assert!(buffer.text_props_put_property_in_emacs_byte_range(
+            EmacsByteRange::new(EmacsBytePos::new(replaced_start), EmacsBytePos::new(point)),
+            Value::symbol("display"),
+            Value::string("replacement"),
+        ));
+    }
+
+    let request = BufferWindowSourceRequest::new(
+        0,
+        None,
+        point as i64,
+        0,
+        text.len() as i64,
+        4,
+        WindowKind::Main,
+        ScrollPolicy::Recenter,
+        0,
+    );
+    let buffer = eval
+        .buffer_manager()
+        .get(buffer_id)
+        .expect("current buffer");
+
+    assert_eq!(
+        request.resolve(&RustBufferAccess::new(buffer)).get(),
+        0,
+        "replacing display spans must use their rendered rows before scrolling"
+    );
 }
 
 // 6 single-letter lines; line N is the letter at charpos 2*(N-1).

--- a/crates/neomacs-layout-engine/src/display_text_window_row_lifecycle.rs
+++ b/crates/neomacs-layout-engine/src/display_text_window_row_lifecycle.rs
@@ -23,7 +23,7 @@ use crate::display_row::walk_state::{
 };
 use crate::display_status_line::ChromeRowRenderServices;
 use crate::hit_test::HitRow;
-use crate::neovm_bridge::{LayoutBufferView, RustBufferAccess};
+use crate::neovm_bridge::{ForwardScrollMeasurement, LayoutBufferView, RustBufferAccess};
 use crate::scroll_policy::{
     ForwardScroll, ScrollPolicy, count_lines_bounded, last_usable_row, line_start_above,
     line_start_below,
@@ -864,6 +864,27 @@ impl<'a, 'buf, B: LayoutBufferView> TextWindowVisibilityRetryRequest<'a, 'buf, B
         // `scroll_margin_y`, xdisp.c:19420).
         let laid_out_rows = visible_rows_below(self.rows, self.window_start);
         let bottom_row = last_usable_row(laid_out_rows as usize, self.scroll_margin);
+
+        // A point below the measured rows can be extrapolated in source lines
+        // only when source and display progress monotonically together.  If an
+        // intervening property may consume source text, advance solely through
+        // rows this render actually measured and retry from that proven
+        // boundary.  The next render can then walk the fold/replacement and
+        // either place point or make another measured step.
+        let first_unmeasured = visible_end_lisp
+            .map(crate::coords::lisp_char_pos_to_layout_i64)
+            .unwrap_or(self.charpos);
+        let forward_measurement = point_beyond_visible_span.then(|| {
+            self.buf_access
+                .forward_scroll_measurement(first_unmeasured, self.point_charpos)
+        });
+        if forward_measurement == Some(ForwardScrollMeasurement::DisplayRowsRequired) {
+            return next_window_start_from_visible_rows(
+                self.rows,
+                self.window_start,
+                laid_out_rows,
+            );
+        }
 
         // Which display row point landed on. Inside the laid-out rows this is
         // exact — it accounts for wrapped lines and for text the display hides.

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -9321,6 +9321,72 @@ fn implemented_text_backends_match_layout_frame_invisible_text_output() {
 }
 
 #[test]
+fn point_after_large_fold_keeps_visually_valid_window_start() {
+    let mut eval = Context::new();
+    let buf_id = eval
+        .buffer_manager()
+        .current_buffer()
+        .expect("current buffer")
+        .id();
+    let hidden = (0..80)
+        .map(|index| format!("hidden state {index}\n"))
+        .collect::<String>();
+    let text = format!("heading\n:LOGBOOK:\n{hidden}:END:\nafter\nnext\n");
+    let hidden_start = text.find("hidden state").expect("hidden start");
+    let hidden_end = text.find(":END:").expect("hidden end");
+    let after = text.find("after").expect("after");
+    {
+        let buf = eval.buffer_manager_mut().get_mut(buf_id).expect("buffer");
+        buf.insert(&text);
+        buf.set_buffer_local(
+            "buffer-invisibility-spec",
+            Value::list(vec![Value::cons(Value::symbol("folded"), Value::T)]),
+        );
+        assert!(buf.put_text_property(
+            hidden_start,
+            hidden_end,
+            Value::symbol("invisible"),
+            Value::symbol("folded"),
+        ));
+        buf.goto_emacs_byte_pos(EmacsBytePos::new(0));
+    }
+    let frame_id =
+        eval.frame_manager_mut()
+            .create_frame("point-after-large-fold", 640, 120, buf_id);
+    let selected_window = eval
+        .frame_manager()
+        .get(frame_id)
+        .expect("frame")
+        .selected_window;
+    let mut engine = LayoutEngine::new();
+    engine.layout_frame_rust(&mut eval, frame_id);
+
+    eval.buffer_manager_mut()
+        .goto_buffer_emacs_byte_pos(buf_id, EmacsBytePos::new(after));
+    let frame = eval.frame_manager_mut().get_mut(frame_id).expect("frame");
+    let neovm_core::window::Window::Leaf { point, .. } = frame
+        .find_window_mut(selected_window)
+        .expect("selected window")
+    else {
+        panic!("selected window is not a leaf");
+    };
+    *point = LispCharPos1::new((after + 1) as i64);
+    engine.layout_frame_rust(&mut eval, frame_id);
+
+    let frame = eval.frame_manager().get(frame_id).expect("frame");
+    let neovm_core::window::Window::Leaf { window_start, .. } =
+        frame.find_window(selected_window).expect("selected window")
+    else {
+        panic!("selected window is not a leaf");
+    };
+    assert_eq!(
+        *window_start,
+        LispCharPos1::ONE,
+        "hidden logical lines must not recenter a visually visible point into the fold"
+    );
+}
+
+#[test]
 fn layout_frame_rust_renders_invisible_ellipsis_through_row_builder() {
     let mut eval = Context::new();
     let buf_id = eval

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -9387,6 +9387,143 @@ fn point_after_large_fold_keeps_visually_valid_window_start() {
 }
 
 #[test]
+fn visibility_retry_never_places_window_start_inside_unmeasured_fold() {
+    let mut eval = Context::new();
+    let buf_id = eval
+        .buffer_manager()
+        .current_buffer()
+        .expect("current buffer")
+        .id();
+    let prefix = (0..12)
+        .map(|index| format!("visible prefix {index}\n"))
+        .collect::<String>();
+    let hidden = (0..80)
+        .map(|index| format!("hidden state {index}\n"))
+        .collect::<String>();
+    let text = format!("{prefix}{hidden}after\nnext\n");
+    let hidden_start = prefix.len();
+    let hidden_end = hidden_start + hidden.len();
+    let after = hidden_end;
+    {
+        let buf = eval.buffer_manager_mut().get_mut(buf_id).expect("buffer");
+        buf.insert(&text);
+        buf.set_buffer_local(
+            "buffer-invisibility-spec",
+            Value::list(vec![Value::cons(Value::symbol("folded"), Value::T)]),
+        );
+        assert!(buf.put_text_property(
+            hidden_start,
+            hidden_end,
+            Value::symbol("invisible"),
+            Value::symbol("folded"),
+        ));
+        buf.goto_emacs_byte_pos(EmacsBytePos::new(0));
+    }
+    let frame_id = eval.frame_manager_mut().create_frame(
+        "visibility-retry-across-large-fold",
+        640,
+        120,
+        buf_id,
+    );
+    let selected_window = eval
+        .frame_manager()
+        .get(frame_id)
+        .expect("frame")
+        .selected_window;
+    let mut engine = LayoutEngine::new();
+    engine.layout_frame_rust(&mut eval, frame_id);
+
+    eval.buffer_manager_mut()
+        .goto_buffer_emacs_byte_pos(buf_id, EmacsBytePos::new(after));
+    let frame = eval.frame_manager_mut().get_mut(frame_id).expect("frame");
+    let neovm_core::window::Window::Leaf { point, .. } = frame
+        .find_window_mut(selected_window)
+        .expect("selected window")
+    else {
+        panic!("selected window is not a leaf");
+    };
+    *point = LispCharPos1::new((after + 1) as i64);
+    engine.layout_frame_rust(&mut eval, frame_id);
+
+    let frame = eval.frame_manager().get(frame_id).expect("frame");
+    let neovm_core::window::Window::Leaf { window_start, .. } =
+        frame.find_window(selected_window).expect("selected window")
+    else {
+        panic!("selected window is not a leaf");
+    };
+    let start_byte = window_start.as_i64() as usize - 1;
+    assert!(
+        start_byte <= hidden_start || start_byte >= hidden_end,
+        "the retry must advance through measured display rows, not raw source lines; \
+         window-start={window_start:?}, hidden={hidden_start}..{hidden_end}"
+    );
+    assert!(
+        engine
+            .last_frame_display_state
+            .as_ref()
+            .and_then(|state| state.phys_cursor.as_ref())
+            .is_some(),
+        "the accepted retry must make point visibly placeable"
+    );
+}
+
+#[test]
+fn distant_point_with_unrelated_overlay_does_not_exhaust_visibility_retries() {
+    let mut eval = Context::new();
+    let buf_id = eval
+        .buffer_manager()
+        .current_buffer()
+        .expect("current buffer")
+        .id();
+    let text = (0..1_200)
+        .map(|index| format!("ordinary line {index}\n"))
+        .collect::<String>();
+    {
+        let buf = eval.buffer_manager_mut().get_mut(buf_id).expect("buffer");
+        buf.insert(&text);
+        buf.goto_emacs_byte_pos(EmacsBytePos::new(0));
+    }
+    eval.eval_str("(overlay-put (make-overlay 1 2) 'face 'bold)")
+        .expect("install unrelated face overlay");
+    let frame_id =
+        eval.frame_manager_mut()
+            .create_frame("distant-point-with-face-overlay", 640, 120, buf_id);
+    let selected_window = eval
+        .frame_manager()
+        .get(frame_id)
+        .expect("frame")
+        .selected_window;
+    let mut engine = LayoutEngine::new();
+    engine.layout_frame_rust(&mut eval, frame_id);
+
+    let point = text.rfind("ordinary line").expect("last line");
+    eval.buffer_manager_mut()
+        .goto_buffer_emacs_byte_pos(buf_id, EmacsBytePos::new(point));
+    let frame = eval.frame_manager_mut().get_mut(frame_id).expect("frame");
+    let neovm_core::window::Window::Leaf {
+        point: window_point,
+        ..
+    } = frame
+        .find_window_mut(selected_window)
+        .expect("selected window")
+    else {
+        panic!("selected window is not a leaf");
+    };
+    *window_point = LispCharPos1::new((point + 1) as i64);
+    engine.layout_frame_rust(&mut eval, frame_id);
+
+    assert!(
+        engine
+            .last_frame_display_state
+            .as_ref()
+            .and_then(|state| state.phys_cursor.as_ref())
+            .is_some(),
+        "a non-display overlay must not turn an ordinary jump into more than \
+         MAX_WINDOW_VISIBILITY_RETRIES screen-at-a-time retries"
+    );
+}
+
+#[test]
 fn layout_frame_rust_renders_invisible_ellipsis_through_row_builder() {
     let mut eval = Context::new();
     let buf_id = eval

--- a/crates/neomacs-layout-engine/src/neovm_bridge.rs
+++ b/crates/neomacs-layout-engine/src/neovm_bridge.rs
@@ -15,6 +15,7 @@ use neovm_core::emacs_core::effect_profile::{
     EffectScope, effect_name_from_lisp, effect_operation_from_lisp,
 };
 use neovm_core::emacs_core::image_catalog::image_scale_environment;
+use neovm_core::emacs_core::invisibility::{Invisibility, text_prop_means_invisible};
 use neovm_core::emacs_core::plist::plist_get;
 use neovm_core::emacs_core::symbol::Obarray;
 use neovm_core::emacs_core::textprop::{DirectCharProperties, resolve_effective_char_property};
@@ -1410,6 +1411,19 @@ pub(crate) fn buffer_selective_display<B: LayoutBufferView>(buffer: &B) -> i32 {
     }
 }
 
+/// Evidence available for estimating forward scrolling before all intervening
+/// display rows have been produced.
+///
+/// Counting source newlines can under-estimate display rows (wrapping and
+/// inserted display material), which a later measured retry can correct.  It
+/// must not over-estimate them: selective display, invisibility and replacing
+/// display properties can collapse many source lines into one display item.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ForwardScrollMeasurement {
+    SourceLineEstimate,
+    DisplayRowsRequired,
+}
+
 fn parse_color_pixel(value: &Value) -> Option<u32> {
     value
         .as_runtime_string_owned()
@@ -2401,6 +2415,29 @@ impl<'a, B: LayoutBufferView> RustBufferAccess<'a, B> {
         buffer_i64_charpos_to_emacs_byte_pos(self.buffer, charpos).get() as i64
     }
 
+    /// Classify an unmeasured layout-character span for forward scrolling.
+    ///
+    /// This is shared by pre-layout source selection and post-layout retries;
+    /// neither phase may silently fall back to source-line arithmetic across a
+    /// span whose display walk can consume or replace source text.
+    pub(crate) fn forward_scroll_measurement(
+        &self,
+        char_from: i64,
+        char_to: i64,
+    ) -> ForwardScrollMeasurement {
+        if char_to <= char_from {
+            return ForwardScrollMeasurement::SourceLineEstimate;
+        }
+        if buffer_selective_display(self.view()) != 0
+            || RustTextPropAccess::new(self.view())
+                .has_display_row_collapse_between(char_from, char_to)
+        {
+            ForwardScrollMeasurement::DisplayRowsRequired
+        } else {
+            ForwardScrollMeasurement::SourceLineEstimate
+        }
+    }
+
     /// Convert a GNU Lisp-visible buffer position to a byte position.
     ///
     /// GNU Lisp positions are 1-based, so this is only appropriate for
@@ -2958,7 +2995,25 @@ pub(crate) enum InvisibleStatus {
 }
 
 impl InvisibleStatus {
+    #[cfg(test)]
     const VISIBLE: Self = Self::Visible;
+
+    const fn from_invisibility(
+        invisibility: Invisibility,
+        origin: InvisiblePropertyOrigin,
+    ) -> Self {
+        match invisibility {
+            Invisibility::Visible => Self::Visible,
+            Invisibility::Hidden => Self::Hidden {
+                ellipsis: false,
+                origin,
+            },
+            Invisibility::HiddenWithEllipsis => Self::Hidden {
+                ellipsis: true,
+                origin,
+            },
+        }
+    }
 
     pub(crate) const fn hidden(self) -> bool {
         matches!(self, Self::Hidden { .. })
@@ -3034,91 +3089,15 @@ fn clamped_layout_emacs_byte_range<B: LayoutBufferView>(
     (from < to).then(|| EmacsByteRange::new(from, to))
 }
 
-fn invisible_atom_status(
-    prop_atom: Value,
-    spec: Value,
-    origin: InvisiblePropertyOrigin,
-) -> InvisibleStatus {
-    if spec.is_nil() {
-        return InvisibleStatus::VISIBLE;
-    }
-    if spec.is_t() {
-        return InvisibleStatus::Hidden {
-            ellipsis: false,
-            origin,
-        };
-    }
-
-    let mut cursor = spec;
-    while cursor.is_cons() {
-        let entry = cursor.cons_car();
-        if entry.is_cons() {
-            if eq_value(&entry.cons_car(), &prop_atom) {
-                return if entry.cons_cdr().is_nil() {
-                    InvisibleStatus::Hidden {
-                        ellipsis: false,
-                        origin,
-                    }
-                } else {
-                    InvisibleStatus::Hidden {
-                        ellipsis: true,
-                        origin,
-                    }
-                };
-            }
-        } else if eq_value(&entry, &prop_atom) {
-            return InvisibleStatus::Hidden {
-                ellipsis: false,
-                origin,
-            };
-        }
-        cursor = cursor.cons_cdr();
-    }
-
-    if eq_value(&spec, &prop_atom) {
-        InvisibleStatus::Hidden {
-            ellipsis: false,
-            origin,
-        }
-    } else {
-        InvisibleStatus::VISIBLE
-    }
-}
-
-fn invisible_prop_status(
+fn invisible_status_with_origin(
     prop: Option<Value>,
     spec: Value,
     origin: InvisiblePropertyOrigin,
 ) -> InvisibleStatus {
-    let Some(prop) = prop else {
-        return InvisibleStatus::VISIBLE;
-    };
-    if prop.is_nil() || spec.is_nil() {
-        return InvisibleStatus::VISIBLE;
-    }
-    if spec.is_t() {
-        return InvisibleStatus::Hidden {
-            ellipsis: false,
-            origin,
-        };
-    }
-
-    if prop.is_cons() {
-        let mut cursor = prop;
-        while cursor.is_cons() {
-            let status = invisible_atom_status(cursor.cons_car(), spec, origin);
-            if status.hidden() {
-                return status;
-            }
-            cursor = cursor.cons_cdr();
-        }
-        if !cursor.is_nil() {
-            return invisible_atom_status(cursor, spec, origin);
-        }
-        InvisibleStatus::VISIBLE
-    } else {
-        invisible_atom_status(prop, spec, origin)
-    }
+    let invisibility = prop.map_or(Invisibility::Visible, |property| {
+        text_prop_means_invisible(property, spec)
+    });
+    InvisibleStatus::from_invisibility(invisibility, origin)
 }
 
 impl<'a, B: LayoutBufferView + ?Sized> RustTextPropAccess<'a, B> {
@@ -3205,6 +3184,48 @@ impl<'a, B: LayoutBufferView + ?Sized> RustTextPropAccess<'a, B> {
             })
     }
 
+    /// Whether `[char_from, char_to)` contains an effective property that can
+    /// collapse source rows during the display walk.
+    ///
+    /// Unlike [`RustBufferAccess::has_walk_consumption_hazard`], this predicate
+    /// is deliberately range- and semantics-aware.  A face-only overlay, an
+    /// out-of-range overlay, a non-replacing `display` value, or an `invisible`
+    /// value disabled by `buffer-invisibility-spec` cannot make source-line
+    /// counting over-estimate display rows and therefore must not force
+    /// screen-at-a-time visibility retries.
+    fn has_display_row_collapse_between(&self, char_from: i64, char_to: i64) -> bool {
+        let max = self.buffer.layout_point_max_char_pos().get() as i64;
+        let mut charpos = char_from.clamp(0, max);
+        let end = char_to.clamp(charpos, max);
+        let end_byte = buffer_i64_charpos_to_emacs_byte_pos(self.buffer, end);
+        let display = Value::symbol("display");
+
+        while charpos < end {
+            if self.invisible_status_at(charpos).hidden() || self.replacing_display_at(charpos) {
+                return true;
+            }
+
+            let bytepos = buffer_i64_charpos_to_emacs_byte_pos(self.buffer, charpos);
+            let next_display_text = self
+                .buffer
+                .layout_next_single_text_prop_change_after_emacs_byte_pos_bounded(
+                    bytepos, display, end_byte,
+                )
+                .map(|next| buffer_emacs_byte_pos_to_charpos(self.buffer, next) as i64)
+                .unwrap_or(end);
+            // `next_invisible_boundary` includes every overlay endpoint, so it
+            // is also the boundary at which an overlay `display` winner may
+            // change. It separately tracks invisible text-property changes.
+            let next = self
+                .next_invisible_boundary(charpos)
+                .min(next_display_text)
+                .min(end);
+            charpos = next.max(charpos.saturating_add(1));
+        }
+
+        false
+    }
+
     /// Combined `invisible` status at `charpos` from the `invisible` text
     /// property and the highest-priority overlay (GNU `invisible_p`).
     fn invisible_status_at(&self, charpos: i64) -> InvisibleStatus {
@@ -3242,7 +3263,7 @@ impl<'a, B: LayoutBufferView + ?Sized> RustTextPropAccess<'a, B> {
                 InvisiblePropertyOrigin::TextProperty,
             )
         };
-        invisible_prop_status(value, spec, origin)
+        invisible_status_with_origin(value, spec, origin)
     }
 
     /// Next position where the `invisible` property changes, combining the
@@ -3427,7 +3448,8 @@ impl<'a, B: LayoutBufferView + ?Sized> RustTextPropAccess<'a, B> {
             .buffer
             .layout_buffer_local_value(LayoutVar::BufferInvisibilitySpec)
             .unwrap_or(Value::T);
-        invisible_prop_status(Some(invisible), spec, InvisiblePropertyOrigin::Overlay).hidden()
+        invisible_status_with_origin(Some(invisible), spec, InvisiblePropertyOrigin::Overlay)
+            .hidden()
     }
 
     /// The overlay's `before-string` / `after-string` if it is something GNU

--- a/crates/neovm-core/src/emacs_core/display/invisibility/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/invisibility/mod.rs
@@ -1,0 +1,87 @@
+//! GNU-compatible interpretation of `invisible` property values.
+//!
+//! This is deliberately pure and independent of buffers, overlays and the
+//! display iterator.  Lisp builtins, editor motion and the layout engine all
+//! resolve their effective property value separately, then use this one
+//! classifier so GNU's nil/t/ellipsis states cannot drift between subsystems.
+
+use crate::emacs_core::value::{Value, eq_value};
+
+/// The internal meaning of GNU's numeric `invisible-p` result.
+///
+/// Lisp compatibility still exposes nil/t/2, but native consumers match this
+/// enum so adding or changing an invisibility class is compiler-checked.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Invisibility {
+    Visible,
+    Hidden,
+    HiddenWithEllipsis,
+}
+
+impl Invisibility {
+    pub const fn hides_source(self) -> bool {
+        !matches!(self, Self::Visible)
+    }
+
+    pub const fn shows_ellipsis(self) -> bool {
+        matches!(self, Self::HiddenWithEllipsis)
+    }
+
+    pub(crate) fn into_lisp(self) -> Value {
+        match self {
+            Self::Visible => Value::NIL,
+            Self::Hidden => Value::T,
+            Self::HiddenWithEllipsis => Value::fixnum(2),
+        }
+    }
+}
+
+fn invisible_prop_member(propval: Value, list: Value) -> Invisibility {
+    let mut tail = list;
+    while tail.is_cons() {
+        let element = tail.cons_car();
+        if eq_value(&propval, &element) {
+            return Invisibility::Hidden;
+        }
+        if element.is_cons() && eq_value(&propval, &element.cons_car()) {
+            return if element.cons_cdr().is_nil() {
+                Invisibility::Hidden
+            } else {
+                Invisibility::HiddenWithEllipsis
+            };
+        }
+        tail = tail.cons_cdr();
+    }
+    Invisibility::Visible
+}
+
+fn invisible_prop(propval: Value, list: Value) -> Invisibility {
+    let direct = invisible_prop_member(propval, list);
+    if direct.hides_source() {
+        return direct;
+    }
+
+    let mut proptail = propval;
+    while proptail.is_cons() {
+        let result = invisible_prop_member(proptail.cons_car(), list);
+        if result.hides_source() {
+            return result;
+        }
+        proptail = proptail.cons_cdr();
+    }
+    Invisibility::Visible
+}
+
+/// GNU `TEXT_PROP_MEANS_INVISIBLE`: classify a resolved `invisible` property
+/// against the current buffer's `buffer-invisibility-spec`.
+pub fn text_prop_means_invisible(prop: Value, invisibility_spec: Value) -> Invisibility {
+    if invisibility_spec == Value::T {
+        if prop.is_truthy() {
+            Invisibility::Hidden
+        } else {
+            Invisibility::Visible
+        }
+    } else {
+        invisible_prop(prop, invisibility_spec)
+    }
+}

--- a/crates/neovm-core/src/emacs_core/display/window_cmds/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/window_cmds/tests/mod.rs
@@ -9161,9 +9161,10 @@ fn scroll_down_skips_invisible_logical_lines_when_measuring_a_page() {
                  (setq i (1+ i))))
              (goto-char (point-min))
              (forward-line 20)
+             (setq buffer-invisibility-spec '((fold . t)))
              (let ((hidden-beg (point)))
                (forward-line 40)
-               (put-text-property hidden-beg (point) 'invisible t))
+               (put-text-property hidden-beg (point) 'invisible 'fold))
              (goto-char (point-min))
              (forward-line 69))
            (set-window-point w (point))
@@ -9171,9 +9172,11 @@ fn scroll_down_skips_invisible_logical_lines_when_measuring_a_page() {
            (scroll-down nil)
            (list (window-body-height w)
                  next-screen-context-lines
-                 (line-number-at-pos (window-start w))))",
+                 (line-number-at-pos (window-start w))
+                 (line-number-at-pos (point))
+                 (invisible-p (point))))",
     );
-    assert_eq!(results[0], "OK (35 2 1)");
+    assert_eq!(results[0], "OK (35 2 1 70 nil)");
 }
 
 /// Page-up near the end of a large buffer must not restart display scanning at

--- a/crates/neovm-core/src/emacs_core/display/xdisp/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/xdisp/mod.rs
@@ -21,6 +21,7 @@ use super::display_spec;
 use super::error::{EvalResult, Flow, signal};
 use super::hook_runtime;
 use super::intern::intern;
+pub(crate) use super::invisibility::{Invisibility, text_prop_means_invisible};
 use super::symbol::LispVariableLocality;
 use super::value::*;
 use crate::buffer::{
@@ -3767,44 +3768,26 @@ fn expand_mode_line_percent_in_state(
     }
 }
 
-fn invisible_prop_member(propval: Value, list: Value) -> i64 {
-    let mut tail = list;
-    while tail.is_cons() {
-        let element = tail.cons_car();
-        if eq_value(&propval, &element) {
-            return 1;
+impl Invisibility {
+    const fn elides_source_for(self, context: InvisibleRunContext) -> bool {
+        match (context, self) {
+            (_, Self::Visible) => false,
+            (_, Self::Hidden) | (InvisibleRunContext::DisplayMotion, Self::HiddenWithEllipsis) => {
+                true
+            }
+            (InvisibleRunContext::ColumnScan, Self::HiddenWithEllipsis) => false,
         }
-        if element.is_cons() && eq_value(&propval, &element.cons_car()) {
-            return if element.cons_cdr().is_nil() { 1 } else { 2 };
-        }
-        tail = tail.cons_cdr();
     }
-    0
 }
 
-fn invisible_prop(propval: Value, list: Value) -> i64 {
-    let direct = invisible_prop_member(propval, list);
-    if direct != 0 {
-        return direct;
-    }
-
-    let mut proptail = propval;
-    while proptail.is_cons() {
-        let result = invisible_prop_member(proptail.cons_car(), list);
-        if result != 0 {
-            return result;
-        }
-        proptail = proptail.cons_cdr();
-    }
-    0
-}
-
-pub(crate) fn text_prop_means_invisible(prop: Value, invisibility_spec: Value) -> i64 {
-    if invisibility_spec == Value::T {
-        i64::from(prop.is_truthy())
-    } else {
-        invisible_prop(prop, invisibility_spec)
-    }
+/// GNU's `skip_invisible` gives ellipsis-bearing invisibility different
+/// semantics depending on its WINDOW argument: display motion elides the
+/// source and realizes an ellipsis, while `current-column`/`move-to-column`
+/// pass nil and count the underlying source text.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum InvisibleRunContext {
+    DisplayMotion,
+    ColumnScan,
 }
 
 /// Port of GNU `xdisp.c:display_prop_intangible_p`: does this `display` property
@@ -3861,7 +3844,7 @@ fn display_single_spec_replacing_p(spec: Value, frame_window_p: bool) -> bool {
 pub(crate) fn invisible_status_for_value(
     eval: &mut super::eval::Context,
     pos_or_prop: Value,
-) -> Result<i64, Flow> {
+) -> Result<Invisibility, Flow> {
     let prop = match pos_or_prop.kind() {
         ValueKind::Fixnum(v) if v >= 0 => super::textprop::builtin_get_char_property(
             eval,
@@ -3877,10 +3860,11 @@ pub(crate) fn invisible_status_for_value(
     Ok(text_prop_means_invisible(prop, invisibility_spec))
 }
 
-pub(crate) fn zero_width_invisible_run_end_byte(
+pub(crate) fn invisible_source_run_end_byte(
     eval: &mut super::eval::Context,
     buffer_id: BufferId,
     byte_pos: usize,
+    context: InvisibleRunContext,
 ) -> Result<Option<usize>, Flow> {
     let byte_pos = EmacsBytePos::new(byte_pos);
     let lisp_pos = {
@@ -3893,16 +3877,10 @@ pub(crate) fn zero_width_invisible_run_end_byte(
         super::textprop::byte_to_elisp_pos(buf, byte_pos)
     };
 
-    // `invisible-p` returns 1 for hidden text without an ellipsis and 2 for
-    // hidden text whose invisibility spec requests one.  Both values hide the
-    // underlying buffer run from display motion.  Treating only 1 as hidden
-    // made `vertical-motion` walk through org-fold drawers (`((SPEC . t))`
-    // yields 2), so ordinary up/down motion could land inside a folded drawer;
-    // Org then correctly revealed the drawer around point.  The display
-    // iterator must skip the hidden source run in both cases.  This helper
-    // intentionally reports zero width: its callers need the hidden source
-    // elision for row motion, while redisplay owns the synthetic ellipsis glyph.
-    if invisible_status_for_value(eval, Value::fixnum(lisp_pos))? == 0 {
+    // This helper answers only the source boundary, never an estimated
+    // ellipsis width. The typed context preserves GNU's deliberate distinction
+    // between display motion and column scans.
+    if !invisible_status_for_value(eval, Value::fixnum(lisp_pos))?.elides_source_for(context) {
         return Ok(None);
     }
 
@@ -3924,11 +3902,7 @@ pub(crate) fn zero_width_invisible_run_end_byte(
 /// (invisible-p POS-OR-PROP) -> boolean
 pub(crate) fn builtin_invisible_p(eval: &mut super::eval::Context, args: Vec<Value>) -> EvalResult {
     expect_args("invisible-p", &args, 1)?;
-    match invisible_status_for_value(eval, args[0])? {
-        0 => Ok(Value::NIL),
-        1 => Ok(Value::T),
-        other => Ok(Value::fixnum(other)),
-    }
+    Ok(invisible_status_for_value(eval, args[0])?.into_lisp())
 }
 
 /// (line-pixel-height) -> integer

--- a/crates/neovm-core/src/emacs_core/display/xdisp/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/xdisp/mod.rs
@@ -3893,7 +3893,16 @@ pub(crate) fn zero_width_invisible_run_end_byte(
         super::textprop::byte_to_elisp_pos(buf, byte_pos)
     };
 
-    if invisible_status_for_value(eval, Value::fixnum(lisp_pos))? != 1 {
+    // `invisible-p` returns 1 for hidden text without an ellipsis and 2 for
+    // hidden text whose invisibility spec requests one.  Both values hide the
+    // underlying buffer run from display motion.  Treating only 1 as hidden
+    // made `vertical-motion` walk through org-fold drawers (`((SPEC . t))`
+    // yields 2), so ordinary up/down motion could land inside a folded drawer;
+    // Org then correctly revealed the drawer around point.  The display
+    // iterator must skip the hidden source run in both cases.  This helper
+    // intentionally reports zero width: its callers need the hidden source
+    // elision for row motion, while redisplay owns the synthetic ellipsis glyph.
+    if invisible_status_for_value(eval, Value::fixnum(lisp_pos))? == 0 {
         return Ok(None);
     }
 

--- a/crates/neovm-core/src/emacs_core/editing/indent/mod.rs
+++ b/crates/neovm-core/src/emacs_core/editing/indent/mod.rs
@@ -363,10 +363,11 @@ fn previous_screen_line_target(
             }
         }
 
-        let anchor_is_invisible = crate::emacs_core::xdisp::zero_width_invisible_run_end_byte(
+        let anchor_is_invisible = crate::emacs_core::xdisp::invisible_source_run_end_byte(
             eval,
             buffer_id,
             anchor.get(),
+            crate::emacs_core::xdisp::InvisibleRunContext::DisplayMotion,
         )?
         .is_some_and(|next_visible| next_visible > anchor.get());
         if anchor_is_invisible {
@@ -556,10 +557,11 @@ fn current_screen_line_start_with_truncation(
             .get(buffer_id)
             .map(|buf| buf.emacs_byte_pos_to_lisp_char_pos(preceding).as_i64())
             .unwrap_or(1);
-        if crate::emacs_core::xdisp::invisible_status_for_value(
+        if !crate::emacs_core::xdisp::invisible_status_for_value(
             eval,
             Value::fixnum(preceding_lisp_pos),
-        )? == 0
+        )?
+        .hides_source()
         {
             break;
         }
@@ -1715,11 +1717,14 @@ impl DisplayStopProp {
     ) -> Result<Option<(usize, usize)>, Flow> {
         let hit =
             match self {
-                Self::Invisible => {
-                    super::xdisp::zero_width_invisible_run_end_byte(ctx, buffer_id, byte)?
-                        .filter(|&next_visible| next_visible > byte)
-                        .map(|next_visible| (0usize, next_visible))
-                }
+                Self::Invisible => super::xdisp::invisible_source_run_end_byte(
+                    ctx,
+                    buffer_id,
+                    byte,
+                    super::xdisp::InvisibleRunContext::DisplayMotion,
+                )?
+                .filter(|&next_visible| next_visible > byte)
+                .map(|next_visible| (0usize, next_visible)),
                 Self::Display => display_run_at(ctx, buffer_id, byte, column)
                     .filter(|&(_, run_end)| run_end > byte),
                 Self::Composition => composition_run_at(ctx, buffer_id, byte)
@@ -2248,9 +2253,12 @@ fn scan_for_column(
 
     while scan < end {
         if scan >= next_invisible_probe {
-            if let Some(next_visible) =
-                super::xdisp::zero_width_invisible_run_end_byte(ctx, buffer_id, scan)?
-                && next_visible > scan
+            if let Some(next_visible) = super::xdisp::invisible_source_run_end_byte(
+                ctx,
+                buffer_id,
+                scan,
+                super::xdisp::InvisibleRunContext::ColumnScan,
+            )? && next_visible > scan
             {
                 scan = next_visible.min(end);
                 if scan >= end {

--- a/crates/neovm-core/src/emacs_core/editing/indent/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/editing/indent/tests/mod.rs
@@ -234,6 +234,25 @@ fn current_column_and_move_to_column_treat_invisible_text_as_zero_width() {
 }
 
 #[test]
+fn vertical_motion_skips_ellipsis_bearing_invisible_runs() {
+    crate::test_utils::init_test_tracing();
+    let mut ev = crate::test_utils::runtime_startup_context();
+    let value = ev
+        .eval_str(
+            r#"(with-temp-buffer
+                 (insert "head\nhidden1\nhidden2\ntail\n")
+                 (setq buffer-invisibility-spec '((fold . t)))
+                 (let ((overlay (make-overlay 5 21)))
+                   (overlay-put overlay 'invisible 'fold))
+                 (list
+                  (progn (goto-char 1) (list (vertical-motion 1) (point)))
+                  (progn (goto-char 1) (list (vertical-motion 2) (point)))))"#,
+        )
+        .expect("ellipsis-bearing invisible vertical motion");
+    assert_eq!(super::super::print::print_value(&value), "((1 22) (2 27))");
+}
+
+#[test]
 fn current_column_and_indentation_handle_unibyte_raw_bytes() {
     crate::test_utils::init_test_tracing();
     let mut ev = Context::new();

--- a/crates/neovm-core/src/emacs_core/editing/indent/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/editing/indent/tests/mod.rs
@@ -234,6 +234,26 @@ fn current_column_and_move_to_column_treat_invisible_text_as_zero_width() {
 }
 
 #[test]
+fn current_column_counts_source_text_when_invisibility_requests_an_ellipsis() {
+    crate::test_utils::init_test_tracing();
+    let mut ev = crate::test_utils::runtime_startup_context();
+    let value = ev
+        .eval_str(
+            r#"(with-temp-buffer
+                 (insert "aaHIDDENbb")
+                 (setq buffer-invisibility-spec '((fold . t)))
+                 (put-text-property 3 9 'invisible 'fold)
+                 (goto-char (point-max))
+                 (current-column))"#,
+        )
+        .expect("ellipsis-bearing invisible column scan");
+
+    // GNU `skip_invisible' receives a nil window from `current-column' and
+    // deliberately leaves status-2 (ellipsis-bearing) source in the scan.
+    assert_eq!(value, Value::fixnum(10));
+}
+
+#[test]
 fn vertical_motion_skips_ellipsis_bearing_invisible_runs() {
     crate::test_utils::init_test_tracing();
     let mut ev = crate::test_utils::runtime_startup_context();

--- a/crates/neovm-core/src/emacs_core/mod.rs
+++ b/crates/neovm-core/src/emacs_core/mod.rs
@@ -63,6 +63,8 @@ pub mod image;
 pub mod image_catalog;
 #[path = "display/image_path/mod.rs"]
 pub mod image_path;
+#[path = "display/invisibility/mod.rs"]
+pub mod invisibility;
 #[path = "display/neo/mod.rs"]
 pub(crate) mod neo;
 #[path = "display/shader_surface/mod.rs"]

--- a/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
@@ -18896,20 +18896,20 @@ impl Context {
             // Find boundaries `beg`..`end` of the invisible run around PT.
             while end < zv {
                 let prop = self.apfp_char_property(end, inv)?;
-                let i = super::xdisp::text_prop_means_invisible(prop, spec);
-                if i == 0 {
+                let invisibility = super::xdisp::text_prop_means_invisible(prop, spec);
+                if !invisibility.hides_source() {
                     break;
                 }
-                ellipsis = ellipsis || i > 1;
+                ellipsis = ellipsis || invisibility.shows_ellipsis();
                 end = self.apfp_next_change(end, inv, zv)?;
             }
             while beg > begv {
                 let prop = self.apfp_char_property(beg - 1, inv)?;
-                let i = super::xdisp::text_prop_means_invisible(prop, spec);
-                if i == 0 {
+                let invisibility = super::xdisp::text_prop_means_invisible(prop, spec);
+                if !invisibility.hides_source() {
                     break;
                 }
-                ellipsis = ellipsis || i > 1;
+                ellipsis = ellipsis || invisibility.shows_ellipsis();
                 beg = self.apfp_prev_change(beg, inv, begv)?;
             }
 
@@ -18949,10 +18949,11 @@ impl Context {
                     // Already as far as we can go; avoid an infinite loop.
                 } else {
                     let here = self.apfp_pos_property(pt2, inv)?;
-                    if super::xdisp::text_prop_means_invisible(here, spec) != 0 {
+                    if super::xdisp::text_prop_means_invisible(here, spec).hides_source() {
                         let other = if pt2 == beg { end } else { beg };
                         let other_val = self.apfp_pos_property(other, inv)?;
-                        if super::xdisp::text_prop_means_invisible(other_val, spec) == 0 {
+                        if !super::xdisp::text_prop_means_invisible(other_val, spec).hides_source()
+                        {
                             self.apfp_set_point(id, other);
                             moved = true;
                         }


### PR DESCRIPTION
Collapsed Org drawers could still affect display motion as if their hidden source lines were visible. Cursor movement could enter a LOGBOOK, expose its contents, recenter the viewport inside the drawer, or make Page Up return to its previous position.

Treat both ordinary invisible runs and ellipsis-bearing runs as hidden during vertical motion. The viewport preflight now also measures point visibility across folded runs before deciding to recenter, so a large hidden LOGBOOK counts as an ellipsis instead of hundreds of visible lines.
