### PR TITLE
fix(emacs-core): log a routine command-loop signal at debug, not error

### DIFF
--- a/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
@@ -4369,6 +4369,54 @@ impl Context {
         Ok(false)
     }
 
+    /// Whether an uncaught command signal is something GNU would show the
+    /// user and forget, or something worth a diagnostic.
+    ///
+    /// GNU's command loop does not distinguish: `cmd_error_internal'
+    /// (src/keyboard.c:1030-1047, emacs-31.0.90) hands every signal to
+    /// `command-error-function' and never logs.  The one place GNU does rank
+    /// signals is the debugger gate, `skip_debugger' (src/eval.c:2146-2180):
+    /// a condition or message matched by `debug-ignored-errors' -- by default
+    /// `beginning-of-line', `end-of-line', `end-of-buffer', `buffer-read-only',
+    /// `user-error', ... (lisp/bindings.el:1038-1046), and whatever packages
+    /// push there, such as evil's `end-of-line' -- is routine and must not
+    /// interrupt the user.  A quit is routine by construction
+    /// (`signal_quit_p', src/eval.c:2181-2190).  This port's command-loop
+    /// log follows the same ranking, so `C-g` and "End of line" are not
+    /// errors in the log while a void function still is.
+    ///
+    /// Two departures from GNU, both deliberate.  GNU consults
+    /// `skip_debugger' only when the debugger is otherwise wanted
+    /// (`maybe_call_debugger', src/eval.c:2206-2213); the log has no such
+    /// gate, so the ignore list is evaluated on every uncaught command
+    /// signal.  And this runs inside `command_loop_2', GNU's sole recovery
+    /// owner (`internal_condition_case (command_loop_1, ..., cmd_error)'),
+    /// where nothing may signal: a string entry in `debug-ignored-errors'
+    /// that is not a valid regexp makes the matcher signal `invalid-regexp',
+    /// and that must classify the original error, not unwind the command
+    /// loop.  So this is infallible: a matcher failure is a `Diagnostic'.
+    fn command_error_severity(&mut self, sig: &SignalData) -> CommandErrorSeverity {
+        if crate::emacs_core::errors::signal_matches_condition_value_sym(
+            &self.obarray,
+            sig.symbol,
+            &Value::from_sym_id(quit_symbol()),
+        ) {
+            return CommandErrorSeverity::Routine;
+        }
+        let conditions = self.signal_conditions_value(sig);
+        match self.skip_debugger(sig, &conditions) {
+            Ok(true) => CommandErrorSeverity::Routine,
+            Ok(false) => CommandErrorSeverity::Diagnostic,
+            Err(flow) => {
+                tracing::debug!(
+                    "`debug-ignored-errors' could not be matched while ranking a command \
+                     loop signal; treating it as a diagnostic: {flow:?}"
+                );
+                CommandErrorSeverity::Diagnostic
+            }
+        }
+    }
+
     fn call_debugger_for_signal(&mut self, sig: &SignalData) -> Result<(), Flow> {
         let rendered = super::error::format_signal_data_with_eval(self, sig);
         tracing::error!(
@@ -7732,10 +7780,21 @@ impl Context {
                     let data = self.signal_error_data_value(&sig);
                     self.report_command_error(data, "")?;
 
-                    tracing::error!(
-                        condition = %sym_name,
-                        "Command loop error: {error_msg} [signal={rendered_signal}]{backtrace_suffix}"
-                    );
+                    // GNU only ever shows the message; the log is this port's
+                    // diagnostic, so it follows GNU's own ranking of signals
+                    // (see `command_error_severity'): a quit or a
+                    // `debug-ignored-errors' match is what the user just did,
+                    // not an error.
+                    match self.command_error_severity(&sig) {
+                        CommandErrorSeverity::Routine => tracing::debug!(
+                            condition = %sym_name,
+                            "Command loop signal: {error_msg} [signal={rendered_signal}]{backtrace_suffix}"
+                        ),
+                        CommandErrorSeverity::Diagnostic => tracing::error!(
+                            condition = %sym_name,
+                            "Command loop error: {error_msg} [signal={rendered_signal}]{backtrace_suffix}"
+                        ),
+                    }
 
                     // Restart the command loop.
                     continue;
@@ -19461,4 +19520,16 @@ mod jit_crash_repro_tests;
 fn next_context_instance_id() -> u64 {
     static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
     NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
+/// How the command loop's log treats an uncaught command signal; see
+/// `Context::command_error_severity'.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CommandErrorSeverity {
+    /// What the user just did: a quit, or a condition GNU's debugger ignores
+    /// (`debug-ignored-errors').  Shown in the echo area, logged at debug.
+    Routine,
+    /// Anything else: shown the same way, logged as an error so a bug
+    /// report carries the condition and payload.
+    Diagnostic,
 }

--- a/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
@@ -7777,6 +7777,11 @@ impl Context {
                     self.assign("last-prefix-arg", Value::NIL);
                     self.cancel_key_echo_state();
 
+                    // Classify while the signal's buffer and ignore policy are
+                    // still current.  The presentation callback below is
+                    // arbitrary Lisp and may change either one; GNU's debugger
+                    // gate has already made this decision before `cmd_error'.
+                    let severity = self.command_error_severity(&sig);
                     let data = self.signal_error_data_value(&sig);
                     self.report_command_error(data, "")?;
 
@@ -7785,7 +7790,7 @@ impl Context {
                     // (see `command_error_severity'): a quit or a
                     // `debug-ignored-errors' match is what the user just did,
                     // not an error.
-                    match self.command_error_severity(&sig) {
+                    match severity {
                         CommandErrorSeverity::Routine => tracing::debug!(
                             condition = %sym_name,
                             "Command loop signal: {error_msg} [signal={rendered_signal}]{backtrace_suffix}"

--- a/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
@@ -7756,32 +7756,15 @@ impl Context {
                     // Keeping reporting here ensures the current buffer's
                     // buffer-local `command-error-function' decides how the
                     // error is presented (notably `minibuffer-error-function').
-                    let sym_name = format_symbol_name_for_diagnostic(sig.symbol);
-                    let error_msg = self.command_error_message(&sig);
-                    // Render the *condition symbol* and full signal payload, not
-                    // just the human message: a bare "peculiar error" (an error
-                    // whose condition has no `error-message`) is otherwise
-                    // undiagnosable in a bug report. `condition=` names the
-                    // symbol; `signal=` is the Lisp-readable `(SYMBOL . DATA)`.
-                    let rendered_signal = super::error::format_signal_data_with_eval(self, &sig);
-                    // Backtrace captured at signal-dispatch time (debug tracing
-                    // only); shows where it was raised without `debug-on-error`.
-                    let backtrace_suffix = self
-                        .last_uncaught_signal_backtrace
-                        .take()
-                        .map(|bt| format!("\nLisp backtrace (innermost first):\n{bt}"))
-                        .unwrap_or_default();
+                    // Capture every diagnostic decision and value before
+                    // arbitrary presentation Lisp can mutate editor state.
+                    let diagnostic = self.capture_command_loop_diagnostic(&sig);
                     // GNU `cmd_error' clears both prefix arguments and key
                     // echoing before calling `cmd_error_internal'.
                     self.assign("prefix-arg", Value::NIL);
                     self.assign("last-prefix-arg", Value::NIL);
                     self.cancel_key_echo_state();
 
-                    // Classify while the signal's buffer and ignore policy are
-                    // still current.  The presentation callback below is
-                    // arbitrary Lisp and may change either one; GNU's debugger
-                    // gate has already made this decision before `cmd_error'.
-                    let severity = self.command_error_severity(&sig);
                     let data = self.signal_error_data_value(&sig);
                     self.report_command_error(data, "")?;
 
@@ -7790,16 +7773,7 @@ impl Context {
                     // (see `command_error_severity'): a quit or a
                     // `debug-ignored-errors' match is what the user just did,
                     // not an error.
-                    match severity {
-                        CommandErrorSeverity::Routine => tracing::debug!(
-                            condition = %sym_name,
-                            "Command loop signal: {error_msg} [signal={rendered_signal}]{backtrace_suffix}"
-                        ),
-                        CommandErrorSeverity::Diagnostic => tracing::error!(
-                            condition = %sym_name,
-                            "Command loop error: {error_msg} [signal={rendered_signal}]{backtrace_suffix}"
-                        ),
-                    }
+                    diagnostic.emit();
 
                     // Restart the command loop.
                     continue;
@@ -7821,6 +7795,25 @@ impl Context {
                     .map(|ls| crate::emacs_core::emacs_char::to_utf8_lossy(ls.as_bytes()))
             })
             .unwrap_or_else(|| format_symbol_name_for_diagnostic(sig.symbol))
+    }
+
+    /// Freeze a command-loop diagnostic before `command-error-function' runs.
+    ///
+    /// GNU makes its debugger-ignore decision during signal dispatch, before
+    /// `cmd_error_internal' calls the presentation hook.  Keeping severity and
+    /// rendered values in one owned record makes that ordering explicit and
+    /// prevents later Lisp state changes from altering the event in flight.
+    fn capture_command_loop_diagnostic(&mut self, sig: &SignalData) -> CommandLoopDiagnostic {
+        CommandLoopDiagnostic {
+            severity: self.command_error_severity(sig),
+            condition: format_symbol_name_for_diagnostic(sig.symbol),
+            message: self.command_error_message(sig),
+            signal: super::error::format_signal_data_with_eval(self, sig),
+            backtrace: self
+                .last_uncaught_signal_backtrace
+                .take()
+                .unwrap_or_default(),
+        }
     }
 
     /// Main command loop — read key sequence, look up binding, execute.
@@ -19530,11 +19523,54 @@ fn next_context_instance_id() -> u64 {
 /// How the command loop's log treats an uncaught command signal; see
 /// `Context::command_error_severity'.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum CommandErrorSeverity {
+enum CommandErrorSeverity {
     /// What the user just did: a quit, or a condition GNU's debugger ignores
     /// (`debug-ignored-errors').  Shown in the echo area, logged at debug.
     Routine,
     /// Anything else: shown the same way, logged as an error so a bug
     /// report carries the condition and payload.
     Diagnostic,
+}
+
+/// An owned snapshot of one uncaught command signal, captured before Lisp
+/// presentation code can alter the state used to classify or render it.
+struct CommandLoopDiagnostic {
+    severity: CommandErrorSeverity,
+    condition: String,
+    message: String,
+    signal: String,
+    backtrace: String,
+}
+
+impl CommandLoopDiagnostic {
+    fn emit(self) {
+        let Self {
+            severity,
+            condition,
+            message,
+            signal,
+            backtrace,
+        } = self;
+
+        // A tracing callsite's level is static metadata, so selecting a level
+        // through a runtime variable would not compile.  Expanding the shared
+        // fields with a literal level keeps two compile-time callsites without
+        // duplicating the diagnostic schema.
+        macro_rules! emit_at {
+            ($level:expr) => {
+                tracing::event!(
+                    $level,
+                    condition = %condition,
+                    signal = %signal,
+                    backtrace = %backtrace,
+                    "Command loop condition: {message}"
+                )
+            };
+        }
+
+        match severity {
+            CommandErrorSeverity::Routine => emit_at!(tracing::Level::DEBUG),
+            CommandErrorSeverity::Diagnostic => emit_at!(tracing::Level::ERROR),
+        }
+    }
 }

--- a/crates/neovm-core/src/emacs_core/runtime/eval/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/eval/tests/mod.rs
@@ -21869,11 +21869,7 @@ fn run_command_loop_error_commands(ev: &mut Context, global_map: Value, commands
             Value::symbol(command),
         )
         .expect("define signaling command");
-        ev.command_loop
-            .keyboard
-            .kboard
-            .unread_events
-            .push_back(Value::symbol(key));
+        ev.command_loop.unread_event(Value::symbol(key));
     }
     crate::emacs_core::keymap::list_keymap_define_seq(
         global_map,
@@ -21881,11 +21877,7 @@ fn run_command_loop_error_commands(ev: &mut Context, global_map: Value, commands
         Value::symbol("neo-stop-command-loop-error-test-command"),
     )
     .expect("define stop command");
-    ev.command_loop
-        .keyboard
-        .kboard
-        .unread_events
-        .push_back(Value::fixnum('q' as i64));
+    ev.command_loop.unread_event(Value::fixnum('q' as i64));
     ev.command_loop.running = true;
 
     ev.recursive_edit_inner()

--- a/crates/neovm-core/src/emacs_core/runtime/eval/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/eval/tests/mod.rs
@@ -22006,6 +22006,134 @@ fn command_loop_captures_ignored_error_severity_before_presentation() {
     });
 }
 
+/// Command-loop diagnostics retain their signal-time classification and expose
+/// enough structured data for logs to be queried without parsing prose.  The
+/// presentation callback deliberately adds `void-function' to the ignore list;
+/// that must not suppress the diagnostic already in flight.  A quit remains a
+/// routine user action regardless of the list.
+#[tracing_test::traced_test]
+#[test]
+fn command_loop_emits_typed_diagnostics_for_error_and_quit() {
+    let mut ev = Context::new();
+    let scratch = ev.buffers.create_buffer("*command-loop-diagnostics*");
+    ev.buffers.set_current(scratch);
+    let frame = ev.frames.create_frame("F1", 80, 24, scratch);
+    assert!(ev.frames.select_frame(frame), "test needs a selected frame");
+    let global_map = crate::emacs_core::keymap::make_sparse_list_keymap();
+    install_global_map_for_test(&mut ev, global_map);
+
+    fn stop_command_loop_after_diagnostic_probe(ctx: &mut Context, args: Vec<Value>) -> EvalResult {
+        assert!(args.is_empty(), "stop helper should not receive arguments");
+        ctx.command_loop.running = false;
+        Ok(Value::NIL)
+    }
+    ev.register_subr(SubrSpec::new(
+        "neo-stop-command-loop-after-diagnostic-probe",
+        NativeFn::ContextVec(stop_command_loop_after_diagnostic_probe),
+        SubrArity::new(0, Some(0)),
+    ));
+    ev.eval_str(
+        r#"(progn
+             (setq debug-ignored-errors nil
+                   neo-command-error-observations nil)
+             (set (make-local-variable 'command-error-function)
+                  (lambda (data _context _caller)
+                    (setq neo-command-error-observations
+                          (cons data neo-command-error-observations))
+                    (if (eq (car data) 'void-function)
+                        (setq debug-ignored-errors '(void-function)))))
+             (fset 'neo-diagnostic-signaling-command
+                   (lambda () (interactive) (neo-no-such-command)))
+             (fset 'neo-quit-signaling-command
+                   (lambda () (interactive) (signal 'quit nil)))
+             (fset 'neo-stop-after-diagnostic-command
+                   (lambda ()
+                     (interactive)
+                     (neo-stop-command-loop-after-diagnostic-probe)))
+             (fset 'command-execute
+                   (lambda (cmd &optional _record _keys _special)
+                     (funcall cmd))))"#,
+    )
+    .expect("install command-loop diagnostic probe");
+
+    for (key, command) in [
+        ("f10", "neo-diagnostic-signaling-command"),
+        ("f11", "neo-quit-signaling-command"),
+    ] {
+        crate::emacs_core::keymap::list_keymap_define_seq(
+            global_map,
+            &[Value::symbol(key)],
+            Value::symbol(command),
+        )
+        .expect("define signaling command");
+        ev.command_loop
+            .keyboard
+            .kboard
+            .unread_events
+            .push_back(Value::symbol(key));
+    }
+    crate::emacs_core::keymap::list_keymap_define_seq(
+        global_map,
+        &[Value::fixnum('q' as i64)],
+        Value::symbol("neo-stop-after-diagnostic-command"),
+    )
+    .expect("define stop command");
+    ev.command_loop
+        .keyboard
+        .kboard
+        .unread_events
+        .push_back(Value::fixnum('q' as i64));
+    ev.command_loop.running = true;
+
+    ev.recursive_edit_inner()
+        .expect("command loop should recover from both signals");
+
+    assert_eq!(
+        ev.eval_symbol("neo-command-error-observations")
+            .expect("command error observations"),
+        Value::list(vec![
+            Value::list(vec![Value::symbol("quit")]),
+            Value::list(vec![
+                Value::symbol("void-function"),
+                Value::symbol("neo-no-such-command"),
+            ]),
+        ]),
+        "both signals must be presented through the buffer-local callback"
+    );
+    logs_assert(|logs| {
+        let event_for = |condition: &str| {
+            logs.iter().copied().find(|line| {
+                line.contains("Command loop condition:")
+                    && line.contains(&format!("condition={condition}"))
+            })
+        };
+        let Some(error) = event_for("void-function") else {
+            return Err(format!("missing void-function diagnostic in {logs:#?}"));
+        };
+        if !error.contains(" ERROR ")
+            || !error.contains("signal=(void-function (neo-no-such-command))")
+            || !error.contains("backtrace=")
+        {
+            return Err(format!(
+                "void-function event lacks ERROR severity or structured fields: {error}"
+            ));
+        }
+
+        let Some(quit) = event_for("quit") else {
+            return Err(format!("missing quit diagnostic in {logs:#?}"));
+        };
+        if !quit.contains(" DEBUG ")
+            || !quit.contains("signal=(quit nil)")
+            || !quit.contains("backtrace=")
+        {
+            return Err(format!(
+                "quit event lacks DEBUG severity or structured fields: {quit}"
+            ));
+        }
+        Ok(())
+    });
+}
+
 /// One completed command is the public observability seam: input waiting has
 /// already ended, and the command loop owns every phase through finalization.
 /// A user can therefore correlate the start/complete records without mistaking

--- a/crates/neovm-core/src/emacs_core/runtime/eval/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/eval/tests/mod.rs
@@ -414,6 +414,115 @@ fn skip_debugger_matches_raw_unibyte_ignored_error_regex() {
     );
 }
 
+/// The command loop's log ranks an uncaught signal the way GNU's debugger
+/// gate does (`skip_debugger', src/eval.c:2146-2180, over
+/// `debug-ignored-errors', lisp/bindings.el:1038-1046): a quit or an ignored
+/// condition is routine, anything else is a diagnostic.  Evil's
+/// `end-of-line' (evil-macros.el: `put' error-conditions, `cl-pushnew' onto
+/// `debug-ignored-errors') is the case that showed up as "ERROR ... End of
+/// line" on every arrow key at the end of a line.
+#[test]
+fn command_error_severity_follows_gnus_debug_ignored_errors() {
+    crate::test_utils::init_test_tracing();
+    let mut ev = Context::new();
+    crate::emacs_core::errors::init_standard_errors(&mut ev.obarray);
+    let signal_of =
+        |name: &str, data: Vec<Value>| match crate::emacs_core::error::signal(name, data) {
+            Flow::Signal(sig) => sig,
+            other => panic!("expected signal flow, got {other:?}"),
+        };
+    ev.eval_str(
+        r#"(progn
+             (put 'end-of-line 'error-conditions '(end-of-line error))
+             (put 'end-of-line 'error-message "End of line")
+             (put 'probe-child-error 'error-conditions '(probe-child-error user-error error))
+             (put 'probe-child-error 'error-message "Child of user-error")
+             (setq debug-ignored-errors nil))"#,
+    )
+    .expect("define evil's end-of-line error and a child of user-error");
+
+    // With nothing ignored, evil's error ranks like any other.
+    let end_of_line = signal_of("end-of-line", vec![]);
+    assert_eq!(
+        ev.command_error_severity(&end_of_line),
+        CommandErrorSeverity::Diagnostic
+    );
+
+    // evil pushes the condition onto `debug-ignored-errors'; GNU's default
+    // list already has `end-of-buffer' and `user-error'.
+    ev.eval_str(
+        r#"(setq debug-ignored-errors '(end-of-line end-of-buffer user-error "^Nothing at"))"#,
+    )
+    .expect("install the ignored conditions");
+    assert_eq!(
+        ev.command_error_severity(&end_of_line),
+        CommandErrorSeverity::Routine
+    );
+    let user_error = signal_of("user-error", vec![Value::string("No recent files")]);
+    assert_eq!(
+        ev.command_error_severity(&user_error),
+        CommandErrorSeverity::Routine,
+        "user-error is GNU's main ignored condition"
+    );
+    // An entry matches through `error-conditions', not only the symbol.
+    let child = signal_of("probe-child-error", vec![]);
+    assert_eq!(
+        ev.command_error_severity(&child),
+        CommandErrorSeverity::Routine,
+        "a condition inherited from user-error is ignored too"
+    );
+    // A string entry is a regexp over the rendered message.
+    let by_message = signal_of("error", vec![Value::string("Nothing at point")]);
+    assert_eq!(
+        ev.command_error_severity(&by_message),
+        CommandErrorSeverity::Routine
+    );
+
+    // A quit is routine whatever the list says (`signal_quit_p'), by the
+    // symbol or by a `quit' condition such as `minibuffer-quit'.
+    assert_eq!(
+        ev.command_error_severity(&signal_of("quit", vec![])),
+        CommandErrorSeverity::Routine
+    );
+    assert_eq!(
+        ev.command_error_severity(&signal_of("minibuffer-quit", vec![])),
+        CommandErrorSeverity::Routine
+    );
+
+    // A real error stays a diagnostic.
+    let void = signal_of("void-function", vec![Value::symbol("no-such-command")]);
+    assert_eq!(
+        ev.command_error_severity(&void),
+        CommandErrorSeverity::Diagnostic
+    );
+}
+
+/// `command_loop_2' is GNU's sole recovery owner; nothing on its error path
+/// may signal.  A string in `debug-ignored-errors' that is not a valid
+/// regexp makes the matcher signal `invalid-regexp'; that ranks the original
+/// error as a diagnostic instead of unwinding the command loop.
+#[test]
+fn command_error_severity_never_signals_on_a_bad_ignore_list() {
+    crate::test_utils::init_test_tracing();
+    let mut ev = Context::new();
+    crate::emacs_core::errors::init_standard_errors(&mut ev.obarray);
+    ev.eval_str(r#"(setq debug-ignored-errors '("[" end-of-buffer))"#)
+        .expect("install a broken regexp entry");
+    let sig = match crate::emacs_core::error::signal("end-of-buffer", vec![]) {
+        Flow::Signal(sig) => sig,
+        other => panic!("expected signal flow, got {other:?}"),
+    };
+    assert!(
+        ev.skip_debugger(&sig, &ev.signal_conditions_value(&sig))
+            .is_err(),
+        "the matcher itself signals on the broken entry"
+    );
+    assert_eq!(
+        ev.command_error_severity(&sig),
+        CommandErrorSeverity::Diagnostic
+    );
+}
+
 fn install_minimal_special_event_command_runtime(ev: &mut Context) {
     ev.eval_str(
         r#"

--- a/crates/neovm-core/src/emacs_core/runtime/eval/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/eval/tests/mod.rs
@@ -21909,6 +21909,103 @@ fn command_loop_error_uses_buffer_local_command_error_function() {
     );
 }
 
+/// GNU decides whether an error is ignored while dispatching the signal, before
+/// `cmd_error_internal' invokes the buffer-local `command-error-function'.  A
+/// presentation callback may mutate `debug-ignored-errors', but that mutation
+/// must only affect later signals, not the one already being handled.
+#[tracing_test::traced_test]
+#[test]
+fn command_loop_captures_ignored_error_severity_before_presentation() {
+    let mut ev = Context::new();
+    let scratch = ev.buffers.create_buffer("*command-error-severity*");
+    ev.buffers.set_current(scratch);
+    let frame = ev.frames.create_frame("F1", 80, 24, scratch);
+    assert!(ev.frames.select_frame(frame), "test needs a selected frame");
+    let global_map = crate::emacs_core::keymap::make_sparse_list_keymap();
+    install_global_map_for_test(&mut ev, global_map);
+
+    fn stop_command_loop_after_severity_probe(ctx: &mut Context, args: Vec<Value>) -> EvalResult {
+        assert!(args.is_empty(), "stop helper should not receive arguments");
+        ctx.command_loop.running = false;
+        Ok(Value::NIL)
+    }
+    ev.register_subr(SubrSpec::new(
+        "neo-stop-command-loop-after-severity-probe",
+        NativeFn::ContextVec(stop_command_loop_after_severity_probe),
+        SubrArity::new(0, Some(0)),
+    ));
+    ev.eval_str(
+        r#"(progn
+             (put 'end-of-line 'error-conditions '(end-of-line error))
+             (put 'end-of-line 'error-message "End of line")
+             (setq debug-ignored-errors '(end-of-line)
+                   neo-command-error-observation nil)
+             (set (make-local-variable 'command-error-function)
+                  (lambda (data _context _caller)
+                    (setq neo-command-error-observation data
+                          debug-ignored-errors nil)))
+             (fset 'neo-ignored-signaling-command
+                   (lambda () (interactive) (signal 'end-of-line nil)))
+             (fset 'neo-stop-after-severity-command
+                   (lambda ()
+                     (interactive)
+                     (neo-stop-command-loop-after-severity-probe)))
+             (fset 'command-execute
+                   (lambda (cmd &optional _record _keys _special)
+                     (funcall cmd))))"#,
+    )
+    .expect("install ignored-error severity probe");
+
+    crate::emacs_core::keymap::list_keymap_define_seq(
+        global_map,
+        &[Value::symbol("f9")],
+        Value::symbol("neo-ignored-signaling-command"),
+    )
+    .expect("define ignored signaling command");
+    crate::emacs_core::keymap::list_keymap_define_seq(
+        global_map,
+        &[Value::fixnum('q' as i64)],
+        Value::symbol("neo-stop-after-severity-command"),
+    )
+    .expect("define stop command");
+
+    ev.command_loop
+        .keyboard
+        .kboard
+        .unread_events
+        .push_back(Value::symbol("f9"));
+    ev.command_loop
+        .keyboard
+        .kboard
+        .unread_events
+        .push_back(Value::fixnum('q' as i64));
+    ev.command_loop.running = true;
+
+    ev.recursive_edit_inner()
+        .expect("command loop should recover and run the stop command");
+
+    assert_eq!(
+        ev.eval_symbol("neo-command-error-observation")
+            .expect("command error observation"),
+        Value::list(vec![Value::symbol("end-of-line")]),
+        "the ignored error must still be presented through the buffer-local callback"
+    );
+    logs_assert(|logs| {
+        let Some(line) = logs
+            .iter()
+            .find(|line| line.contains("Command loop") && line.contains("signal=(end-of-line"))
+        else {
+            return Err(format!("missing command-loop condition event in {logs:#?}"));
+        };
+        if !line.contains(" DEBUG ") {
+            return Err(format!(
+                "ignored error was not logged at DEBUG before presentation mutated state: {line}"
+            ));
+        }
+        Ok(())
+    });
+}
+
 /// One completed command is the public observability seam: input waiting has
 /// already ended, and the command loop owns every phase through finalization.
 /// A user can therefore correlate the start/complete records without mistaking

--- a/crates/neovm-core/src/emacs_core/runtime/eval/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/eval/tests/mod.rs
@@ -21824,69 +21824,63 @@ fn command_loop_test_context() -> Context {
     ev
 }
 
-/// GNU `command_loop_2' catches an unhandled command signal with `cmd_error',
-/// which delegates to the current buffer's `command-error-function'.  This is
-/// load-bearing in an active minibuffer: `minibuffer-error-initialize' installs
-/// a buffer-local handler that renders the diagnostic as an EOB overlay instead
-/// of replacing the prompt in the echo area.
-#[test]
-fn command_loop_error_uses_buffer_local_command_error_function() {
-    crate::test_utils::init_test_tracing();
+fn stop_command_loop_error_test(ctx: &mut Context, args: Vec<Value>) -> EvalResult {
+    assert!(args.is_empty(), "stop helper should not receive arguments");
+    ctx.command_loop.running = false;
+    Ok(Value::NIL)
+}
+
+/// Build the minimal interactive state shared by command-error recovery tests.
+fn command_loop_error_test_context() -> (Context, Value) {
     let mut ev = Context::new();
-    let scratch = ev.buffers.create_buffer("*command-error-function*");
+    let scratch = ev.buffers.create_buffer("*command-loop-error-test*");
     ev.buffers.set_current(scratch);
     let frame = ev.frames.create_frame("F1", 80, 24, scratch);
     assert!(ev.frames.select_frame(frame), "test needs a selected frame");
     let global_map = crate::emacs_core::keymap::make_sparse_list_keymap();
     install_global_map_for_test(&mut ev, global_map);
 
-    fn stop_command_loop_after_error_probe(ctx: &mut Context, args: Vec<Value>) -> EvalResult {
-        assert!(args.is_empty(), "stop helper should not receive arguments");
-        ctx.command_loop.running = false;
-        Ok(Value::NIL)
-    }
     ev.register_subr(SubrSpec::new(
-        "neo-stop-command-loop-after-error-probe",
-        NativeFn::ContextVec(stop_command_loop_after_error_probe),
+        "neo-stop-command-loop-error-test",
+        NativeFn::ContextVec(stop_command_loop_error_test),
         SubrArity::new(0, Some(0)),
     ));
     ev.eval_str(
         r#"(progn
-             (setq neo-command-error-observation nil)
-             (set (make-local-variable 'command-error-function)
-                  (lambda (data context caller)
-                    (setq neo-command-error-observation
-                          (list data context caller))))
-             (fset 'neo-signaling-command
-                   (lambda () (interactive) (signal 'error '("boom"))))
-             (fset 'neo-stop-after-error-command
+             (fset 'neo-stop-command-loop-error-test-command
                    (lambda ()
                      (interactive)
-                     (neo-stop-command-loop-after-error-probe)))
+                     (neo-stop-command-loop-error-test)))
              (fset 'command-execute
                    (lambda (cmd &optional _record _keys _special)
                      (funcall cmd))))"#,
     )
-    .expect("install command-error dispatch probe");
+    .expect("install command-loop error test harness");
+    (ev, global_map)
+}
 
-    crate::emacs_core::keymap::list_keymap_define_seq(
-        global_map,
-        &[Value::symbol("f9")],
-        Value::symbol("neo-signaling-command"),
-    )
-    .expect("define signaling command");
+/// Queue commands behind synthetic function keys, then a final command that
+/// stops the recursive edit after every signal has passed through recovery.
+fn run_command_loop_error_commands(ev: &mut Context, global_map: Value, commands: &[(&str, &str)]) {
+    for &(key, command) in commands {
+        crate::emacs_core::keymap::list_keymap_define_seq(
+            global_map,
+            &[Value::symbol(key)],
+            Value::symbol(command),
+        )
+        .expect("define signaling command");
+        ev.command_loop
+            .keyboard
+            .kboard
+            .unread_events
+            .push_back(Value::symbol(key));
+    }
     crate::emacs_core::keymap::list_keymap_define_seq(
         global_map,
         &[Value::fixnum('q' as i64)],
-        Value::symbol("neo-stop-after-error-command"),
+        Value::symbol("neo-stop-command-loop-error-test-command"),
     )
     .expect("define stop command");
-
-    ev.command_loop
-        .keyboard
-        .kboard
-        .unread_events
-        .push_back(Value::symbol("f9"));
     ev.command_loop
         .keyboard
         .kboard
@@ -21896,6 +21890,30 @@ fn command_loop_error_uses_buffer_local_command_error_function() {
 
     ev.recursive_edit_inner()
         .expect("command loop should recover and run the stop command");
+}
+
+/// GNU `command_loop_2' catches an unhandled command signal with `cmd_error',
+/// which delegates to the current buffer's `command-error-function'.  This is
+/// load-bearing in an active minibuffer: `minibuffer-error-initialize' installs
+/// a buffer-local handler that renders the diagnostic as an EOB overlay instead
+/// of replacing the prompt in the echo area.
+#[test]
+fn command_loop_error_uses_buffer_local_command_error_function() {
+    crate::test_utils::init_test_tracing();
+    let (mut ev, global_map) = command_loop_error_test_context();
+    ev.eval_str(
+        r#"(progn
+             (setq neo-command-error-observation nil)
+             (set (make-local-variable 'command-error-function)
+                  (lambda (data context caller)
+                    (setq neo-command-error-observation
+                          (list data context caller))))
+             (fset 'neo-signaling-command
+                   (lambda () (interactive) (signal 'error '("boom")))))"#,
+    )
+    .expect("install command-error dispatch probe");
+
+    run_command_loop_error_commands(&mut ev, global_map, &[("f9", "neo-signaling-command")]);
 
     assert_eq!(
         ev.eval_symbol("neo-command-error-observation")
@@ -21916,24 +21934,7 @@ fn command_loop_error_uses_buffer_local_command_error_function() {
 #[tracing_test::traced_test]
 #[test]
 fn command_loop_captures_ignored_error_severity_before_presentation() {
-    let mut ev = Context::new();
-    let scratch = ev.buffers.create_buffer("*command-error-severity*");
-    ev.buffers.set_current(scratch);
-    let frame = ev.frames.create_frame("F1", 80, 24, scratch);
-    assert!(ev.frames.select_frame(frame), "test needs a selected frame");
-    let global_map = crate::emacs_core::keymap::make_sparse_list_keymap();
-    install_global_map_for_test(&mut ev, global_map);
-
-    fn stop_command_loop_after_severity_probe(ctx: &mut Context, args: Vec<Value>) -> EvalResult {
-        assert!(args.is_empty(), "stop helper should not receive arguments");
-        ctx.command_loop.running = false;
-        Ok(Value::NIL)
-    }
-    ev.register_subr(SubrSpec::new(
-        "neo-stop-command-loop-after-severity-probe",
-        NativeFn::ContextVec(stop_command_loop_after_severity_probe),
-        SubrArity::new(0, Some(0)),
-    ));
+    let (mut ev, global_map) = command_loop_error_test_context();
     ev.eval_str(
         r#"(progn
              (put 'end-of-line 'error-conditions '(end-of-line error))
@@ -21945,44 +21946,15 @@ fn command_loop_captures_ignored_error_severity_before_presentation() {
                     (setq neo-command-error-observation data
                           debug-ignored-errors nil)))
              (fset 'neo-ignored-signaling-command
-                   (lambda () (interactive) (signal 'end-of-line nil)))
-             (fset 'neo-stop-after-severity-command
-                   (lambda ()
-                     (interactive)
-                     (neo-stop-command-loop-after-severity-probe)))
-             (fset 'command-execute
-                   (lambda (cmd &optional _record _keys _special)
-                     (funcall cmd))))"#,
+                   (lambda () (interactive) (signal 'end-of-line nil))))"#,
     )
     .expect("install ignored-error severity probe");
 
-    crate::emacs_core::keymap::list_keymap_define_seq(
+    run_command_loop_error_commands(
+        &mut ev,
         global_map,
-        &[Value::symbol("f9")],
-        Value::symbol("neo-ignored-signaling-command"),
-    )
-    .expect("define ignored signaling command");
-    crate::emacs_core::keymap::list_keymap_define_seq(
-        global_map,
-        &[Value::fixnum('q' as i64)],
-        Value::symbol("neo-stop-after-severity-command"),
-    )
-    .expect("define stop command");
-
-    ev.command_loop
-        .keyboard
-        .kboard
-        .unread_events
-        .push_back(Value::symbol("f9"));
-    ev.command_loop
-        .keyboard
-        .kboard
-        .unread_events
-        .push_back(Value::fixnum('q' as i64));
-    ev.command_loop.running = true;
-
-    ev.recursive_edit_inner()
-        .expect("command loop should recover and run the stop command");
+        &[("f9", "neo-ignored-signaling-command")],
+    );
 
     assert_eq!(
         ev.eval_symbol("neo-command-error-observation")
@@ -22014,24 +21986,7 @@ fn command_loop_captures_ignored_error_severity_before_presentation() {
 #[tracing_test::traced_test]
 #[test]
 fn command_loop_emits_typed_diagnostics_for_error_and_quit() {
-    let mut ev = Context::new();
-    let scratch = ev.buffers.create_buffer("*command-loop-diagnostics*");
-    ev.buffers.set_current(scratch);
-    let frame = ev.frames.create_frame("F1", 80, 24, scratch);
-    assert!(ev.frames.select_frame(frame), "test needs a selected frame");
-    let global_map = crate::emacs_core::keymap::make_sparse_list_keymap();
-    install_global_map_for_test(&mut ev, global_map);
-
-    fn stop_command_loop_after_diagnostic_probe(ctx: &mut Context, args: Vec<Value>) -> EvalResult {
-        assert!(args.is_empty(), "stop helper should not receive arguments");
-        ctx.command_loop.running = false;
-        Ok(Value::NIL)
-    }
-    ev.register_subr(SubrSpec::new(
-        "neo-stop-command-loop-after-diagnostic-probe",
-        NativeFn::ContextVec(stop_command_loop_after_diagnostic_probe),
-        SubrArity::new(0, Some(0)),
-    ));
+    let (mut ev, global_map) = command_loop_error_test_context();
     ev.eval_str(
         r#"(progn
              (setq debug-ignored-errors nil
@@ -22045,48 +22000,18 @@ fn command_loop_emits_typed_diagnostics_for_error_and_quit() {
              (fset 'neo-diagnostic-signaling-command
                    (lambda () (interactive) (neo-no-such-command)))
              (fset 'neo-quit-signaling-command
-                   (lambda () (interactive) (signal 'quit nil)))
-             (fset 'neo-stop-after-diagnostic-command
-                   (lambda ()
-                     (interactive)
-                     (neo-stop-command-loop-after-diagnostic-probe)))
-             (fset 'command-execute
-                   (lambda (cmd &optional _record _keys _special)
-                     (funcall cmd))))"#,
+                   (lambda () (interactive) (signal 'quit nil))))"#,
     )
     .expect("install command-loop diagnostic probe");
 
-    for (key, command) in [
-        ("f10", "neo-diagnostic-signaling-command"),
-        ("f11", "neo-quit-signaling-command"),
-    ] {
-        crate::emacs_core::keymap::list_keymap_define_seq(
-            global_map,
-            &[Value::symbol(key)],
-            Value::symbol(command),
-        )
-        .expect("define signaling command");
-        ev.command_loop
-            .keyboard
-            .kboard
-            .unread_events
-            .push_back(Value::symbol(key));
-    }
-    crate::emacs_core::keymap::list_keymap_define_seq(
+    run_command_loop_error_commands(
+        &mut ev,
         global_map,
-        &[Value::fixnum('q' as i64)],
-        Value::symbol("neo-stop-after-diagnostic-command"),
-    )
-    .expect("define stop command");
-    ev.command_loop
-        .keyboard
-        .kboard
-        .unread_events
-        .push_back(Value::fixnum('q' as i64));
-    ev.command_loop.running = true;
-
-    ev.recursive_edit_inner()
-        .expect("command loop should recover from both signals");
+        &[
+            ("f10", "neo-diagnostic-signaling-command"),
+            ("f11", "neo-quit-signaling-command"),
+        ],
+    );
 
     assert_eq!(
         ev.eval_symbol("neo-command-error-observations")


### PR DESCRIPTION
Fixes #342.

Pressing an arrow key at the end of a line under evil shows "End of line" in the echo area exactly as GNU does, and also logs

```
ERROR neovm_core::emacs_core::eval: Command loop error: End of line [signal=(end-of-line nil)] condition=end-of-line
```

on every keystroke, and the same for every `C-g`. Evil defines `end-of-line` as an error and pushes it onto `debug-ignored-errors` (evil-macros.el).

GNU's command loop never logs: `cmd_error_internal` (src/keyboard.c:1030-1047, emacs-31.0.90) hands the signal to `command-error-function` and that is the whole handling. The log line is this port's diagnostic, and it ranked every signal the same. GNU ranks signals in one place, the debugger gate `skip_debugger` (src/eval.c:2146-2180) over `debug-ignored-errors` (defaults in lisp/bindings.el:1038-1046: `beginning-of-line`, `end-of-line`, `end-of-buffer`, `buffer-read-only`, `user-error`, ...), and a quit is routine by construction (`signal_quit_p`, src/eval.c:2181-2190).

`Context::command_error_severity` applies that ranking through the existing `skip_debugger` matcher and the crate's quit predicate, as a closed `CommandErrorSeverity { Routine, Diagnostic }`. `command_loop_2` logs a routine signal at debug and keeps the error level, with condition and payload, for everything else, so a void function in a command still reaches a bug report. Presentation is unchanged: `report_command_error` still runs first through Lisp's buffer-local `command-error-function`.

**Declared departures from GNU.** GNU consults `skip_debugger` only when the debugger is otherwise wanted (`maybe_call_debugger`, src/eval.c:2206-2213); the log has no such gate, so the list is evaluated on every uncaught command signal. And the ranking runs inside `command_loop_2`, GNU's sole recovery owner, where nothing may signal: a string entry in `debug-ignored-errors` that is not a valid regexp makes the matcher signal `invalid-regexp`. The classification is therefore infallible and a matcher failure ranks the original error as a diagnostic; a test pins that.

**Tests, red first:** `command_error_severity_follows_gnus_debug_ignored_errors` (evil's `end-of-line` is a diagnostic with an empty list and routine once listed; `user-error`, a condition inheriting from it, and a regexp entry over the message are routine; `quit` and `minibuffer-quit` are routine whatever the list says; `void-function` stays a diagnostic) and `command_error_severity_never_signals_on_a_bad_ignore_list`.

**Verified on macOS:** the two tests, rustfmt, and a GUI run of the release build feeding the real command loop a command that signals `end-of-line` and one that calls a void function: the first logs at debug only, the second keeps its ERROR line. **Not run:** Linux and Windows (platform-neutral Rust in neovm-core); clippy on neovm-core's tests stops on a pre-existing `never_loop` error in the process tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117NsCB7AbwgdEqduGF5Kww
