### PR TITLE
fix(layout): end a leaf at its start once the visibility retry budget is spent

### DIFF
--- a/crates/neomacs-layout-engine/src/buffer_source/render_attempt.rs
+++ b/crates/neomacs-layout-engine/src/buffer_source/render_attempt.rs
@@ -424,28 +424,17 @@ impl BufferSourceRetryPlan {
         self.retry.retry_window_start()
     }
 
+    /// The viewport decision the frame coordinator still has to act on, if
+    /// any. `None` leaves the start to [`Self::should_retry`], which moves it
+    /// only while retries remain; see [`ViewportDecision::resolve_with_budget`]
+    /// for the GNU bound this enforces once the visibility retries are spent.
     pub(crate) fn viewport_resolution(
         &self,
         remaining_visibility_retries: usize,
     ) -> Option<ViewportDecision> {
-        match self.retry.viewport_decision() {
-            ViewportDecision::NeedMoreMeasurement(measurement)
-                if remaining_visibility_retries > 0 =>
-            {
-                Some(ViewportDecision::NeedMoreMeasurement(measurement))
-            }
-            ViewportDecision::NeedMoreMeasurement(measurement) => {
-                Some(measurement.fallback_placement())
-            }
-            decision @ ViewportDecision::PlaceRelativeToPoint { .. }
-                if remaining_visibility_retries > 0 =>
-            {
-                Some(decision)
-            }
-            ViewportDecision::Keep
-            | ViewportDecision::Commit { .. }
-            | ViewportDecision::PlaceRelativeToPoint { .. } => None,
-        }
+        self.retry
+            .viewport_decision()
+            .resolve_with_budget(remaining_visibility_retries, self.retry.start())
     }
 
     /// Target for GNU's force_start point move: the last fully-visible

--- a/crates/neomacs-layout-engine/src/display_text_window_row_lifecycle.rs
+++ b/crates/neomacs-layout-engine/src/display_text_window_row_lifecycle.rs
@@ -29,7 +29,9 @@ use crate::scroll_policy::{
     line_start_below,
 };
 use crate::types::WindowParams;
-use crate::viewport_resolution::{ForwardViewportMeasurement, ViewportDecision};
+use crate::viewport_resolution::{
+    ForwardViewportMeasurement, ViewportAttemptStart, ViewportDecision,
+};
 use crate::window_output::{
     DisplayTextRowBegin, TextWindowBegin, TextWindowBodyOutputInstall, TextWindowCursorEffects,
     TextWindowOutputTarget, TextWindowPendingRowFinish, TextWindowRedisplayPositions,
@@ -337,7 +339,9 @@ impl TextWindowFinishOutput {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct TextWindowVisibilityRetryOutcome {
-    semantic_window_start: i64,
+    /// The start the rows behind this outcome were laid out from: the
+    /// publishable one, or a forward measurement probe and its origin.
+    start: ViewportAttemptStart,
     visible_end_lisp: Option<LispCharPos1>,
     visible_progress: i64,
     point_beyond_visible_span: bool,
@@ -795,11 +799,12 @@ impl<'a, 'buf, B: LayoutBufferView> TextWindowVisibilityRetryRequest<'a, 'buf, B
     }
 
     pub(crate) fn decide(self) -> TextWindowVisibilityRetryOutcome {
-        let semantic_window_start = self
-            .forward_viewport_measurement
-            .map_or(self.window_start, |measurement| {
-                measurement.origin_window_start().get()
-            });
+        let start = self.forward_viewport_measurement.map_or(
+            ViewportAttemptStart::Semantic(self.window_start),
+            |measurement| ViewportAttemptStart::MeasurementProbe {
+                origin: measurement.origin_window_start().get(),
+            },
+        );
         let point_lisp = layout_i64_char_pos_to_lisp_char_pos(self.point_charpos);
         let visible_end_lisp = self.rows.iter().rev().find_map(|row| row.end_buffer_pos);
         let visible_end_lisp = if self.point_is_visible_eob {
@@ -844,7 +849,7 @@ impl<'a, 'buf, B: LayoutBufferView> TextWindowVisibilityRetryRequest<'a, 'buf, B
         );
 
         TextWindowVisibilityRetryOutcome {
-            semantic_window_start,
+            start,
             visible_end_lisp,
             visible_progress,
             point_beyond_visible_span,
@@ -1025,7 +1030,7 @@ impl TextWindowFinishRequest {
 
 impl TextWindowVisibilityRetryOutcome {
     pub(crate) fn semantic_window_start(&self) -> i64 {
-        self.semantic_window_start
+        self.start.semantic_window_start()
     }
 
     pub(crate) fn visible_end_lisp(&self) -> Option<LispCharPos1> {
@@ -1048,6 +1053,10 @@ impl TextWindowVisibilityRetryOutcome {
 
     pub(crate) fn viewport_decision(&self) -> ViewportDecision {
         self.scroll_down.clone()
+    }
+
+    pub(crate) fn start(&self) -> ViewportAttemptStart {
+        self.start
     }
 
     pub(crate) fn point_row_window_start(&self) -> Option<i64> {

--- a/crates/neomacs-layout-engine/src/engine.rs
+++ b/crates/neomacs-layout-engine/src/engine.rs
@@ -3837,6 +3837,11 @@ impl LayoutEngine {
                 // phases are exempt: their start is a probe, and a commit of
                 // the same position re-runs the producer *without* the probe
                 // continuation, which can legitimately converge differently.
+                //
+                // A zero budget is the producer's signal to finish at the
+                // committed start (`ViewportDecision::resolve_with_budget`,
+                // GNU `redisplay_window`'s `done:`), so the retry below is
+                // the last attempt for this leaf.
                 let reattempting_current_start =
                     !matches!(&viewport_resolution, ViewportResolutionPhase::Measure(_))
                         && resolved_start.get() == params.window_start;

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -9980,6 +9980,214 @@ fn distant_point_with_unrelated_overlay_does_not_exhaust_visibility_retries() {
     );
 }
 
+/// The dashboard scenario behind "SPC SPC hangs after a resize": a completion
+/// UI grows the minibuffer, the selected window shrinks under point, and the
+/// redisplay that follows runs while the *minibuffer* is the current buffer.
+/// The point-relative placement must be resolved in the window's buffer (GNU
+/// `redisplay_window` selects `w->contents` before `recenter:`,
+/// src/xdisp.c:20532-20535, emacs-31.0.90), and once the retry budget is
+/// spent the leaf must end at the start it has (xdisp.c:21384-21398 `done:`)
+/// rather than ask for the same placement forever.
+#[test]
+fn point_placement_with_a_foreign_current_buffer_terminates_and_shows_point() {
+    let mut eval = Context::new();
+    let buf_id = eval
+        .buffer_manager()
+        .current_buffer()
+        .expect("current buffer")
+        .id();
+    let text = (0..600)
+        .map(|index| format!("ordinary line {index:03}\n"))
+        .collect::<String>();
+    let hidden_start = text.find("ordinary line 100").expect("line 100");
+    let hidden_end = text.find("ordinary line 110").expect("line 110");
+    {
+        let buf = eval.buffer_manager_mut().get_mut(buf_id).expect("buffer");
+        buf.insert(&text);
+        // A hidden span between the visible rows and point makes the producer
+        // measure display rows instead of counting source lines, which is the
+        // path that asks core display motion for the placement.
+        assert!(buf.put_text_property(
+            hidden_start,
+            hidden_end,
+            Value::symbol("invisible"),
+            Value::T
+        ));
+        buf.set_buffer_local("scroll-conservatively", Value::fixnum(30));
+        buf.goto_emacs_byte_pos(EmacsBytePos::new(0));
+    }
+    let frame_id = eval.frame_manager_mut().create_frame(
+        "placement-with-foreign-current-buffer",
+        640,
+        224,
+        buf_id,
+    );
+    let selected_window = eval
+        .frame_manager()
+        .get(frame_id)
+        .expect("frame")
+        .selected_window;
+    let mut engine = LayoutEngine::new();
+    engine.layout_frame_rust(&mut eval, frame_id);
+
+    let point = text.find("ordinary line 500").expect("line 500") + 3;
+    eval.buffer_manager_mut()
+        .goto_buffer_emacs_byte_pos(buf_id, EmacsBytePos::new(point));
+    {
+        let frame = eval.frame_manager_mut().get_mut(frame_id).expect("frame");
+        let neovm_core::window::Window::Leaf {
+            point: window_point,
+            ..
+        } = frame
+            .find_window_mut(selected_window)
+            .expect("selected window")
+        else {
+            panic!("selected window is not a leaf");
+        };
+        *window_point = LispCharPos1::new((point + 1) as i64);
+    }
+    // Redisplay is entered with the active minibuffer current: a buffer far
+    // smaller than any position the placement scans in the window's buffer.
+    eval.eval_str("(progn (set-buffer (get-buffer-create \" *tiny-minibuf*\")) (insert \"M-x \"))")
+        .expect("select a tiny current buffer");
+    let tiny = eval
+        .buffer_manager()
+        .current_buffer()
+        .expect("current buffer")
+        .id();
+    assert_ne!(
+        tiny, buf_id,
+        "the fixture must redisplay with a foreign current buffer"
+    );
+
+    engine.layout_frame_rust(&mut eval, frame_id);
+
+    assert!(
+        engine
+            .last_frame_display_state
+            .as_ref()
+            .and_then(|state| state.phys_cursor.as_ref())
+            .is_some(),
+        "point must be placed in the window by display-row motion over the \
+         window's buffer, not the current one"
+    );
+    assert_eq!(
+        eval.buffer_manager()
+            .current_buffer()
+            .map(|buffer| buffer.id()),
+        Some(tiny),
+        "redisplay restores the current buffer it was entered with"
+    );
+}
+
+/// The leaf loop must end once the visibility retry budget is spent even
+/// when the point-relative placement resolves to the start already laid out.
+///
+/// The first source line carries a `display` string of thirty rows. The row
+/// producer fills the window with those rows, so point on the second source
+/// line is beyond the visible span, and a hidden span before point forces a
+/// display-row measurement; core screen-line motion counts that first line
+/// as one screen line, so every placement relative to point clamps back to
+/// the window start. The old decision table turned the spent-budget
+/// measurement that followed into another placement request and re-entered
+/// the leaf with the same inputs forever; GNU ends the pass at `done:`
+/// (src/xdisp.c:21384-21398, emacs-31.0.90). The layout runs on a helper
+/// thread so a regression fails on the timeout instead of hanging the test
+/// binary.
+#[test]
+fn spent_visibility_budget_ends_the_leaf_at_its_start() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::Builder::new()
+        .stack_size(256 << 20)
+        .spawn(move || {
+            let mut eval = Context::new();
+            let buf_id = eval
+                .buffer_manager()
+                .current_buffer()
+                .expect("current buffer")
+                .id();
+            let text = format!(
+                "ab\n{}",
+                (0..20)
+                    .map(|index| format!("ordinary line {index:03}\n"))
+                    .collect::<String>()
+            );
+            let replacement = (0..30)
+                .map(|index| format!("replacement row {index:02}\n"))
+                .collect::<String>();
+            let point = text.find("ordinary line 000").expect("line 000") + 3;
+            {
+                let buf = eval.buffer_manager_mut().get_mut(buf_id).expect("buffer");
+                buf.insert(&text);
+                // The replacement sits on the second character so the walk
+                // makes progress past the window start before it fills the
+                // window; a walk with no progress is settled, not scrolled.
+                assert!(buf.put_text_property(
+                    1,
+                    2,
+                    Value::symbol("display"),
+                    Value::string(&replacement)
+                ));
+                // A hidden span between the visible rows and point makes the
+                // producer measure display rows instead of source lines.
+                assert!(buf.put_text_property(
+                    point - 2,
+                    point,
+                    Value::symbol("invisible"),
+                    Value::T
+                ));
+                buf.set_buffer_local("scroll-conservatively", Value::fixnum(30));
+                buf.goto_emacs_byte_pos(EmacsBytePos::new(point));
+            }
+            let frame_id = eval.frame_manager_mut().create_frame(
+                "spent-budget-placement-clamps-to-start",
+                640,
+                224,
+                buf_id,
+            );
+            let selected_window = eval
+                .frame_manager()
+                .get(frame_id)
+                .expect("frame")
+                .selected_window;
+            {
+                let frame = eval.frame_manager_mut().get_mut(frame_id).expect("frame");
+                let neovm_core::window::Window::Leaf {
+                    point: window_point,
+                    ..
+                } = frame
+                    .find_window_mut(selected_window)
+                    .expect("selected window")
+                else {
+                    panic!("selected window is not a leaf");
+                };
+                *window_point = LispCharPos1::new((point + 1) as i64);
+            }
+            let mut engine = LayoutEngine::new();
+            engine.layout_frame_rust(&mut eval, frame_id);
+            let prepared = engine.last_frame_display_state.is_some();
+            let window_start = eval
+                .frame_manager()
+                .get(frame_id)
+                .and_then(|frame| frame.find_window(selected_window))
+                .and_then(neovm_core::window::Window::window_start)
+                .map(|start| start.as_i64());
+            tx.send((prepared, window_start))
+                .expect("report the layout outcome");
+        })
+        .expect("spawn the layout thread");
+
+    let (prepared, window_start) = rx
+        .recv_timeout(std::time::Duration::from_secs(120))
+        .expect("the leaf loop must end once its visibility retry budget is spent");
+    assert!(prepared, "a bounded leaf still publishes the frame");
+    assert_eq!(
+        window_start,
+        Some(1),
+        "with no retries left and no better placement, the leaf ends at the start it had"
+    );
+}
+
 #[test]
 fn layout_frame_rust_renders_invisible_ellipsis_through_row_builder() {
     let mut eval = Context::new();

--- a/crates/neomacs-layout-engine/src/viewport_resolution.rs
+++ b/crates/neomacs-layout-engine/src/viewport_resolution.rs
@@ -26,6 +26,82 @@ pub(crate) enum ViewportDecision {
     },
 }
 
+/// The start the rows behind a decision were laid out from.
+///
+/// The frame coordinator may publish a semantic start as the window's
+/// viewport, but a measurement probe is evidence only
+/// ([`ForwardViewportMeasurement::probe_window_start`]): rows produced from
+/// it can never become the accepted presentation, and the semantic start
+/// they stand in for is the probe's origin.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ViewportAttemptStart {
+    /// `window-start`, or a placement the coordinator already committed.
+    Semantic(i64),
+    /// A transient forward probe rooted at `origin`, the last semantic start.
+    MeasurementProbe { origin: i64 },
+}
+
+impl ViewportAttemptStart {
+    /// The start that is Lisp-visible for this attempt.
+    pub(crate) const fn semantic_window_start(self) -> i64 {
+        match self {
+            Self::Semantic(start) | Self::MeasurementProbe { origin: start } => start,
+        }
+    }
+}
+
+impl ViewportDecision {
+    /// Resolve this decision against the leaf attempts the coordinator can
+    /// still grant.
+    ///
+    /// GNU bounds the same search in two places: `try_scrolling` gives up
+    /// once point is more than `scroll_max` lines away (src/xdisp.c:19445-
+    /// 19446, emacs-31.0.90) and, after `try_window` has run from the
+    /// `recenter:` start, `redisplay_window` re-recenters at most twice
+    /// before reaching `done:` with whatever start it has (xdisp.c:21360-
+    /// 21398). With retries left, the decision stands. With none left, a
+    /// semantic start is final: returning `None` lets the producer finish
+    /// its rows there, the port's `done:`. A probe start is never
+    /// publishable, so its decision is replaced by the policy's
+    /// point-relative placement, which the coordinator commits with no
+    /// retries left and the producer then accepts on the next attempt.
+    /// Every path therefore ends at most one leaf attempt after the budget
+    /// is spent; the caller must never re-derive a decision from a spent
+    /// budget on its own.
+    ///
+    /// Declared divergence: GNU answers `SCROLLING_FAILED` with `recenter:`
+    /// (xdisp.c:21097-21108) and so always ends with a start placed around
+    /// point. The coordinator spends its last retry on that placement; when
+    /// core display motion cannot produce one (it returned the start already
+    /// laid out), the leaf ends at that start and point may be outside the
+    /// window for this redisplay, where GNU would have recentered. Ending
+    /// there is what keeps the leaf loop bounded.
+    pub(crate) fn resolve_with_budget(
+        self,
+        remaining_visibility_retries: usize,
+        start: ViewportAttemptStart,
+    ) -> Option<Self> {
+        match self {
+            Self::Keep | Self::Commit { .. } => None,
+            Self::NeedMoreMeasurement(_) | Self::PlaceRelativeToPoint { .. }
+                if remaining_visibility_retries > 0 =>
+            {
+                Some(self)
+            }
+            Self::NeedMoreMeasurement(measurement) => match start {
+                ViewportAttemptStart::Semantic(_) => None,
+                ViewportAttemptStart::MeasurementProbe { .. } => {
+                    Some(measurement.fallback_placement())
+                }
+            },
+            Self::PlaceRelativeToPoint { .. } => match start {
+                ViewportAttemptStart::Semantic(_) => None,
+                ViewportAttemptStart::MeasurementProbe { .. } => Some(self),
+            },
+        }
+    }
+}
+
 /// A forward display-row probe rooted at the last semantic `window-start`.
 ///
 /// `probe_window_start` is deliberately not a candidate for publication.  The
@@ -362,5 +438,102 @@ mod tests {
             },
             "a transient probe must not become the presentation when its rows cannot supply a policy-approved start"
         );
+    }
+
+    fn probe_measurement() -> ForwardViewportMeasurement {
+        let initial = vec![row(0, 1, 10), row(1, 11, 20), row(2, 21, 30)];
+        let ViewportDecision::NeedMoreMeasurement(measurement) = ForwardViewportMeasurement::begin(
+            &initial,
+            ResolvedWindowStart::from_layout_charpos(1),
+            ScrollPolicy::Conservative { max_lines: 30 },
+            0,
+        ) else {
+            panic!("a bounded conservative policy measures forward first")
+        };
+        measurement
+    }
+
+    #[test]
+    fn budget_left_keeps_the_producer_decision() {
+        let measurement = probe_measurement();
+        assert_eq!(
+            ViewportDecision::NeedMoreMeasurement(measurement.clone())
+                .resolve_with_budget(1, ViewportAttemptStart::Semantic(1)),
+            Some(ViewportDecision::NeedMoreMeasurement(measurement))
+        );
+        let placement = ViewportDecision::PlaceRelativeToPoint {
+            lines_above_point: 0,
+            fallback_window_start: ResolvedWindowStart::from_layout_charpos(1),
+        };
+        assert_eq!(
+            placement
+                .clone()
+                .resolve_with_budget(1, ViewportAttemptStart::MeasurementProbe { origin: 1 }),
+            Some(placement)
+        );
+    }
+
+    #[test]
+    fn spent_budget_ends_the_leaf_at_a_semantic_start() {
+        // The hang behind "SPC SPC after a resize": with no retries left the
+        // producer kept asking for a placement that resolved to the start it
+        // already had. GNU reaches `done:` instead (xdisp.c:21384-21398).
+        let measurement = probe_measurement();
+        assert_eq!(
+            ViewportDecision::NeedMoreMeasurement(measurement)
+                .resolve_with_budget(0, ViewportAttemptStart::Semantic(1)),
+            None
+        );
+        assert_eq!(
+            ViewportDecision::PlaceRelativeToPoint {
+                lines_above_point: 0,
+                fallback_window_start: ResolvedWindowStart::from_layout_charpos(1),
+            }
+            .resolve_with_budget(0, ViewportAttemptStart::Semantic(1)),
+            None
+        );
+    }
+
+    #[test]
+    fn spent_budget_never_publishes_a_measurement_probe() {
+        let measurement = probe_measurement();
+        let fallback = measurement.fallback_placement();
+        assert!(matches!(
+            fallback,
+            ViewportDecision::PlaceRelativeToPoint { .. }
+        ));
+        assert_eq!(
+            ViewportDecision::NeedMoreMeasurement(measurement)
+                .resolve_with_budget(0, ViewportAttemptStart::MeasurementProbe { origin: 1 }),
+            Some(fallback.clone())
+        );
+        assert_eq!(
+            fallback
+                .clone()
+                .resolve_with_budget(0, ViewportAttemptStart::MeasurementProbe { origin: 1 }),
+            Some(fallback)
+        );
+    }
+
+    #[test]
+    fn settled_decisions_need_no_retry_at_any_budget() {
+        for budget in [0, 1] {
+            for start in [
+                ViewportAttemptStart::Semantic(1),
+                ViewportAttemptStart::MeasurementProbe { origin: 1 },
+            ] {
+                assert_eq!(
+                    ViewportDecision::Keep.resolve_with_budget(budget, start),
+                    None
+                );
+                assert_eq!(
+                    ViewportDecision::Commit {
+                        window_start: ResolvedWindowStart::from_layout_charpos(1)
+                    }
+                    .resolve_with_budget(budget, start),
+                    None
+                );
+            }
+        }
     }
 }

--- a/crates/neovm-core/src/emacs_core/display/xdisp/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/xdisp/mod.rs
@@ -48,6 +48,15 @@ impl super::eval::Context {
     /// can wrap, fold, or be replaced. `None` leaves the caller's semantic
     /// viewport unchanged; a failed motion must never turn into a jump to
     /// `point-min`.
+    ///
+    /// GNU reaches `recenter:` inside `redisplay_window`, after
+    /// `set_buffer_internal_1 (XBUFFER (w->contents))` (xdisp.c:20532-20535,
+    /// emacs-31.0.90), so the iterator and every text-property probe it makes
+    /// read the window's buffer. Redisplay here is entered with whatever
+    /// buffer Lisp left current -- the active minibuffer while a completion
+    /// UI is up -- so this helper selects `buffer_id` for the scan and hands
+    /// the caller's buffer back afterwards, as `with_frame_display_context`
+    /// does for mode-line Lisp.
     pub fn redisplay_start_before_point_by_display_rows(
         &mut self,
         buffer_id: BufferId,
@@ -62,13 +71,29 @@ impl super::eval::Context {
         else {
             return None;
         };
-        let start_byte = match super::indent::scan_screen_line_motion_target(
+        let saved_buffer_id = self.buffers.current_buffer_id();
+        if saved_buffer_id != Some(buffer_id)
+            && let Err(flow) = self.set_current_buffer_unrecorded(buffer_id)
+        {
+            tracing::debug!(
+                "display-row viewport placement cannot select the window buffer: {flow:?}"
+            );
+            if let Some(saved_buffer_id) = saved_buffer_id {
+                self.restore_current_buffer_if_live(saved_buffer_id);
+            }
+            return None;
+        }
+        let motion = super::indent::scan_screen_line_motion_target(
             self,
             buffer_id,
             point_byte,
             Some(Value::make_window(window_id.0)),
             -rows.max(0),
-        ) {
+        );
+        if let Some(saved_buffer_id) = saved_buffer_id {
+            self.restore_current_buffer_if_live(saved_buffer_id);
+        }
+        let start_byte = match motion {
             Ok(motion) => motion.target,
             Err(flow) => {
                 tracing::debug!("display-row viewport placement failed: {flow:?}");

--- a/crates/neovm-core/src/emacs_core/display/xdisp/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/xdisp/tests/mod.rs
@@ -6107,3 +6107,58 @@ fn window_line_height_refuses_every_line_form_without_a_current_matrix_like_gnu(
         );
     }
 }
+
+/// GNU runs the `recenter:` placement inside `redisplay_window`, after
+/// `set_buffer_internal_1 (XBUFFER (w->contents))` (src/xdisp.c:20532-20535,
+/// emacs-31.0.90), so the display iterator and every text-property probe it
+/// makes read the window's buffer. This port's redisplay runs with whatever
+/// buffer Lisp left current -- the active minibuffer while a completion UI
+/// is up -- so the placement scan must select the window's buffer itself
+/// and hand the caller's buffer back afterwards.
+#[test]
+fn redisplay_start_before_point_scans_the_window_buffer_not_the_current_one() {
+    crate::test_utils::init_test_tracing();
+    let mut eval = interactive_context();
+    let window_buffer = eval.buffers.current_buffer_id().expect("current buffer");
+    let text: String = (0..600).map(|index| format!("line {index:03}\n")).collect();
+    eval.buffers
+        .get_mut(window_buffer)
+        .expect("window buffer")
+        .insert(&text);
+    let frame_id = eval
+        .frames
+        .create_frame("recenter-window-buffer", 80, 24, window_buffer);
+    let window_id = eval.frames.get(frame_id).expect("frame").selected_window;
+
+    // A four-character buffer is current, as " *Minibuf-1*" is while `M-x`
+    // completes; every position the scan probes lies beyond its end.
+    let tiny = eval.buffers.create_buffer(" *tiny*");
+    eval.switch_current_buffer(tiny)
+        .expect("select the tiny buffer");
+    eval.buffers
+        .get_mut(tiny)
+        .expect("tiny buffer")
+        .insert("M-x ");
+
+    let line = |index: usize| {
+        text.find(&format!("line {index:03}\n"))
+            .expect("line present")
+    };
+    let point = CharPos0::new(line(500) + 3);
+
+    assert_eq!(
+        eval.redisplay_start_before_point_by_display_rows(window_buffer, window_id, point, 0),
+        Some(CharPos0::new(line(500))),
+        "zero rows above point is the start of point's own screen line"
+    );
+    assert_eq!(
+        eval.redisplay_start_before_point_by_display_rows(window_buffer, window_id, point, 2),
+        Some(CharPos0::new(line(498))),
+        "two rows above point on unwrapped lines is two source lines up"
+    );
+    assert_eq!(
+        eval.buffers.current_buffer_id(),
+        Some(tiny),
+        "the placement scan restores the buffer redisplay was entered with"
+    );
+}


### PR DESCRIPTION
## Summary

Entering the minibuffer with vertico (`M-x`) while the selected window was small (a freshly started frame, or one tiled to half the screen) froze the GUI at 100% CPU: no key, `C-g` or `Esc` was accepted and the process had to be killed. `-Q` did not reproduce; the trigger is a completion UI growing the minibuffer so the selected window (here the dashboard) shrinks under point, plus a display-row-collapsing property between the visible rows and point and `scroll-conservatively` > 0.

A `sample` of the hung process showed the evaluator thread inside `layout_frame_rust_for_purpose_inner`, re-laying the same leaf forever with nothing logged (the leaf loop bypasses the 12-retry `FrameLayoutCoordinator`). Two defects combined:

1. **Unbounded leaf retry.** `BufferSourceRetryPlan::viewport_resolution` turned a `NeedMoreMeasurement` decision with no visibility retries left into a `PlaceRelativeToPoint` request; the engine resolved it to the start it already had, zeroed the budget "to stop the chain", and issued a `Retry` anyway. GNU bounds this search: `try_scrolling` gives up past `scroll_max` lines (src/xdisp.c:19445-19446, emacs-31.0.90) and, after the `recenter:` start has been laid out, `redisplay_window` re-recenters at most twice before `done:` (xdisp.c:21360-21398). `ViewportDecision::resolve_with_budget` now owns that rule, keyed on the typed `ViewportAttemptStart` the rows were produced from: a spent budget ends the leaf at a semantic start; a measurement probe, which is never publishable, still falls back to the policy placement, committed with no retries left. The old table also finished on a probe start when a placement request arrived with no budget; that path now places instead.

2. **Placement scanned the wrong buffer.** `Context::redisplay_start_before_point_by_display_rows` walked the window's buffer while the minibuffer was current; the invisible-newline check in `current_screen_line_start_with_truncation` probes Lisp positions in the *current* buffer, so every probe past the minibuffer's end signalled `args-out-of-range`, the placement returned `None`, and the fallback was the unchanged start that fed defect 1. GNU reaches `recenter:` inside `redisplay_window` after `set_buffer_internal_1 (XBUFFER (w->contents))` (xdisp.c:20532-20535); the helper now selects the window's buffer for the scan and restores the caller's (the `with_frame_display_context` idiom).

**Declared divergence:** GNU answers `SCROLLING_FAILED` with `recenter:` (xdisp.c:21097-21108) and always ends with a start placed around point. When core display motion cannot improve on the start already laid out, the leaf now ends there and point may be off-window for that redisplay instead of looping. The same terminal rule now applies to the passes whose budget is forced to zero on purpose (scroll replay and one-row transient windows in `window_render.rs`, which previously contradicted their own comments by placing).

## Tests (red first)

- `xdisp::tests::redisplay_start_before_point_scans_the_window_buffer_not_the_current_one`: `None` before, `Some(CharPos0(4500))` after; also pins that the caller's buffer is restored.
- `engine::tests::point_placement_with_a_foreign_current_buffer_terminates_and_shows_point`: reproduces the report (foreign current buffer, hidden span, `scroll-conservatively` 30); hung before both fixes.
- `engine::tests::spent_visibility_budget_ends_the_leaf_at_its_start`: pins defect 1 alone with a thirty-row `display` string that the producer lays out as rows while screen-line motion counts it as one line, so every placement clamps back to the window start. Runs the layout on a helper thread; under the old decision table it fails on its 120 s timeout, with the fix it finishes in 0.5 s.
- `viewport_resolution::tests::spent_budget_*` and `budget_left_*`: the decision table per attempt start and budget.

## Verification

- `cargo fmt --check` clean; `cargo clippy -p neomacs-layout-engine --tests` and `-p neovm-core` with no errors.
- `cargo test -p neomacs-layout-engine --lib` and the core `xdisp::`/`indent::`/`window::` tests with `--no-fail-fast`, baselined against `main` on the same machine: every test that failed only on this branch passes in isolation; the remaining failures are the run-to-run flaky set `main` shows here too (font/glyph/display_row tests).
- GUI (macOS, the reporter's config with vertico, dashboard, Rectangle left-half): after `cargo xtask --release`, `M-x` opens both in the fresh frame and after tiling, a heartbeat timer keeps firing, and `C-g` returns to the dashboard. No `failed to converge` in the log.

**Not run:** Linux, TTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3wJN81Y4miZnPBNY9o1Xv
