### PR TITLE
Render Flyspell wave underlines on graphical frames

### DIFF
--- a/crates/neomacs-display-protocol/src/face.rs
+++ b/crates/neomacs-display-protocol/src/face.rs
@@ -67,6 +67,25 @@ pub enum UnderlineStyle {
     Dashed = 5,
 }
 
+/// A non-font face feature whose availability is owned by a graphical
+/// renderer.
+///
+/// This crosses the evaluator/host/renderer boundary as a closed enum so each
+/// renderer must handle new feature variants explicitly at compile time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphicalFaceAttribute {
+    Foreground,
+    Background,
+    DistantForeground,
+    Stipple,
+    Underline(UnderlineStyle),
+    Overline,
+    StrikeThrough,
+    Box,
+    InverseVideo,
+    Extend,
+}
+
 impl UnderlineStyle {
     pub fn from_gnu_code(code: u8) -> Option<Self> {
         Self::try_from(code).ok()

--- a/crates/neomacs-display-runtime/src/lib.rs
+++ b/crates/neomacs-display-runtime/src/lib.rs
@@ -42,6 +42,7 @@ pub mod layout {
 }
 
 pub use crate::core::*;
+pub use neomacs_renderer_wgpu::supports_graphical_face_attribute;
 
 /// Shader-surface composition/validation (re-exported so the frontend can
 /// naga-validate user WGSL on the Lisp thread without a renderer dependency).

--- a/crates/neomacs-renderer-wgpu/src/lib.rs
+++ b/crates/neomacs-renderer-wgpu/src/lib.rs
@@ -63,6 +63,37 @@ pub use video_cache::{CachedVideo, VideoCache, VideoRecoveryManifest, VideoState
 #[cfg(all(feature = "webview", target_os = "linux"))]
 pub use webview_cache::{CachedWebView, WgpuWebViewCache};
 
+/// Whether the WGPU backend has a concrete rendering path for a graphical
+/// face feature.
+///
+/// Keep this match exhaustive: extending the shared capability domain should
+/// fail this crate's build until the renderer makes an explicit decision.
+pub const fn supports_graphical_face_attribute(
+    attribute: neomacs_display_protocol::GraphicalFaceAttribute,
+) -> bool {
+    use neomacs_display_protocol::{GraphicalFaceAttribute, UnderlineStyle};
+
+    match attribute {
+        GraphicalFaceAttribute::Foreground
+        | GraphicalFaceAttribute::Background
+        | GraphicalFaceAttribute::DistantForeground
+        | GraphicalFaceAttribute::Stipple
+        | GraphicalFaceAttribute::Underline(
+            UnderlineStyle::None
+            | UnderlineStyle::Line
+            | UnderlineStyle::Double
+            | UnderlineStyle::Wave
+            | UnderlineStyle::Dotted
+            | UnderlineStyle::Dashed,
+        )
+        | GraphicalFaceAttribute::Overline
+        | GraphicalFaceAttribute::StrikeThrough
+        | GraphicalFaceAttribute::Box
+        | GraphicalFaceAttribute::InverseVideo
+        | GraphicalFaceAttribute::Extend => true,
+    }
+}
+
 /// Re-exported effect configuration module for renderer internals and callers.
 pub mod effect_config {
     pub use neomacs_display_protocol::effect_config::*;

--- a/crates/neomacs/src/main.rs
+++ b/crates/neomacs/src/main.rs
@@ -196,7 +196,9 @@ use neovm_core::emacs_core::terminal::pure::{
     TerminalRuntimeConfig, configure_terminal_runtime, ensure_terminal_runtime_owner,
     reset_terminal_host, reset_terminal_runtime, set_terminal_host,
 };
-use neovm_core::emacs_core::{Context, DisplayHost, GuiFrameHostRequest, PopupMenuRequest};
+use neovm_core::emacs_core::{
+    Context, DisplayHost, GraphicalFaceAttribute, GuiFrameHostRequest, PopupMenuRequest,
+};
 use neovm_core::face::{FaceHeight, FontWeight, LFaceAttr};
 use neovm_core::heap_types::LispString;
 use neovm_core::window::{
@@ -1424,6 +1426,10 @@ fn render_fullscreen_mode(fullscreen: FrameFullscreen) -> WindowFullscreenMode {
 }
 
 impl DisplayHost for PrimaryWindowDisplayHost {
+    fn supports_graphical_face_attribute(&self, attribute: GraphicalFaceAttribute) -> bool {
+        neomacs_display_runtime::supports_graphical_face_attribute(attribute)
+    }
+
     fn realize_gui_frame(&mut self, request: GuiFrameHostRequest) -> Result<(), String> {
         let title_string = request.title.as_utf8_str().unwrap_or("Neomacs").to_owned();
         tracing::debug!(

--- a/crates/neovm-core/src/emacs_core/display/display/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/display/mod.rs
@@ -1123,6 +1123,24 @@ pub(crate) fn builtin_display_supports_face_attributes_p(
             host
         }
     };
+
+    // These attributes are rendered directly by the graphical backend; they
+    // do not require selecting a different font. In particular, reporting a
+    // wave underline as supported lets Flyspell choose its GNU graphical face
+    // instead of the `:inherit error`/`warning` fallback that recolors words.
+    let graphical_attribute = requested_attributes.foreground.is_some()
+        || requested_attributes.background.is_some()
+        || requested_attributes.underline.enabled().is_some()
+        || requested_attributes.overline == Some(true)
+        || requested_attributes.strike_through == Some(true)
+        || requested_attributes.box_border.enabled().is_some()
+        || requested_attributes.inverse_video == Some(true)
+        || requested_attributes.distant_foreground.is_some()
+        || requested_attributes.extend == Some(true);
+    if graphical_attribute {
+        return Ok(Value::T);
+    }
+
     let default_font = host
         .resolve_frame_font(
             frame_id,
@@ -1138,7 +1156,16 @@ pub(crate) fn builtin_display_supports_face_attributes_p(
         .ok()
         .flatten();
     let supported = match (default_font, requested_font) {
-        (Some(default), Some(requested)) if default != requested => {
+        // Native materialization may allocate a fresh `ResolvedFontId` for each
+        // request even when both requests opened the same exact font. GNU
+        // compares the realized selection, not transient host handles.
+        (Some(default), Some(requested))
+            if default.font.resolved.identity != requested.font.resolved.identity
+                || default.font.weight() != requested.font.weight()
+                || default.font.slant != requested.font.slant
+                || default.font.width() != requested.font.width()
+                || default.height_tenths != requested.height_tenths =>
+        {
             requested_attributes
                 .slant
                 .is_none_or(|slant| requested.font.slant.is_italic() == slant.is_italic())

--- a/crates/neovm-core/src/emacs_core/display/display/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/display/mod.rs
@@ -1069,6 +1069,147 @@ impl FrameFaceBackend {
     }
 }
 
+/// The non-font portion of one GUI face-support query.
+///
+/// GNU rejects the whole query when any explicitly requested graphical
+/// attribute equals the default face.  Otherwise every enabled feature must
+/// be representable by the concrete display host.  The enum makes those three
+/// states explicit instead of collapsing them into an early-return boolean.
+enum GraphicalFaceRequest {
+    None,
+    SameAsDefault,
+    Different {
+        required: smallvec::SmallVec<[super::display_host::GraphicalFaceAttribute; 4]>,
+    },
+}
+
+impl GraphicalFaceRequest {
+    fn from_faces(default: &crate::face::Face, requested: &crate::face::Face) -> Self {
+        use super::display_host::GraphicalFaceAttribute;
+        use crate::face::FaceDecoration;
+
+        let mut any = false;
+        let mut same_as_default = false;
+        let mut required = smallvec::SmallVec::new();
+
+        macro_rules! requested_value {
+            ($field:ident, $capability:expr) => {
+                if let Some(value) = requested.$field.as_ref() {
+                    any = true;
+                    same_as_default |= default.$field.as_ref() == Some(value);
+                    required.push($capability);
+                }
+            };
+        }
+
+        requested_value!(foreground, GraphicalFaceAttribute::Foreground);
+        requested_value!(background, GraphicalFaceAttribute::Background);
+        requested_value!(
+            distant_foreground,
+            GraphicalFaceAttribute::DistantForeground
+        );
+        requested_value!(stipple, GraphicalFaceAttribute::Stipple);
+
+        match &requested.underline {
+            FaceDecoration::Unspecified => {}
+            FaceDecoration::Disabled => {
+                any = true;
+                same_as_default |= default.underline.enabled().is_none();
+            }
+            FaceDecoration::Enabled(underline) => {
+                any = true;
+                same_as_default |= default.underline.enabled() == Some(underline);
+                let style = match underline.style {
+                    crate::face::UnderlineStyle::Line => {
+                        neomacs_display_protocol::UnderlineStyle::Line
+                    }
+                    crate::face::UnderlineStyle::DoubleLine => {
+                        neomacs_display_protocol::UnderlineStyle::Double
+                    }
+                    crate::face::UnderlineStyle::Wave => {
+                        neomacs_display_protocol::UnderlineStyle::Wave
+                    }
+                    crate::face::UnderlineStyle::Dots => {
+                        neomacs_display_protocol::UnderlineStyle::Dotted
+                    }
+                    crate::face::UnderlineStyle::Dashes => {
+                        neomacs_display_protocol::UnderlineStyle::Dashed
+                    }
+                };
+                required.push(GraphicalFaceAttribute::Underline(style));
+            }
+        }
+
+        if let Some(enabled) = requested.overline {
+            any = true;
+            same_as_default |= enabled == default.overline.unwrap_or(false)
+                && (!enabled || requested.overline_color == default.overline_color);
+            if enabled {
+                required.push(GraphicalFaceAttribute::Overline);
+            }
+        }
+        if let Some(enabled) = requested.strike_through {
+            any = true;
+            same_as_default |= enabled == default.strike_through.unwrap_or(false)
+                && (!enabled || requested.strike_through_color == default.strike_through_color);
+            if enabled {
+                required.push(GraphicalFaceAttribute::StrikeThrough);
+            }
+        }
+
+        match &requested.box_border {
+            FaceDecoration::Unspecified => {}
+            FaceDecoration::Disabled => {
+                any = true;
+                same_as_default |= default.box_border.enabled().is_none();
+            }
+            FaceDecoration::Enabled(border) => {
+                any = true;
+                same_as_default |= default.box_border.enabled() == Some(border);
+                required.push(GraphicalFaceAttribute::Box);
+            }
+        }
+
+        macro_rules! requested_boolean {
+            ($field:ident, $capability:expr) => {
+                if let Some(enabled) = requested.$field {
+                    any = true;
+                    same_as_default |= enabled == default.$field.unwrap_or(false);
+                    if enabled {
+                        required.push($capability);
+                    }
+                }
+            };
+        }
+
+        requested_boolean!(inverse_video, GraphicalFaceAttribute::InverseVideo);
+        requested_boolean!(extend, GraphicalFaceAttribute::Extend);
+
+        if same_as_default {
+            Self::SameAsDefault
+        } else if any {
+            Self::Different { required }
+        } else {
+            Self::None
+        }
+    }
+
+    fn supported_by(&self, host: &dyn super::display_host::DisplayHost) -> bool {
+        match self {
+            Self::None => true,
+            Self::SameAsDefault => false,
+            Self::Different { required } => required
+                .iter()
+                .copied()
+                .all(|attribute| host.supports_graphical_face_attribute(attribute)),
+        }
+    }
+
+    fn was_requested(&self) -> bool {
+        matches!(self, Self::Different { .. })
+    }
+}
+
 /// Context-aware variant of `display-supports-face-attributes-p`.
 ///
 /// Emacs accepts broad argument shapes here in batch mode and still returns
@@ -1102,6 +1243,7 @@ pub(crate) fn builtin_display_supports_face_attributes_p(
     let default_face = eval.face_table().resolve("default");
     let requested_attributes = crate::face::Face::from_plist("anonymous", &attributes);
     let requested_face = default_face.merge(&requested_attributes);
+    let graphical_request = GraphicalFaceRequest::from_faces(&default_face, &requested_attributes);
     let host = match backend {
         FrameFaceBackend::TextTerminal => {
             return Ok(Value::bool_val(tty_supports_face_attributes_p(
@@ -1110,13 +1252,6 @@ pub(crate) fn builtin_display_supports_face_attributes_p(
             )));
         }
         FrameFaceBackend::WindowSystem => {
-            // Stipple is a GUI-only background fill (GNU realizes it to a
-            // pixmap).  It is usable only when this window-system frame has a
-            // live host; the terminal arm above rejects it with every other
-            // unsupported TTY attribute.
-            if requested_attributes.stipple.is_some() {
-                return Ok(Value::bool_val(eval.display_host.is_some()));
-            }
             let Some(host) = eval.display_host.as_mut() else {
                 return Ok(Value::NIL);
             };
@@ -1124,21 +1259,18 @@ pub(crate) fn builtin_display_supports_face_attributes_p(
         }
     };
 
-    // These attributes are rendered directly by the graphical backend; they
-    // do not require selecting a different font. In particular, reporting a
-    // wave underline as supported lets Flyspell choose its GNU graphical face
-    // instead of the `:inherit error`/`warning` fallback that recolors words.
-    let graphical_attribute = requested_attributes.foreground.is_some()
-        || requested_attributes.background.is_some()
-        || requested_attributes.underline.enabled().is_some()
-        || requested_attributes.overline == Some(true)
-        || requested_attributes.strike_through == Some(true)
-        || requested_attributes.box_border.enabled().is_some()
-        || requested_attributes.inverse_video == Some(true)
-        || requested_attributes.distant_foreground.is_some()
-        || requested_attributes.extend == Some(true);
-    if graphical_attribute {
-        return Ok(Value::T);
+    if !graphical_request.supported_by(&**host) {
+        return Ok(Value::NIL);
+    }
+
+    let font_attribute = requested_attributes.family.is_some()
+        || requested_attributes.foundry.is_some()
+        || requested_attributes.height.is_some()
+        || requested_attributes.weight.is_some()
+        || requested_attributes.slant.is_some()
+        || requested_attributes.width.is_some();
+    if !font_attribute {
+        return Ok(Value::bool_val(graphical_request.was_requested()));
     }
 
     let default_font = host
@@ -1159,13 +1291,7 @@ pub(crate) fn builtin_display_supports_face_attributes_p(
         // Native materialization may allocate a fresh `ResolvedFontId` for each
         // request even when both requests opened the same exact font. GNU
         // compares the realized selection, not transient host handles.
-        (Some(default), Some(requested))
-            if default.font.resolved.identity != requested.font.resolved.identity
-                || default.font.weight() != requested.font.weight()
-                || default.font.slant != requested.font.slant
-                || default.font.width() != requested.font.width()
-                || default.height_tenths != requested.height_tenths =>
-        {
+        (Some(default), Some(requested)) if !default.same_face_selection_as(&requested) => {
             requested_attributes
                 .slant
                 .is_none_or(|slant| requested.font.slant.is_italic() == slant.is_italic())

--- a/crates/neovm-core/src/emacs_core/display/display/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/display/tests/mod.rs
@@ -82,6 +82,13 @@ struct FreshIdSameFontDisplayHost {
 }
 
 impl DisplayHost for FreshIdSameFontDisplayHost {
+    fn supports_graphical_face_attribute(
+        &self,
+        _attribute: crate::emacs_core::eval::GraphicalFaceAttribute,
+    ) -> bool {
+        true
+    }
+
     fn realize_gui_frame(&mut self, _request: GuiFrameHostRequest) -> Result<(), String> {
         Ok(())
     }
@@ -3856,6 +3863,10 @@ fn display_supports_face_attributes_p_ignores_fresh_handles_for_the_same_font() 
     let frame_id = eval
         .frames
         .create_frame("gui-face-support-same-font", 800, 600, scratch);
+    eval.frames
+        .get_mut(frame_id)
+        .expect("GUI frame")
+        .set_window_system(Some(Value::symbol("neo")));
     eval.frames.select_frame(frame_id);
     eval.set_display_host(Box::new(FreshIdSameFontDisplayHost::default()));
 
@@ -3878,6 +3889,10 @@ fn display_supports_face_attributes_p_reports_gui_wave_underline() {
     let frame_id = eval
         .frames
         .create_frame("gui-face-support-wave-underline", 800, 600, scratch);
+    eval.frames
+        .get_mut(frame_id)
+        .expect("GUI frame")
+        .set_window_system(Some(Value::symbol("neo")));
     eval.frames.select_frame(frame_id);
     eval.set_display_host(Box::new(FreshIdSameFontDisplayHost::default()));
 
@@ -3889,6 +3904,120 @@ fn display_supports_face_attributes_p_reports_gui_wave_underline() {
         builtin_display_supports_face_attributes_p(&mut eval, vec![attrs]).unwrap(),
         Value::T,
         "the graphical renderer supports Flyspell's wave underline without changing fonts",
+    );
+}
+
+#[test]
+fn display_supports_face_attributes_p_requires_every_gui_attribute_to_be_supported() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::Context::new();
+    let scratch = eval.buffers.create_buffer("*scratch*");
+    let frame_id = eval
+        .frames
+        .create_frame("gui-face-support-mixed-request", 800, 600, scratch);
+    eval.frames
+        .get_mut(frame_id)
+        .expect("GUI frame")
+        .set_window_system(Some(Value::symbol("neo")));
+    eval.frames.select_frame(frame_id);
+    eval.set_display_host(Box::new(FreshIdSameFontDisplayHost::default()));
+
+    let attrs = Value::list(vec![
+        Value::keyword("underline"),
+        Value::list(vec![Value::keyword("style"), Value::symbol("wave")]),
+        Value::keyword("family"),
+        Value::string("Definitely Missing Font"),
+    ]);
+    assert_eq!(
+        builtin_display_supports_face_attributes_p(&mut eval, vec![attrs]).unwrap(),
+        Value::NIL,
+        "a supported decoration must not hide an unsupported font request",
+    );
+}
+
+#[test]
+fn display_supports_face_attributes_p_rejects_gui_attribute_equal_to_default() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::Context::new();
+    let mut default_face = eval.face_table().resolve("default");
+    default_face.extend = Some(true);
+    eval.face_table_mut().define("default", default_face);
+
+    let scratch = eval.buffers.create_buffer("*scratch*");
+    let frame_id = eval
+        .frames
+        .create_frame("gui-face-support-default-equality", 800, 600, scratch);
+    eval.frames
+        .get_mut(frame_id)
+        .expect("GUI frame")
+        .set_window_system(Some(Value::symbol("neo")));
+    eval.frames.select_frame(frame_id);
+    eval.set_display_host(Box::new(FreshIdSameFontDisplayHost::default()));
+
+    let attrs = Value::list(vec![Value::keyword("extend"), Value::T]);
+    assert_eq!(
+        builtin_display_supports_face_attributes_p(&mut eval, vec![attrs]).unwrap(),
+        Value::NIL,
+        "an explicitly requested decoration equal to the default is not a visible difference",
+    );
+}
+
+#[test]
+fn display_supports_face_attributes_p_uses_graphical_host_capabilities() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::Context::new();
+    let scratch = eval.buffers.create_buffer("*scratch*");
+    let frame_id = eval
+        .frames
+        .create_frame("gui-face-support-no-decorations", 800, 600, scratch);
+    eval.frames
+        .get_mut(frame_id)
+        .expect("GUI frame")
+        .set_window_system(Some(Value::symbol("neo")));
+    eval.frames.select_frame(frame_id);
+    // This host opts into italic font materialization only; the default
+    // DisplayHost capability answer for graphical decorations is false.
+    eval.set_display_host(Box::new(ItalicCapableDisplayHost));
+
+    let attrs = Value::list(vec![
+        Value::keyword("underline"),
+        Value::list(vec![Value::keyword("style"), Value::symbol("wave")]),
+    ]);
+    assert_eq!(
+        builtin_display_supports_face_attributes_p(&mut eval, vec![attrs]).unwrap(),
+        Value::NIL,
+        "core must ask the concrete graphical host instead of assuming renderer capabilities",
+    );
+}
+
+#[test]
+fn display_supports_face_attributes_p_accepts_disabling_nondefault_gui_decoration() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::Context::new();
+    let mut default_face = eval.face_table().resolve("default");
+    default_face.underline = crate::face::FaceDecoration::Enabled(crate::face::Underline {
+        style: crate::face::UnderlineStyle::Line,
+        color: None,
+        position: crate::face::UnderlinePosition::FontMetric,
+    });
+    eval.face_table_mut().define("default", default_face);
+
+    let scratch = eval.buffers.create_buffer("*scratch*");
+    let frame_id =
+        eval.frames
+            .create_frame("gui-face-support-disable-decoration", 800, 600, scratch);
+    eval.frames
+        .get_mut(frame_id)
+        .expect("GUI frame")
+        .set_window_system(Some(Value::symbol("neo")));
+    eval.frames.select_frame(frame_id);
+    eval.set_display_host(Box::new(FreshIdSameFontDisplayHost::default()));
+
+    let attrs = Value::list(vec![Value::keyword("underline"), Value::NIL]);
+    assert_eq!(
+        builtin_display_supports_face_attributes_p(&mut eval, vec![attrs]).unwrap(),
+        Value::T,
+        "explicitly removing a default decoration is a representable visible difference",
     );
 }
 

--- a/crates/neovm-core/src/emacs_core/display/display/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/display/tests/mod.rs
@@ -76,6 +76,54 @@ impl DisplayHost for ItalicCapableDisplayHost {
     }
 }
 
+#[derive(Default)]
+struct FreshIdSameFontDisplayHost {
+    next_id: u32,
+}
+
+impl DisplayHost for FreshIdSameFontDisplayHost {
+    fn realize_gui_frame(&mut self, _request: GuiFrameHostRequest) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn resize_gui_frame(&mut self, _request: GuiFrameHostRequest) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn resolve_frame_font(
+        &mut self,
+        _frame_id: crate::window::FrameId,
+        _request: crate::emacs_core::display_host::FrameFontRequest,
+    ) -> Result<Option<crate::emacs_core::eval::ResolvedFrameFont>, String> {
+        let metrics = crate::emacs_core::eval::FontPxProbeResult {
+            pixel_size: 14,
+            height: 16,
+            ascent: 12,
+            descent: 4,
+            max_width: 8,
+            space_width: 8,
+            average_width: 8,
+        };
+        let mut font = crate::emacs_core::eval::test_resolved_opened_font(
+            "Noto Sans",
+            None,
+            None,
+            crate::face::FontWeight::NORMAL,
+            crate::face::FontSlant::Normal,
+            crate::face::FontWidth::Normal,
+            None,
+            metrics,
+            None,
+        );
+        self.next_id += 1;
+        font.resolved.id = neomacs_display_protocol::font::ResolvedFontId(self.next_id);
+        Ok(Some(crate::emacs_core::eval::ResolvedFrameFont {
+            font,
+            height_tenths: 100,
+        }))
+    }
+}
+
 struct FailingClipboardDisplayHost;
 
 impl DisplayHost for FailingClipboardDisplayHost {
@@ -3797,6 +3845,50 @@ fn display_supports_face_attributes_p_uses_live_gui_font_capabilities() {
         builtin_display_supports_face_attributes_p(&mut eval, vec![attrs]).unwrap(),
         Value::T,
         "a GUI host that realizes the requested italic font must report the face spec as supported",
+    );
+}
+
+#[test]
+fn display_supports_face_attributes_p_ignores_fresh_handles_for_the_same_font() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::Context::new();
+    let scratch = eval.buffers.create_buffer("*scratch*");
+    let frame_id = eval
+        .frames
+        .create_frame("gui-face-support-same-font", 800, 600, scratch);
+    eval.frames.select_frame(frame_id);
+    eval.set_display_host(Box::new(FreshIdSameFontDisplayHost::default()));
+
+    let attrs = Value::list(vec![
+        Value::keyword("family"),
+        Value::string("Definitely Missing Font"),
+    ]);
+    assert_eq!(
+        builtin_display_supports_face_attributes_p(&mut eval, vec![attrs]).unwrap(),
+        Value::NIL,
+        "fresh native handles for the same opened font must not make an unavailable font look supported",
+    );
+}
+
+#[test]
+fn display_supports_face_attributes_p_reports_gui_wave_underline() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = crate::emacs_core::Context::new();
+    let scratch = eval.buffers.create_buffer("*scratch*");
+    let frame_id = eval
+        .frames
+        .create_frame("gui-face-support-wave-underline", 800, 600, scratch);
+    eval.frames.select_frame(frame_id);
+    eval.set_display_host(Box::new(FreshIdSameFontDisplayHost::default()));
+
+    let attrs = Value::list(vec![
+        Value::keyword("underline"),
+        Value::list(vec![Value::keyword("style"), Value::symbol("wave")]),
+    ]);
+    assert_eq!(
+        builtin_display_supports_face_attributes_p(&mut eval, vec![attrs]).unwrap(),
+        Value::T,
+        "the graphical renderer supports Flyspell's wave underline without changing fonts",
     );
 }
 

--- a/crates/neovm-core/src/emacs_core/display/display_host/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/display_host/mod.rs
@@ -17,6 +17,7 @@ use crate::buffer::BufferId;
 use crate::face::{Face as RuntimeFace, FaceHeight};
 use crate::heap_types::LispString;
 use crate::window::FrameFullscreen;
+pub use neomacs_display_protocol::GraphicalFaceAttribute;
 use neomacs_display_protocol::{VideoId, WebViewId};
 use neomacs_video_model::{PlaybackAction, VideoDiagnostics, VideoOpenRequest};
 
@@ -258,6 +259,13 @@ impl TerminalFloatPlacement {
 pub trait DisplayHost {
     fn realize_gui_frame(&mut self, request: GuiFrameHostRequest) -> Result<(), String>;
     fn resize_gui_frame(&mut self, request: GuiFrameHostRequest) -> Result<(), String>;
+    /// Whether this concrete graphical backend can represent ATTRIBUTE.
+    ///
+    /// The conservative default keeps test/dummy hosts from accidentally
+    /// claiming rendering support.  Real graphical hosts must opt in.
+    fn supports_graphical_face_attribute(&self, _attribute: GraphicalFaceAttribute) -> bool {
+        false
+    }
     fn set_clipboard_text(&mut self, _text: Option<&str>) -> Result<(), String> {
         Err("clipboard is unsupported by this display host".to_owned())
     }

--- a/crates/neovm-core/src/emacs_core/mod.rs
+++ b/crates/neovm-core/src/emacs_core/mod.rs
@@ -426,7 +426,7 @@ pub(crate) struct MenuBarPopupAnchor {
 
 // Re-export the main public API
 pub use bytecode::{ByteCodeFunction, Vm as ByteVm};
-pub use display_host::DisplayHost;
+pub use display_host::{DisplayHost, GraphicalFaceAttribute};
 pub use error::{
     EvalError, format_eval_result, format_eval_result_bytes_with_eval,
     format_eval_result_with_eval, print_value_bytes_with_eval, print_value_with_eval,

--- a/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
@@ -23,8 +23,9 @@ use super::command_observation::{
 use super::custom::CustomManager;
 use super::debug_on_call::DebugOnCallCode;
 pub use super::display_host::{
-    DisplayHost, FrameFontRequest, FrameFontSize, TerminalCreateRequest, TerminalDisplayTarget,
-    TerminalFloatPlacement, TerminalGridSize, TerminalId, XwidgetScriptRequestId,
+    DisplayHost, FrameFontRequest, FrameFontSize, GraphicalFaceAttribute, TerminalCreateRequest,
+    TerminalDisplayTarget, TerminalFloatPlacement, TerminalGridSize, TerminalId,
+    XwidgetScriptRequestId,
 };
 use super::error::*;
 use super::interactive::InteractiveRegistry;
@@ -2123,6 +2124,23 @@ pub struct ResolvedFrameFont {
     /// `LFACE_HEIGHT_INDEX`; keep the point-height value beside the pixel
     /// metrics so core code never has to guess a frame DPI from pixels.
     pub height_tenths: i32,
+}
+
+impl ResolvedFrameFont {
+    /// Compare the stable font characteristics that determine a realized
+    /// Lisp face, deliberately excluding transient host handles and metrics.
+    ///
+    /// Native materializers may return a fresh `ResolvedFontId` for the same
+    /// opened font. GNU's face-support predicate compares realized font
+    /// properties, so handle allocation must not turn fallback to the default
+    /// font into an apparent successful selection.
+    pub(crate) fn same_face_selection_as(&self, other: &Self) -> bool {
+        self.font.resolved.identity == other.font.resolved.identity
+            && self.font.weight() == other.font.weight()
+            && self.font.slant == other.font.slant
+            && self.font.width() == other.font.width()
+            && self.height_tenths == other.height_tenths
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Flyspell's graphical faces use styled wave underlines, but Neomacs tied face capability detection to whether font selection returned a different native font handle. Decoration-only faces could therefore select the fallback error or warning face instead of the normal graphical Flyspell face.

Report renderer-backed graphical decorations independently from font selection, and compare stable realized font characteristics rather than transient host handles for font-only requests. Flyspell can then retain the underlying Org foreground while drawing the expected colored wave underline.
