### PR TITLE
fix(font,renderer): canonicalize font instances and validate glyph overhang

### DIFF
--- a/crates/neomacs-display-protocol/src/font.rs
+++ b/crates/neomacs-display-protocol/src/font.rs
@@ -412,24 +412,6 @@ fn append_variation_key(stable_key: &mut String, variation_coords: &[FontVariati
     }
 }
 
-/// How a resolved font was chosen. Distinguishing fallback tiers keeps
-/// traces and oracle runs able to flag unexpected selection paths.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[non_exhaustive]
-pub enum FontResolutionSource {
-    /// The realized face's primary font.
-    FacePrimary,
-    /// Chosen via fontset / per-character coverage fallback.
-    FontsetFallback,
-    /// Chosen via emoji presentation fallback.
-    EmojiFallback,
-    /// Chosen by the platform's last-resort matching.
-    PlatformFallback,
-    /// Renderer-side emergency fallback: text reached the render thread
-    /// without a resolved identity. Must be zero for normal GUI text.
-    EmergencyFallback,
-}
-
 /// Font slant as carried across the display protocol.
 #[derive(
     Clone, Copy, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
@@ -823,7 +805,6 @@ pub struct ResolvedFont {
     /// canonical fixed-pitch cell.
     #[serde(default)]
     pub glyph_advance: ResolvedFontAdvance,
-    pub source: FontResolutionSource,
 }
 
 /// Resolved font table carried by frame state, keyed by [`ResolvedFontId`].

--- a/crates/neomacs-display-protocol/src/font_test.rs
+++ b/crates/neomacs-display-protocol/src/font_test.rs
@@ -25,7 +25,6 @@ fn sample_font(id: u32) -> ResolvedFont {
         descent_px: 3.0,
         space_advance_px: 8.0,
         glyph_advance: Default::default(),
-        source: FontResolutionSource::FacePrimary,
     }
 }
 

--- a/crates/neomacs-display-protocol/src/frame_glyphs_test.rs
+++ b/crates/neomacs-display-protocol/src/frame_glyphs_test.rs
@@ -20,8 +20,8 @@ fn assert_color_eq(actual: &Color, expected: &Color) {
 #[test]
 fn frame_default_resolved_font_is_one_coherent_binding_lookup() {
     use crate::font::{
-        FontFileAsset, FontOutlineAsset, FontReplay, FontResolutionSource, FontSlantKind,
-        ResolvedFont, ResolvedFontAdvance, ResolvedFontId, ResolvedFontIdentity,
+        FontFileAsset, FontOutlineAsset, FontReplay, FontSlantKind, ResolvedFont,
+        ResolvedFontAdvance, ResolvedFontId, ResolvedFontIdentity,
     };
 
     let mut frame = FrameGlyphBuffer::with_size(120.0, 80.0);
@@ -51,7 +51,6 @@ fn frame_default_resolved_font_is_one_coherent_binding_lookup() {
             descent_px: 4.0,
             space_advance_px: 10.0,
             glyph_advance: ResolvedFontAdvance::fixed_cell(10.0),
-            source: FontResolutionSource::FacePrimary,
         },
     );
 

--- a/crates/neomacs-display-protocol/src/glyph_matrix_test.rs
+++ b/crates/neomacs-display-protocol/src/glyph_matrix_test.rs
@@ -2848,8 +2848,8 @@ fn frame_display_state_integer_map_keys_round_trip() {
 #[test]
 fn resolved_fonts_survive_materialize_and_round_trip() {
     use crate::font::{
-        FontFileAsset, FontOutlineAsset, FontReplay, FontResolutionSource, FontSlantKind,
-        ResolvedFont, ResolvedFontId, ResolvedFontIdentity,
+        FontFileAsset, FontOutlineAsset, FontReplay, FontSlantKind, ResolvedFont, ResolvedFontId,
+        ResolvedFontIdentity,
     };
 
     let mut state = state_with_text("f");
@@ -2876,7 +2876,6 @@ fn resolved_fonts_survive_materialize_and_round_trip() {
             descent_px: 3.0,
             space_advance_px: 8.0,
             glyph_advance: Default::default(),
-            source: FontResolutionSource::FacePrimary,
         },
     );
 

--- a/crates/neomacs-display-runtime/src/render_thread/media_test.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/media_test.rs
@@ -4,8 +4,8 @@ use super::*;
 use crate::terminal::content::{RenderCell, RenderCursor, TerminalContent};
 #[cfg(feature = "neo-term")]
 use neomacs_display_protocol::font::{
-    FontFileAsset, FontOutlineAsset, FontReplay, FontResolutionSource, FontSlantKind, ResolvedFont,
-    ResolvedFontAdvance, ResolvedFontId, ResolvedFontIdentity,
+    FontFileAsset, FontOutlineAsset, FontReplay, FontSlantKind, ResolvedFont, ResolvedFontAdvance,
+    ResolvedFontId, ResolvedFontIdentity,
 };
 #[cfg(feature = "neo-term")]
 use rio_vt::crosswords::style::StyleFlags as CellFlags;
@@ -67,7 +67,6 @@ fn terminal_face_for_flags_and_font(
         descent_px: 4.0,
         space_advance_px: 10.0,
         glyph_advance: ResolvedFontAdvance::fixed_cell(10.0),
-        source: FontResolutionSource::FacePrimary,
     };
     let mut default_face = Face::new(FaceId::new(0));
     default_face.default_resolved_font_id = Some(font_id);

--- a/crates/neomacs-layout-engine/src/font/instance.rs
+++ b/crates/neomacs-layout-engine/src/font/instance.rs
@@ -1,0 +1,105 @@
+//! Canonical records for metrics-bearing font instances.
+//!
+//! GNU `font_open_entity` reuses an opened entity at its pixel size when
+//! `cached_font_ok` permits it; `font_clear_cache` invalidates its observations.
+//! Here IDs survive for the resolver lifetime, while records expire only on a
+//! catalog transition. Keeping both states here prevents independent builders
+//! or cache-clearing paths from publishing conflicting records under one ID.
+
+use neomacs_display_protocol::font::{
+    FontReplay, FontSlantKind, ResolvedFont, ResolvedFontAdvance, ResolvedFontId,
+    ResolvedFontIdentity,
+};
+use rustc_hash::FxHashMap;
+
+/// Builders provide observations, never the identity fields owned by the key.
+/// In particular, a builder cannot choose another ID, replay, or pixel size.
+pub(super) struct FontInstanceProperties {
+    pub family: String,
+    pub full_name: Option<String>,
+    pub postscript_name: Option<String>,
+    pub weight: u16,
+    pub slant: FontSlantKind,
+    pub width: u16,
+    pub ascent_px: f32,
+    pub descent_px: f32,
+    pub space_advance_px: f32,
+    pub glyph_advance: ResolvedFontAdvance,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct FontInstanceKey {
+    identity: ResolvedFontIdentity,
+    replay: FontReplay,
+    pixel_size_bits: u32,
+}
+
+struct InternedFontInstance {
+    id: ResolvedFontId,
+    record: Option<ResolvedFont>,
+}
+
+#[derive(Default)]
+pub(super) struct FontInstanceInterner {
+    instances: FxHashMap<FontInstanceKey, InternedFontInstance>,
+}
+
+impl FontInstanceInterner {
+    pub fn intern(
+        &mut self,
+        identity: ResolvedFontIdentity,
+        replay: FontReplay,
+        pixel_size: f32,
+        observe: impl FnOnce() -> FontInstanceProperties,
+    ) -> ResolvedFont {
+        let key = FontInstanceKey {
+            identity: identity.clone(),
+            replay: replay.clone(),
+            pixel_size_bits: pixel_size.to_bits(),
+        };
+        let allocated = self.instances.len();
+        let instance = self
+            .instances
+            .entry(key)
+            .or_insert_with(|| InternedFontInstance {
+                id: ResolvedFontId(
+                    u32::try_from(allocated)
+                        .ok()
+                        .and_then(|count| count.checked_add(1))
+                        .expect("resolved font ID space exhausted"),
+                ),
+                record: None,
+            });
+        instance
+            .record
+            .get_or_insert_with(|| {
+                let properties = observe();
+                ResolvedFont {
+                    id: instance.id,
+                    identity,
+                    replay,
+                    pixel_size,
+                    family: properties.family,
+                    full_name: properties.full_name,
+                    postscript_name: properties.postscript_name,
+                    weight: properties.weight,
+                    slant: properties.slant,
+                    width: properties.width,
+                    ascent_px: properties.ascent_px,
+                    descent_px: properties.descent_px,
+                    space_advance_px: properties.space_advance_px,
+                    glyph_advance: properties.glyph_advance,
+                }
+            })
+            .clone()
+    }
+
+    /// Old frame snapshots retain their owned records; new observations reuse
+    /// the stable ID after a catalog change. Ordinary cache clears do not call
+    /// this, so request provenance cannot change a published record.
+    pub fn invalidate_catalog_records(&mut self) {
+        for instance in self.instances.values_mut() {
+            instance.record = None;
+        }
+    }
+}

--- a/crates/neomacs-layout-engine/src/font/metrics.rs
+++ b/crates/neomacs-layout-engine/src/font/metrics.rs
@@ -393,7 +393,8 @@ struct LayoutFontHandle {
     /// Which GNU lookup tier produced this handle for the requesting
     /// character. A property of the request, not of the font: GNU keeps one
     /// font object per entity and pixel size (font.c `font_open_entity`
-    /// returns the already-open object from `FONT_OBJLIST_INDEX`), whether
+    /// reuses a live object from `FONT_OBJLIST_INDEX` when the driver's
+    /// `cached_font_ok` permits it), whether
     /// fontset.c `face_for_char` returned the ASCII face's font or a fontset
     /// tier found the same font again. It therefore stays off
     /// [`ResolvedFont`], whose id-keyed frame table holds one record per

--- a/crates/neomacs-layout-engine/src/font/metrics.rs
+++ b/crates/neomacs-layout-engine/src/font/metrics.rs
@@ -7,6 +7,7 @@
 //! rendered glyph widths — eliminating gaps and overlaps caused by the
 //! C fontconfig and cosmic-text resolving different font files.
 
+use super::instance::{FontInstanceInterner, FontInstanceProperties};
 use crate::font::frame_metrics::{FrameFontDomain, GraphicFontSizePx};
 use cosmic_text::{Attrs, Buffer, Family, FontSystem, Style, Weight};
 use neomacs_display_protocol::types::FaceId;
@@ -439,18 +440,6 @@ fn resolved_font_advance(
     }
 }
 
-/// Complete identity of one metrics-bearing protocol font entry.
-///
-/// A durable source identity alone is insufficient: one file can realize at
-/// several sizes or fixed strikes, and [`ResolvedFont`] carries metrics for
-/// exactly one of those instances.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct ResolvedFontInstanceKey {
-    identity: ResolvedFontIdentity,
-    replay: FontReplay,
-    pixel_size_bits: u32,
-}
-
 #[derive(Clone, Copy, Debug)]
 enum PlatformFontDbFace {
     /// Re-registered from a decoded/in-memory source; the platform identity
@@ -714,20 +703,9 @@ pub struct FontMetricsService {
     /// Cache: face attrs → the face's resolved primary font. Same generation
     /// contract as the other caches: cleared by `clear_caches`.
     resolved_face_font_cache: HashMap<MetricsCacheKey, Option<LayoutFontHandle>>,
-    /// Interner: complete realized instance → stable [`ResolvedFontId`]. NOT
-    /// cleared by `clear_caches`: ids stay stable for the service's lifetime
-    /// so consecutive frame snapshots reference the same font by the same id.
-    /// Renderer caches key on the identity anyway, so a stale id can never
-    /// alias a glyph to the wrong font.
-    resolved_font_ids: HashMap<ResolvedFontInstanceKey, ResolvedFontId>,
-    /// The one [`ResolvedFont`] record published under each interned id, so
-    /// no later resolution path can publish a second record for an id the
-    /// frame table already carries. Dropped on a native catalog advance
-    /// (the same boundary on which the renderer drops its font tables and a
-    /// file replaced in place gets fresh metrics), never on `clear_caches`.
-    /// GNU: `font_clear_cache` closes the objects in `FONT_OBJLIST_INDEX`
-    /// while `font_open_entity` otherwise hands back the open object.
-    resolved_font_records: HashMap<ResolvedFontId, ResolvedFont>,
+    /// Owns lifetime-stable IDs and catalog-local canonical records together.
+    /// Ordinary request/cache invalidation leaves these instances untouched.
+    font_instances: FontInstanceInterner,
     /// Cache: (realized face/fontset selection, char) → the exact selected
     /// font. Same generation contract as the other caches: cleared by
     /// `clear_caches`.
@@ -800,8 +778,7 @@ impl FontMetricsService {
             font_resolver,
             shaper: crate::text_shaper::default_text_shaper(),
             resolved_face_font_cache: HashMap::default(),
-            resolved_font_ids: HashMap::default(),
-            resolved_font_records: HashMap::default(),
+            font_instances: FontInstanceInterner::default(),
             resolved_char_font_cache: HashMap::default(),
             resolved_cluster_cache: HashMap::default(),
             primary_pin_cache: HashMap::default(),
@@ -845,7 +822,7 @@ impl FontMetricsService {
             // Records carry metrics read from the files; a replaced file must
             // republish under its stable id, as the renderer rebuilds its
             // tables for this generation.
-            self.resolved_font_records.clear();
+            self.font_instances.invalidate_catalog_records();
         }
         update
     }
@@ -1976,29 +1953,24 @@ impl FontMetricsService {
         let device_ascii_advances =
             self.probe_resolved_font_device_ascii_advances(&identity, font_size);
         let replay = FontReplay::Swash { asset };
-        let font =
-            self.intern_resolved_font(identity, replay, font_size, |id, identity, replay| {
-                ResolvedFont {
-                    id,
-                    identity,
-                    replay,
-                    family: resolved_family,
-                    full_name: None,
-                    postscript_name,
-                    // Preserve the resolved CSS weight, not the container face's
-                    // metadata weight (variable fonts; cf. `select_font_for_char`).
-                    weight: resolved_weight,
-                    slant: render_slant,
-                    width: stretch.to_number(),
-                    pixel_size: font_size,
-                    ascent_px: vertical.as_ref().map(|v| v.ascent).unwrap_or(0.0),
-                    descent_px: vertical.as_ref().map(|v| v.descent).unwrap_or(0.0),
-                    space_advance_px: px_metrics
-                        .map(|metrics| metrics.space_width.max(0) as f32)
-                        .unwrap_or(0.0),
-                    glyph_advance,
-                }
-            });
+        let font = self.font_instances.intern(identity, replay, font_size, || {
+            FontInstanceProperties {
+                family: resolved_family,
+                full_name: None,
+                postscript_name,
+                // Preserve the resolved CSS weight, not the container face's
+                // metadata weight (variable fonts; cf. `select_font_for_char`).
+                weight: resolved_weight,
+                slant: render_slant,
+                width: stretch.to_number(),
+                ascent_px: vertical.as_ref().map(|v| v.ascent).unwrap_or(0.0),
+                descent_px: vertical.as_ref().map(|v| v.descent).unwrap_or(0.0),
+                space_advance_px: px_metrics
+                    .map(|metrics| metrics.space_width.max(0) as f32)
+                    .unwrap_or(0.0),
+                glyph_advance,
+            }
+        });
         Some(LayoutFontHandle {
             font,
             resolution: FontResolutionSource::FacePrimary,
@@ -2045,19 +2017,16 @@ impl FontMetricsService {
         let identity = matched.identity.clone();
         let selector_slant = matched.slant();
         let replay = opened.replay();
-        let font =
-            self.intern_resolved_font(identity, replay, effective_size, |id, identity, replay| {
-                ResolvedFont {
-                    id,
-                    identity,
-                    replay,
+        let font = self
+            .font_instances
+            .intern(identity, replay, effective_size, || {
+                FontInstanceProperties {
                     family: family.to_owned(),
                     full_name: None,
                     postscript_name: matched.identity.postscript_name.clone(),
                     weight: matched.weight().unwrap_or(requested_weight),
                     slant: font_slant_kind_from_platform(selector_slant),
                     width: matched.metadata.width_class(),
-                    pixel_size: effective_size,
                     ascent_px: observed.ascent_px,
                     descent_px: observed.descent_px,
                     space_advance_px: observed.space_advance_px,
@@ -2280,29 +2249,24 @@ impl FontMetricsService {
             .or_else(|| self.font_metrics_from_selected_face(font_id, selection.font_size));
         let glyph_advance = resolved_font_advance(spacing, px_metrics);
         let replay = FontReplay::Swash { asset };
-        let font = self.intern_resolved_font(
-            identity,
-            replay,
-            selection.font_size,
-            |id, identity, replay| ResolvedFont {
-                id,
-                identity,
-                replay,
-                family: resolved.family.clone(),
-                full_name: None,
-                postscript_name,
-                weight: resolved.weight,
-                slant: render_slant,
-                width: stretch.to_number(),
-                pixel_size: selection.font_size,
-                ascent_px: vertical.as_ref().map(|v| v.ascent).unwrap_or(0.0),
-                descent_px: vertical.as_ref().map(|v| v.descent).unwrap_or(0.0),
-                space_advance_px: px_metrics
-                    .map(|metrics| metrics.space_width.max(0) as f32)
-                    .unwrap_or(0.0),
-                glyph_advance,
-            },
-        );
+        let font = self
+            .font_instances
+            .intern(identity, replay, selection.font_size, || {
+                FontInstanceProperties {
+                    family: resolved.family.clone(),
+                    full_name: None,
+                    postscript_name,
+                    weight: resolved.weight,
+                    slant: render_slant,
+                    width: stretch.to_number(),
+                    ascent_px: vertical.as_ref().map(|v| v.ascent).unwrap_or(0.0),
+                    descent_px: vertical.as_ref().map(|v| v.descent).unwrap_or(0.0),
+                    space_advance_px: px_metrics
+                        .map(|metrics| metrics.space_width.max(0) as f32)
+                        .unwrap_or(0.0),
+                    glyph_advance,
+                }
+            });
         Some(LayoutFontHandle {
             font,
             resolution: FontResolutionSource::FontsetFallback,
@@ -2579,68 +2543,22 @@ impl FontMetricsService {
             .unwrap_or(file_weight);
         let glyph_advance = resolved_font_advance(spacing, px_metrics);
         let replay = swash_file_replay(&identity)?;
-        Some(
-            self.intern_resolved_font(identity, replay, font_size, |id, identity, replay| {
-                ResolvedFont {
-                    id,
-                    identity,
-                    replay,
-                    family,
-                    full_name: None,
-                    postscript_name,
-                    weight,
-                    slant: font_slant_kind_from_fontdb(style),
-                    width: stretch.to_number(),
-                    pixel_size: font_size,
-                    ascent_px: vertical.as_ref().map(|v| v.ascent).unwrap_or(0.0),
-                    descent_px: vertical.as_ref().map(|v| v.descent).unwrap_or(0.0),
-                    space_advance_px: px_metrics
-                        .map(|metrics| metrics.space_width.max(0) as f32)
-                        .unwrap_or(0.0),
-                    glyph_advance,
-                }
-            }),
-        )
-    }
-
-    /// Intern one realized instance and return its canonical record.
-    ///
-    /// The interner owns the record: within one catalog generation the first
-    /// builder to realize a `(identity, replay, pixel_size)` key defines the
-    /// [`ResolvedFont`] every later path receives for that id, so no
-    /// resolution path can publish a second record under an id the frame
-    /// table already carries. GNU font.c `font_open_entity` likewise hands
-    /// back the font object already open for an entity at that pixel size
-    /// (`FONT_OBJLIST_INDEX`) when the driver's `cached_font_ok` accepts it;
-    /// `font_clear_cache` closes those objects when the font set changes.
-    fn intern_resolved_font(
-        &mut self,
-        identity: ResolvedFontIdentity,
-        replay: FontReplay,
-        pixel_size: f32,
-        build: impl FnOnce(ResolvedFontId, ResolvedFontIdentity, FontReplay) -> ResolvedFont,
-    ) -> ResolvedFont {
-        let key = ResolvedFontInstanceKey {
-            identity: identity.clone(),
-            replay: replay.clone(),
-            pixel_size_bits: pixel_size.to_bits(),
-        };
-        let id = match self.resolved_font_ids.get(&key) {
-            Some(&id) => id,
-            None => {
-                // Ids start at 1; 0 stays unused so an uninitialized id is visible.
-                let id = ResolvedFontId(self.resolved_font_ids.len() as u32 + 1);
-                self.resolved_font_ids.insert(key, id);
-                id
+        Some(self.font_instances.intern(identity, replay, font_size, || {
+            FontInstanceProperties {
+                family,
+                full_name: None,
+                postscript_name,
+                weight,
+                slant: font_slant_kind_from_fontdb(style),
+                width: stretch.to_number(),
+                ascent_px: vertical.as_ref().map(|v| v.ascent).unwrap_or(0.0),
+                descent_px: vertical.as_ref().map(|v| v.descent).unwrap_or(0.0),
+                space_advance_px: px_metrics
+                    .map(|metrics| metrics.space_width.max(0) as f32)
+                    .unwrap_or(0.0),
+                glyph_advance,
             }
-        };
-        if let Some(font) = self.resolved_font_records.get(&id) {
-            return font.clone();
-        }
-        let mut font = build(id, identity, replay);
-        font.id = id;
-        self.resolved_font_records.insert(id, font.clone());
-        font
+        }))
     }
 
     /// Measure one character after platform selection has produced its exact
@@ -3217,10 +3135,8 @@ impl FontMetricsService {
     }
 
     /// Clear all caches. Call when fonts change (e.g., text-scale-adjust).
-    /// `resolved_font_ids` and `resolved_font_records` intentionally survive:
-    /// complete instance keys are durable and ids must stay stable across
-    /// generations; records are dropped only by a catalog advance (see field
-    /// docs).
+    /// Canonical font instances intentionally survive: IDs are durable and
+    /// records are dropped only by a catalog advance, not request changes.
     pub fn clear_caches(&mut self) {
         self.ascii_cache.clear();
         self.char_cache.clear();

--- a/crates/neomacs-layout-engine/src/font/metrics.rs
+++ b/crates/neomacs-layout-engine/src/font/metrics.rs
@@ -2515,9 +2515,9 @@ impl FontMetricsService {
     }
 
     /// Build a [`ResolvedFont`] for a concrete fontdb face chosen by
-    /// shaping. Unlike the face/char resolvers (which preserve selector
-    /// family/weight semantics), this records the file's own metadata: the
-    /// font was picked by shaping fallback, not by a request.
+    /// shaping. Recover native metrics and selector metadata when the platform
+    /// names the same instance; otherwise use the selected file's metrics.
+    /// Diagnostic family metadata still comes from the shaping-selected face.
     fn resolved_font_from_fontdb_id(
         &mut self,
         font_id: fontdb::ID,
@@ -2544,8 +2544,23 @@ impl FontMetricsService {
             postscript_name.clone(),
             &family,
         );
-        let px_metrics =
-            Self::probe_resolved_font_metrics(&identity, None, font_size).or_else(|| {
+        // Recover native metrics and selector metadata only for this exact
+        // instance. A same-family match can select another file or variation;
+        // neither may supply metrics for the face shaping already chose.
+        // resolve_primary finalizes the winner and attaches native metrics.
+        let selection_size = self.selection_size(font_size);
+        let platform = self
+            .font_resolver
+            .resolve_primary(
+                &family,
+                file_weight,
+                font_slant_from_fontdb(style),
+                FontWidth::Normal,
+                selection_size,
+            )
+            .filter(|matched| matched.identity == identity);
+        let px_metrics = Self::probe_resolved_font_metrics(&identity, platform.as_ref(), font_size)
+            .or_else(|| {
                 self.font_px_metrics_from_selected_face(
                     font_id,
                     font_size,
@@ -2559,26 +2574,6 @@ impl FontMetricsService {
                 line_height: metrics.height.max(1) as f32,
             })
             .or_else(|| self.font_metrics_from_selected_face(font_id, font_size));
-        // Prefer the platform's answer for this exact file (GNU `FC_SPACING`
-        // / CoreText traits and the realized weight) over the file's own
-        // metadata and the family-name heuristic, so a font first realized
-        // through shaping publishes the record the face path would. Selection
-        // only: the face is already open in `font_system`, so nothing is
-        // pinned or re-validated here.
-        let selection_size = self.selection_size(font_size);
-        let platform = self
-            .font_resolver
-            .resolve_primary(
-                &family,
-                file_weight,
-                font_slant_from_fontdb(style),
-                FontWidth::Normal,
-                selection_size,
-            )
-            .filter(|matched| {
-                matched.identity.file_path.as_deref() == file.as_deref()
-                    && matched.identity.file_face_index() == face_index
-            });
         let spacing = match platform.as_ref() {
             Some(matched) => matched.metadata.fixed_spacing_policy(),
             None if self.font_resolver.family_prefers_monospace(&family) => {
@@ -2624,7 +2619,7 @@ impl FontMetricsService {
     /// resolution path can publish a second record under an id the frame
     /// table already carries. GNU font.c `font_open_entity` likewise hands
     /// back the font object already open for an entity at that pixel size
-    /// (`FONT_OBJLIST_INDEX`) instead of opening a second one, and
+    /// (`FONT_OBJLIST_INDEX`) when the driver's `cached_font_ok` accepts it;
     /// `font_clear_cache` closes those objects when the font set changes.
     fn intern_resolved_font(
         &mut self,

--- a/crates/neomacs-layout-engine/src/font/metrics.rs
+++ b/crates/neomacs-layout-engine/src/font/metrics.rs
@@ -19,9 +19,8 @@ fn safe_metrics(font_size: f32, line_height: f32) -> cosmic_text::Metrics {
     cosmic_text::Metrics::new(font_size.max(1.0), line_height.max(1.0))
 }
 use neomacs_display_protocol::font::{
-    FontBackendKind, FontFileAsset, FontOutlineAsset, FontReplay, FontResolutionSource,
-    FontSlantKind, ResolvedFont, ResolvedFontAdvance, ResolvedFontId, ResolvedFontIdentity,
-    ResolvedGlyph,
+    FontBackendKind, FontFileAsset, FontOutlineAsset, FontReplay, FontSlantKind, ResolvedFont,
+    ResolvedFontAdvance, ResolvedFontId, ResolvedFontIdentity, ResolvedGlyph,
 };
 #[cfg(test)]
 #[cfg(target_os = "linux")]
@@ -391,6 +390,15 @@ struct ResolvedCharFont {
 #[derive(Debug, Clone)]
 struct LayoutFontHandle {
     font: ResolvedFont,
+    /// Which GNU lookup tier produced this handle for the requesting
+    /// character. A property of the request, not of the font: GNU keeps one
+    /// font object per entity and pixel size (font.c `font_open_entity`
+    /// returns the already-open object from `FONT_OBJLIST_INDEX`), whether
+    /// fontset.c `face_for_char` returned the ASCII face's font or a fontset
+    /// tier found the same font again. It therefore stays off
+    /// [`ResolvedFont`], whose id-keyed frame table holds one record per
+    /// instance.
+    resolution: FontResolutionSource,
     selector_slant: FontSlant,
     source: LayoutFontSource,
     px_metrics: Option<crate::font::probe::FontPxMetrics>,
@@ -398,6 +406,17 @@ struct LayoutFontHandle {
     /// device size.  Stored separately from logical aggregate metrics so the
     /// coordinate domains cannot be mixed accidentally.
     device_ascii_advances: Option<std::sync::Arc<crate::font::probe::DeviceAsciiAdvances>>,
+}
+
+/// How a font request was answered. Distinguishing the tiers keeps traces and
+/// the direct-glyph measurement path able to tell a primary-face answer from
+/// a fontset fallback that happened to land on the same font.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FontResolutionSource {
+    /// The realized face's primary font (GNU `face->font`).
+    FacePrimary,
+    /// Chosen via fontset / per-character coverage fallback.
+    FontsetFallback,
 }
 
 #[derive(Debug, Clone)]
@@ -694,12 +713,20 @@ pub struct FontMetricsService {
     /// Cache: face attrs → the face's resolved primary font. Same generation
     /// contract as the other caches: cleared by `clear_caches`.
     resolved_face_font_cache: HashMap<MetricsCacheKey, Option<LayoutFontHandle>>,
-    /// Interner: complete realized instance → stable [`ResolvedFontId`]. NOT cleared
-    /// by `clear_caches`: ids stay stable for the service's lifetime so
-    /// consecutive frame snapshots reference the same font by the same id.
+    /// Interner: complete realized instance → stable [`ResolvedFontId`]. NOT
+    /// cleared by `clear_caches`: ids stay stable for the service's lifetime
+    /// so consecutive frame snapshots reference the same font by the same id.
     /// Renderer caches key on the identity anyway, so a stale id can never
     /// alias a glyph to the wrong font.
     resolved_font_ids: HashMap<ResolvedFontInstanceKey, ResolvedFontId>,
+    /// The one [`ResolvedFont`] record published under each interned id, so
+    /// no later resolution path can publish a second record for an id the
+    /// frame table already carries. Dropped on a native catalog advance
+    /// (the same boundary on which the renderer drops its font tables and a
+    /// file replaced in place gets fresh metrics), never on `clear_caches`.
+    /// GNU: `font_clear_cache` closes the objects in `FONT_OBJLIST_INDEX`
+    /// while `font_open_entity` otherwise hands back the open object.
+    resolved_font_records: HashMap<ResolvedFontId, ResolvedFont>,
     /// Cache: (realized face/fontset selection, char) → the exact selected
     /// font. Same generation contract as the other caches: cleared by
     /// `clear_caches`.
@@ -773,6 +800,7 @@ impl FontMetricsService {
             shaper: crate::text_shaper::default_text_shaper(),
             resolved_face_font_cache: HashMap::default(),
             resolved_font_ids: HashMap::default(),
+            resolved_font_records: HashMap::default(),
             resolved_char_font_cache: HashMap::default(),
             resolved_cluster_cache: HashMap::default(),
             primary_pin_cache: HashMap::default(),
@@ -813,6 +841,10 @@ impl FontMetricsService {
             self.font_system = FontSystem::new();
             self.font_file_cache = FontFileCache::new();
             self.clear_caches();
+            // Records carry metrics read from the files; a replaced file must
+            // republish under its stable id, as the renderer rebuilds its
+            // tables for this generation.
+            self.resolved_font_records.clear();
         }
         update
     }
@@ -1943,29 +1975,32 @@ impl FontMetricsService {
         let device_ascii_advances =
             self.probe_resolved_font_device_ascii_advances(&identity, font_size);
         let replay = FontReplay::Swash { asset };
-        let id = self.intern_resolved_font_id(&identity, replay.clone(), font_size);
+        let font =
+            self.intern_resolved_font(identity, replay, font_size, |id, identity, replay| {
+                ResolvedFont {
+                    id,
+                    identity,
+                    replay,
+                    family: resolved_family,
+                    full_name: None,
+                    postscript_name,
+                    // Preserve the resolved CSS weight, not the container face's
+                    // metadata weight (variable fonts; cf. `select_font_for_char`).
+                    weight: resolved_weight,
+                    slant: render_slant,
+                    width: stretch.to_number(),
+                    pixel_size: font_size,
+                    ascent_px: vertical.as_ref().map(|v| v.ascent).unwrap_or(0.0),
+                    descent_px: vertical.as_ref().map(|v| v.descent).unwrap_or(0.0),
+                    space_advance_px: px_metrics
+                        .map(|metrics| metrics.space_width.max(0) as f32)
+                        .unwrap_or(0.0),
+                    glyph_advance,
+                }
+            });
         Some(LayoutFontHandle {
-            font: ResolvedFont {
-                id,
-                identity,
-                replay,
-                family: resolved_family,
-                full_name: None,
-                postscript_name,
-                // Preserve the resolved CSS weight, not the container face's
-                // metadata weight (variable fonts; cf. `select_font_for_char`).
-                weight: resolved_weight,
-                slant: render_slant,
-                width: stretch.to_number(),
-                pixel_size: font_size,
-                ascent_px: vertical.as_ref().map(|v| v.ascent).unwrap_or(0.0),
-                descent_px: vertical.as_ref().map(|v| v.descent).unwrap_or(0.0),
-                space_advance_px: px_metrics
-                    .map(|metrics| metrics.space_width.max(0) as f32)
-                    .unwrap_or(0.0),
-                glyph_advance,
-                source: FontResolutionSource::FacePrimary,
-            },
+            font,
+            resolution: FontResolutionSource::FacePrimary,
             selector_slant,
             source: LayoutFontSource::Swash(font_id),
             px_metrics,
@@ -1979,7 +2014,7 @@ impl FontMetricsService {
         family: &str,
         requested_weight: u16,
         font_size: f32,
-        source: FontResolutionSource,
+        resolution: FontResolutionSource,
     ) -> Option<LayoutFontHandle> {
         let opened = match self.open_bitmap_font(matched, font_size) {
             Ok(opened) => opened,
@@ -2009,25 +2044,28 @@ impl FontMetricsService {
         let identity = matched.identity.clone();
         let selector_slant = matched.slant();
         let replay = opened.replay();
-        let id = self.intern_resolved_font_id(&identity, replay.clone(), effective_size);
+        let font =
+            self.intern_resolved_font(identity, replay, effective_size, |id, identity, replay| {
+                ResolvedFont {
+                    id,
+                    identity,
+                    replay,
+                    family: family.to_owned(),
+                    full_name: None,
+                    postscript_name: matched.identity.postscript_name.clone(),
+                    weight: matched.weight().unwrap_or(requested_weight),
+                    slant: font_slant_kind_from_platform(selector_slant),
+                    width: matched.metadata.width_class(),
+                    pixel_size: effective_size,
+                    ascent_px: observed.ascent_px,
+                    descent_px: observed.descent_px,
+                    space_advance_px: observed.space_advance_px,
+                    glyph_advance,
+                }
+            });
         Some(LayoutFontHandle {
-            font: ResolvedFont {
-                id,
-                identity,
-                replay,
-                family: family.to_owned(),
-                full_name: None,
-                postscript_name: matched.identity.postscript_name.clone(),
-                weight: matched.weight().unwrap_or(requested_weight),
-                slant: font_slant_kind_from_platform(selector_slant),
-                width: matched.metadata.width_class(),
-                pixel_size: effective_size,
-                ascent_px: observed.ascent_px,
-                descent_px: observed.descent_px,
-                space_advance_px: observed.space_advance_px,
-                glyph_advance,
-                source,
-            },
+            font,
+            resolution,
             selector_slant,
             source: LayoutFontSource::FreeTypeBitmap(opened),
             px_metrics: Some(px_metrics),
@@ -2241,9 +2279,11 @@ impl FontMetricsService {
             .or_else(|| self.font_metrics_from_selected_face(font_id, selection.font_size));
         let glyph_advance = resolved_font_advance(spacing, px_metrics);
         let replay = FontReplay::Swash { asset };
-        let id = self.intern_resolved_font_id(&identity, replay.clone(), selection.font_size);
-        Some(LayoutFontHandle {
-            font: ResolvedFont {
+        let font = self.intern_resolved_font(
+            identity,
+            replay,
+            selection.font_size,
+            |id, identity, replay| ResolvedFont {
                 id,
                 identity,
                 replay,
@@ -2260,8 +2300,11 @@ impl FontMetricsService {
                     .map(|metrics| metrics.space_width.max(0) as f32)
                     .unwrap_or(0.0),
                 glyph_advance,
-                source: FontResolutionSource::FontsetFallback,
             },
+        );
+        Some(LayoutFontHandle {
+            font,
+            resolution: FontResolutionSource::FontsetFallback,
             selector_slant,
             source: LayoutFontSource::Swash(font_id),
             px_metrics,
@@ -2376,7 +2419,6 @@ impl FontMetricsService {
                         _ => self.resolved_font_from_fontdb_id(
                             shaped_glyph.font_id,
                             selection.font_size,
-                            FontResolutionSource::FontsetFallback,
                         )?,
                     };
                     let id = font.id;
@@ -2480,7 +2522,6 @@ impl FontMetricsService {
         &mut self,
         font_id: fontdb::ID,
         font_size: f32,
-        source: FontResolutionSource,
     ) -> Option<ResolvedFont> {
         let (file, face_index, postscript_name, style, stretch, family, file_weight) = {
             let face = self.font_system.db().face(font_id)?;
@@ -2518,53 +2559,101 @@ impl FontMetricsService {
                 line_height: metrics.height.max(1) as f32,
             })
             .or_else(|| self.font_metrics_from_selected_face(font_id, font_size));
-        let spacing = if self.font_resolver.family_prefers_monospace(&family) {
-            neomacs_display_protocol::font::FixedFontSpacing::MonospaceOrCharacterCell
-        } else {
-            neomacs_display_protocol::font::FixedFontSpacing::ProportionalOrDual
+        // Prefer the platform's answer for this exact file (GNU `FC_SPACING`
+        // / CoreText traits and the realized weight) over the file's own
+        // metadata and the family-name heuristic, so a font first realized
+        // through shaping publishes the record the face path would. Selection
+        // only: the face is already open in `font_system`, so nothing is
+        // pinned or re-validated here.
+        let selection_size = self.selection_size(font_size);
+        let platform = self
+            .font_resolver
+            .resolve_primary(
+                &family,
+                file_weight,
+                font_slant_from_fontdb(style),
+                FontWidth::Normal,
+                selection_size,
+            )
+            .filter(|matched| {
+                matched.identity.file_path.as_deref() == file.as_deref()
+                    && matched.identity.file_face_index() == face_index
+            });
+        let spacing = match platform.as_ref() {
+            Some(matched) => matched.metadata.fixed_spacing_policy(),
+            None if self.font_resolver.family_prefers_monospace(&family) => {
+                neomacs_display_protocol::font::FixedFontSpacing::MonospaceOrCharacterCell
+            }
+            None => neomacs_display_protocol::font::FixedFontSpacing::ProportionalOrDual,
         };
+        let weight = platform
+            .as_ref()
+            .and_then(|matched| matched.weight())
+            .unwrap_or(file_weight);
         let glyph_advance = resolved_font_advance(spacing, px_metrics);
         let replay = swash_file_replay(&identity)?;
-        let id = self.intern_resolved_font_id(&identity, replay.clone(), font_size);
-        Some(ResolvedFont {
-            id,
-            identity,
-            replay,
-            family,
-            full_name: None,
-            postscript_name,
-            weight: file_weight,
-            slant: font_slant_kind_from_fontdb(style),
-            width: stretch.to_number(),
-            pixel_size: font_size,
-            ascent_px: vertical.as_ref().map(|v| v.ascent).unwrap_or(0.0),
-            descent_px: vertical.as_ref().map(|v| v.descent).unwrap_or(0.0),
-            space_advance_px: px_metrics
-                .map(|metrics| metrics.space_width.max(0) as f32)
-                .unwrap_or(0.0),
-            glyph_advance,
-            source,
-        })
+        Some(
+            self.intern_resolved_font(identity, replay, font_size, |id, identity, replay| {
+                ResolvedFont {
+                    id,
+                    identity,
+                    replay,
+                    family,
+                    full_name: None,
+                    postscript_name,
+                    weight,
+                    slant: font_slant_kind_from_fontdb(style),
+                    width: stretch.to_number(),
+                    pixel_size: font_size,
+                    ascent_px: vertical.as_ref().map(|v| v.ascent).unwrap_or(0.0),
+                    descent_px: vertical.as_ref().map(|v| v.descent).unwrap_or(0.0),
+                    space_advance_px: px_metrics
+                        .map(|metrics| metrics.space_width.max(0) as f32)
+                        .unwrap_or(0.0),
+                    glyph_advance,
+                }
+            }),
+        )
     }
 
-    fn intern_resolved_font_id(
+    /// Intern one realized instance and return its canonical record.
+    ///
+    /// The interner owns the record: within one catalog generation the first
+    /// builder to realize a `(identity, replay, pixel_size)` key defines the
+    /// [`ResolvedFont`] every later path receives for that id, so no
+    /// resolution path can publish a second record under an id the frame
+    /// table already carries. GNU font.c `font_open_entity` likewise hands
+    /// back the font object already open for an entity at that pixel size
+    /// (`FONT_OBJLIST_INDEX`) instead of opening a second one, and
+    /// `font_clear_cache` closes those objects when the font set changes.
+    fn intern_resolved_font(
         &mut self,
-        identity: &ResolvedFontIdentity,
+        identity: ResolvedFontIdentity,
         replay: FontReplay,
         pixel_size: f32,
-    ) -> ResolvedFontId {
+        build: impl FnOnce(ResolvedFontId, ResolvedFontIdentity, FontReplay) -> ResolvedFont,
+    ) -> ResolvedFont {
         let key = ResolvedFontInstanceKey {
             identity: identity.clone(),
-            replay,
+            replay: replay.clone(),
             pixel_size_bits: pixel_size.to_bits(),
         };
-        if let Some(&id) = self.resolved_font_ids.get(&key) {
-            return id;
+        let id = match self.resolved_font_ids.get(&key) {
+            Some(&id) => id,
+            None => {
+                // Ids start at 1; 0 stays unused so an uninitialized id is visible.
+                let id = ResolvedFontId(self.resolved_font_ids.len() as u32 + 1);
+                self.resolved_font_ids.insert(key, id);
+                id
+            }
+        };
+        if let Some(font) = self.resolved_font_records.get(&id) {
+            return font.clone();
         }
-        // Ids start at 1; 0 stays unused so an uninitialized id is visible.
-        let id = ResolvedFontId(self.resolved_font_ids.len() as u32 + 1);
-        self.resolved_font_ids.insert(key, id);
-        id
+        let mut font = build(id, identity, replay);
+        font.id = id;
+        self.resolved_font_records.insert(id, font.clone());
+        font
     }
 
     /// Measure one character after platform selection has produced its exact
@@ -2775,7 +2864,7 @@ impl FontMetricsService {
 
         let materialized = self.materialized_font_for_realized_face_char(ch, selection);
         let direct_glyph = materialized.as_ref().filter(|materialized| {
-            materialized.font.source == FontResolutionSource::FacePrimary
+            materialized.resolution == FontResolutionSource::FacePrimary
                 || materialized
                     .font
                     .glyph_advance
@@ -3141,8 +3230,10 @@ impl FontMetricsService {
     }
 
     /// Clear all caches. Call when fonts change (e.g., text-scale-adjust).
-    /// `resolved_font_ids` intentionally survives: complete instance keys are
-    /// durable and ids must stay stable across generations (see field doc).
+    /// `resolved_font_ids` and `resolved_font_records` intentionally survive:
+    /// complete instance keys are durable and ids must stay stable across
+    /// generations; records are dropped only by a catalog advance (see field
+    /// docs).
     pub fn clear_caches(&mut self) {
         self.ascii_cache.clear();
         self.char_cache.clear();

--- a/crates/neomacs-layout-engine/src/font/metrics.rs
+++ b/crates/neomacs-layout-engine/src/font/metrics.rs
@@ -2548,18 +2548,9 @@ impl FontMetricsService {
         // Recover native metrics and selector metadata only for this exact
         // instance. A same-family match can select another file or variation;
         // neither may supply metrics for the face shaping already chose.
-        // resolve_primary finalizes the winner and attaches native metrics.
-        let selection_size = self.selection_size(font_size);
-        let platform = self
-            .font_resolver
-            .resolve_primary(
-                &family,
-                file_weight,
-                font_slant_from_fontdb(style),
-                FontWidth::Normal,
-                selection_size,
-            )
-            .filter(|matched| matched.identity == identity);
+        // Observe the already chosen identity instead of selecting a family
+        // winner, which can be another width, file, or variation.
+        let platform = self.font_resolver.observe_exact_font(&identity, &family);
         let px_metrics = Self::probe_resolved_font_metrics(&identity, platform.as_ref(), font_size)
             .or_else(|| {
                 self.font_px_metrics_from_selected_face(

--- a/crates/neomacs-layout-engine/src/font/metrics_test.rs
+++ b/crates/neomacs-layout-engine/src/font/metrics_test.rs
@@ -886,6 +886,51 @@ struct FixedNativeMemoryFontBackend {
 
 struct NoCandidateFontBackend;
 
+struct NativeMetricsPrimaryBackend {
+    candidate: crate::font_backend::PlatformFontCandidate,
+    metrics: crate::font_backend::PlatformFontDesignMetrics,
+}
+
+impl crate::font_backend::FontBackend for NativeMetricsPrimaryBackend {
+    fn kind(&self) -> FontBackendKind {
+        FontBackendKind::CoreText
+    }
+
+    fn list_families(&self) -> Vec<crate::font_backend::FontFamilyName> {
+        Vec::new()
+    }
+
+    fn resolve_family(&self, family: &str) -> String {
+        family.to_owned()
+    }
+
+    fn family_prefers_monospace(&self, _family: &str) -> bool {
+        true
+    }
+
+    fn list_candidates(
+        &self,
+        _query: &crate::font_backend::FontCandidateQuery,
+    ) -> Vec<crate::font_backend::FontCandidate> {
+        vec![crate::font_backend::FontCandidate {
+            matched: self.candidate.clone(),
+        }]
+    }
+
+    fn design_metrics(
+        &self,
+        _matched: &crate::font_backend::PlatformFontMatch,
+    ) -> Option<crate::font_backend::PlatformFontDesignMetrics> {
+        Some(self.metrics)
+    }
+
+    fn advance_catalog_generation(&mut self) {}
+
+    fn poll_catalog_change(&mut self) -> crate::font::catalog::FontCatalogChange {
+        crate::font::catalog::FontCatalogChange::Unchanged
+    }
+}
+
 struct ChangingCatalogBackend {
     pending: std::sync::Arc<std::sync::atomic::AtomicBool>,
     advances: std::sync::Arc<std::sync::atomic::AtomicUsize>,
@@ -1580,52 +1625,135 @@ fn char_first_realization_publishes_the_face_record() {
     );
 }
 
-#[test]
-fn shaping_first_realization_publishes_the_face_record() {
-    // Reverse order of `shaping_selected_face_reuses_the_realized_face_record`:
-    // when shaping realizes a file before any face does, the pinned record
-    // must still be the one the face path would have built.
-    let mut reference = make_svc();
-    let Some(face) = reference.materialized_font_for_face("Monospace", 400, false, 14.0) else {
-        return;
+fn native_metrics_fixture_service(
+    variations: Vec<neomacs_display_protocol::font::FontVariationCoord>,
+) -> (
+    FontMetricsService,
+    fontdb::ID,
+    String,
+    crate::font_backend::PlatformFontDesignMetrics,
+) {
+    let fixture = test_font_path(neomacs_test_fonts::spleen_2_2_0().woff());
+    let design_metrics = crate::font_backend::PlatformFontDesignMetrics {
+        units_per_em: 1000,
+        ascent: 1010,
+        descent: 300,
+        line_gap: 0,
+        max_advance: 600,
+        space_advance: 600,
+        average_advance: 600,
     };
-    let Some(file) = face.font.identity.file_path.clone() else {
-        debug!("skipping: platform identity has no file path (in-memory asset)");
-        return;
-    };
-    let face_index = face.font.identity.file_face_index();
-
     let mut svc = make_svc();
-    let Some(fontdb_id) = svc.font_system.db().faces().find_map(|candidate| {
-        (fontdb_face_file(candidate).as_deref() == Some(file.as_str())
-            && candidate.index == face_index)
-            .then_some(candidate.id)
-    }) else {
-        debug!("skipping: fontdb has no face for the platform file");
-        return;
-    };
-    let Some(from_shaping) = svc.resolved_font_from_fontdb_id(fontdb_id, 14.0) else {
-        debug!("skipping: fontdb face has no replayable file");
-        return;
-    };
-    let via_face = svc
-        .resolved_font_for_face("Monospace", 400, false, 14.0)
-        .expect("realized primary font");
-    if via_face.id != from_shaping.id {
-        debug!("skipping: fontdb identity differs from the platform identity");
-        return;
-    }
-    assert_eq!(
-        via_face, face.font,
-        "shaping-first realization must not change the face record"
+    let ids = FontFileCache::open_file(svc.font_system.db_mut(), &fixture, 0)
+        .expect("decode pinned font fixture");
+    let fontdb_id = *ids.first().expect("fixture has a fontdb face");
+    let face = svc.font_system.db().face(fontdb_id).expect("fixture face");
+    let family = face.families[0].0.clone();
+    let identity = ResolvedFontIdentity::from_platform_file_with_variations(
+        FontBackendKind::CoreText,
+        &fixture,
+        face.index,
+        Some(face.post_script_name.clone()),
+        variations,
     );
+    svc.font_resolver
+        .replace_backend(Box::new(NativeMetricsPrimaryBackend {
+            candidate: platform_file_candidate(
+                identity,
+                crate::font_backend::PlatformFontMetadata {
+                    foundry: None,
+                    family: family.clone(),
+                    weight: Some(400),
+                    slant: FontSlant::Normal,
+                    width: Some(FontWidth::Normal),
+                    spacing: Some(100),
+                    // Exercise the resolver's native-metric enrichment,
+                    // not metadata pre-attached to a catalog candidate.
+                    design_metrics: None,
+                    size: crate::font_backend::PlatformFontSize::Scalable,
+                },
+            ),
+            metrics: design_metrics,
+        }));
+    (svc, fontdb_id, family, design_metrics)
+}
+
+#[test]
+fn shaping_first_realization_publishes_the_native_face_metrics() {
+    // Catch table metrics being interned before the resolver attaches native
+    // metrics. The fixture and backend do not depend on installed system fonts.
+    for size in [10.6, 14.0] {
+        let (mut reference, _, family, design_metrics) = native_metrics_fixture_service(Vec::new());
+        let expected = reference
+            .materialized_font_for_face(&family, 400, false, size)
+            .expect("fixture primary face");
+        let native = design_metrics.at_pixel_size(size).expect("native metrics");
+        assert_eq!(expected.font.ascent_px, native.ascent as f32);
+        assert_eq!(expected.font.space_advance_px, native.space_width as f32);
+
+        let (mut svc, fontdb_id, _, _) = native_metrics_fixture_service(Vec::new());
+        let shaping = svc
+            .resolved_font_from_fontdb_id(fontdb_id, size)
+            .expect("shaping-selected fixture");
+        let via_face = svc
+            .materialized_font_for_face(&family, 400, false, size)
+            .expect("primary after shaping");
+        assert_eq!(shaping, via_face.font, "one id must publish one record");
+        assert_eq!(
+            via_face.font, expected.font,
+            "shaping-first must preserve native metrics at {size}px"
+        );
+        let handle_metrics = via_face.px_metrics.expect("native handle metrics");
+        assert_eq!(via_face.font.ascent_px, handle_metrics.ascent as f32);
+        assert_eq!(via_face.font.descent_px, handle_metrics.descent as f32);
+        assert_eq!(
+            via_face.font.space_advance_px,
+            handle_metrics.space_width as f32
+        );
+        assert_eq!(
+            via_face.font.glyph_advance,
+            resolved_font_advance(
+                neomacs_display_protocol::font::FixedFontSpacing::MonospaceOrCharacterCell,
+                Some(handle_metrics),
+            )
+        );
+    }
+}
+
+#[test]
+fn shaping_metrics_do_not_come_from_another_variation_of_the_same_file() {
+    let variation = neomacs_display_protocol::font::FontVariationCoord::try_new(
+        u32::from_be_bytes(*b"wght"),
+        700.0,
+    )
+    .expect("finite weight coordinate");
+    let (mut svc, fontdb_id, family, _) = native_metrics_fixture_service(vec![variation]);
+    let size = 10.6;
+    let selected = svc.font_system.db().face(fontdb_id).expect("fixture face");
+    let identity = svc.fontdb_face_identity(
+        fontdb_face_file(selected).as_deref(),
+        selected.index,
+        Some(selected.post_script_name.clone()),
+        &family,
+    );
+    let expected = FontMetricsService::probe_resolved_font_metrics(&identity, None, size)
+        .or_else(|| svc.font_px_metrics_from_selected_face(fontdb_id, size, &[]))
+        .expect("selected file metrics");
+    let shaping = svc
+        .resolved_font_from_fontdb_id(fontdb_id, size)
+        .expect("selected face");
+    assert_eq!(shaping.identity, identity);
+    assert_eq!(
+        shaping.ascent_px, expected.ascent as f32,
+        "same-file native metrics belong to a different variation identity"
+    );
+    assert_eq!(shaping.space_advance_px, expected.space_width as f32);
 }
 
 #[test]
 fn shaping_selected_face_reuses_the_realized_face_record() {
-    // `resolved_font_from_fontdb_id` builds from file metadata rather than the
-    // platform selection; when shaping lands on the face's own fontdb face it
-    // must still publish the face's record.
+    // When shaping lands on the face's own fontdb face, it must publish the
+    // already interned record even if its diagnostic family metadata differs.
     let mut svc = make_svc();
     let Some(primary) = svc.materialized_font_for_face("Monospace", 400, false, 14.0) else {
         return;

--- a/crates/neomacs-layout-engine/src/font/metrics_test.rs
+++ b/crates/neomacs-layout-engine/src/font/metrics_test.rs
@@ -247,6 +247,33 @@ fn symbol_font_policy_tracks_the_live_char_script_table_and_invalidates_char_cac
 }
 
 #[test]
+fn covered_char_publishes_the_same_record_as_the_realized_face() {
+    // GNU keeps one font object per realized entity and size; whether the
+    // ASCII face or a fontset tier led to it is not a property of the font.
+    // The frame font table is keyed by id, so both paths must publish one
+    // identical record or the renderer sees an id reused for a new instance.
+    let mut svc = make_svc();
+    let face = svc
+        .resolved_font_for_face("Monospace", 400, false, 14.0)
+        .expect("realized primary font");
+    let Some(ch) = ['é', 'ü', 'ñ', 'ö'].into_iter().find(|ch| {
+        svc.resolved_font_for_char(*ch, "Monospace", 400, false, 14.0)
+            .is_some_and(|font| font.id == face.id)
+    }) else {
+        debug!("skipping: platform monospace font covers none of the probe characters");
+        return;
+    };
+
+    let via_char = svc
+        .resolved_font_for_char(ch, "Monospace", 400, false, 14.0)
+        .expect("covered character");
+    assert_eq!(
+        via_char, face,
+        "one resolved font id must name one record on every resolution path"
+    );
+}
+
+#[test]
 fn covered_symbol_uses_and_publishes_the_realized_primary_font() {
     let mut eval = neovm_core::Context::new();
     eval.eval_str("(set-char-table-range char-script-table '(#x2000 . #x27ff) 'symbol)")
@@ -268,7 +295,7 @@ fn covered_symbol_uses_and_publishes_the_realized_primary_font() {
         .materialized_font_for_realized_face_char('▶', selection)
         .expect("covered symbol font");
     assert_eq!(symbol.font.id, primary.font.id);
-    assert_eq!(symbol.font.source, FontResolutionSource::FacePrimary);
+    assert_eq!(symbol.resolution, FontResolutionSource::FacePrimary);
 
     let (_, published_fonts) = svc
         .resolve_cluster_uncached("▶", selection)
@@ -277,7 +304,7 @@ fn covered_symbol_uses_and_publishes_the_realized_primary_font() {
         .iter()
         .find(|font| font.id == primary.font.id)
         .expect("selected primary is published for the cluster");
-    assert_eq!(published.source, FontResolutionSource::FacePrimary);
+    assert_eq!(*published, primary.font);
 }
 
 #[test]
@@ -328,7 +355,7 @@ fn realized_face_complex_run_shapes_with_the_exact_materialized_fontset_font() {
         .expect("materialized fontset font");
     assert_eq!(materialized.font.family, "JetBrainsMono Nerd Font");
     assert_eq!(
-        materialized.font.source,
+        materialized.resolution,
         FontResolutionSource::FontsetFallback
     );
     let exact_family = match svc
@@ -1398,6 +1425,31 @@ fn scalable_color_bitmap_keeps_exact_platform_identity_at_requested_size() {
     assert_eq!(resolved.pixel_size, 14.0);
 }
 
+fn fixture_record(
+    id: ResolvedFontId,
+    identity: &ResolvedFontIdentity,
+    replay: &FontReplay,
+    pixel_size: f32,
+    family: &str,
+) -> ResolvedFont {
+    ResolvedFont {
+        id,
+        identity: identity.clone(),
+        replay: replay.clone(),
+        family: family.to_owned(),
+        full_name: None,
+        postscript_name: None,
+        weight: 400,
+        slant: FontSlantKind::Normal,
+        width: 5,
+        pixel_size,
+        ascent_px: pixel_size,
+        descent_px: 0.0,
+        space_advance_px: pixel_size * 0.6,
+        glyph_advance: ResolvedFontAdvance::PerGlyph,
+    }
+}
+
 #[test]
 fn resolved_font_ids_name_a_complete_realized_instance() {
     use neomacs_display_protocol::font::{BitmapStrikeKey, FontReplay, GlyphSampling};
@@ -1415,21 +1467,182 @@ fn resolved_font_ids_name_a_complete_realized_instance() {
         sampling: GlyphSampling::Nearest,
         spacing: neomacs_display_protocol::font::FixedFontSpacing::MonospaceOrCharacterCell,
     };
+    let intern = |svc: &mut FontMetricsService, replay: FontReplay, size: f32| {
+        svc.intern_resolved_font(identity.clone(), replay, size, |id, identity, replay| {
+            fixture_record(id, &identity, &replay, size, "fixed")
+        })
+        .id
+    };
 
-    let first = svc.intern_resolved_font_id(&identity, strike(0), 13.0);
-    assert_eq!(
-        first,
-        svc.intern_resolved_font_id(&identity, strike(0), 13.0)
-    );
+    let first = intern(&mut svc, strike(0), 13.0);
+    assert_eq!(first, intern(&mut svc, strike(0), 13.0));
+    assert_ne!(first, intern(&mut svc, strike(1), 14.0));
     assert_ne!(
-        first,
-        svc.intern_resolved_font_id(&identity, strike(1), 14.0)
-    );
-    assert_ne!(
-        svc.intern_resolved_font_id(&identity, swash_replay_for(&identity), 13.0),
-        svc.intern_resolved_font_id(&identity, swash_replay_for(&identity), 14.0),
+        intern(&mut svc, swash_replay_for(&identity), 13.0),
+        intern(&mut svc, swash_replay_for(&identity), 14.0),
         "metrics-bearing protocol entries at distinct sizes cannot share an id"
     );
+}
+
+#[test]
+fn interner_owns_the_record_published_under_an_id() {
+    // Four builders realize records independently; the interner must hand
+    // every later builder the first record for the key, or the id-keyed frame
+    // table can carry two records for one id across frames.
+    let mut svc = make_svc();
+    let identity = ResolvedFontIdentity::from_file("/fonts/one.ttf", 0, None);
+    let replay = swash_replay_for(&identity);
+    let first = svc.intern_resolved_font(
+        identity.clone(),
+        replay.clone(),
+        12.0,
+        |id, identity, replay| fixture_record(id, &identity, &replay, 12.0, "First Family"),
+    );
+    let second = svc.intern_resolved_font(identity, replay, 12.0, |id, identity, replay| {
+        fixture_record(id, &identity, &replay, 12.0, "Second Family")
+    });
+    assert_eq!(second, first);
+    assert_eq!(second.family, "First Family");
+}
+
+#[test]
+fn catalog_advance_republishes_records_under_stable_ids() {
+    // A file replaced in place keeps its id (frames keep referencing it) but
+    // must republish its metrics: GNU `font_clear_cache` closes the objects in
+    // `FONT_OBJLIST_INDEX` when the font set changes.
+    let pending = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let advances = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let mut svc = make_svc();
+    svc.font_resolver
+        .replace_backend(Box::new(ChangingCatalogBackend {
+            pending: std::sync::Arc::clone(&pending),
+            advances: std::sync::Arc::clone(&advances),
+        }));
+    let identity = ResolvedFontIdentity::from_file("/fonts/replaced.ttf", 0, None);
+    let replay = swash_replay_for(&identity);
+    let before = svc.intern_resolved_font(
+        identity.clone(),
+        replay.clone(),
+        12.0,
+        |id, identity, replay| fixture_record(id, &identity, &replay, 12.0, "Version 1"),
+    );
+    let pinned = svc.intern_resolved_font(
+        identity.clone(),
+        replay.clone(),
+        12.0,
+        |id, identity, replay| fixture_record(id, &identity, &replay, 12.0, "Version 2"),
+    );
+    assert_eq!(
+        pinned, before,
+        "within one generation the first record stands"
+    );
+
+    pending.store(true, std::sync::atomic::Ordering::Release);
+    assert!(svc.synchronize_font_catalog().changed());
+    let after = svc.intern_resolved_font(identity, replay, 12.0, |id, identity, replay| {
+        fixture_record(id, &identity, &replay, 12.0, "Version 2")
+    });
+    assert_eq!(after.id, before.id, "the id survives the catalog advance");
+    assert_eq!(
+        after.family, "Version 2",
+        "the record is rebuilt from the new file"
+    );
+}
+
+#[test]
+fn char_first_realization_publishes_the_face_record() {
+    // The per-character builder realizes the file before any face does (a
+    // fallback-only frame); the pinned record must be the face path's.
+    let mut reference = make_svc();
+    let Some(face) = reference.resolved_font_for_face("Monospace", 400, false, 14.0) else {
+        return;
+    };
+    let Some(ch) = ['é', 'ü', 'ñ', 'ö'].into_iter().find(|ch| {
+        reference
+            .resolved_font_for_char(*ch, "Monospace", 400, false, 14.0)
+            .is_some_and(|font| font.id == face.id)
+    }) else {
+        debug!("skipping: platform monospace font covers none of the probe characters");
+        return;
+    };
+
+    let mut svc = make_svc();
+    let via_char = svc
+        .resolved_font_for_char(ch, "Monospace", 400, false, 14.0)
+        .expect("covered character");
+    let via_face = svc
+        .resolved_font_for_face("Monospace", 400, false, 14.0)
+        .expect("realized primary font");
+    assert_eq!(via_face.id, via_char.id);
+    assert_eq!(
+        via_face, face,
+        "char-first realization must not change the face record"
+    );
+}
+
+#[test]
+fn shaping_first_realization_publishes_the_face_record() {
+    // Reverse order of `shaping_selected_face_reuses_the_realized_face_record`:
+    // when shaping realizes a file before any face does, the pinned record
+    // must still be the one the face path would have built.
+    let mut reference = make_svc();
+    let Some(face) = reference.materialized_font_for_face("Monospace", 400, false, 14.0) else {
+        return;
+    };
+    let Some(file) = face.font.identity.file_path.clone() else {
+        debug!("skipping: platform identity has no file path (in-memory asset)");
+        return;
+    };
+    let face_index = face.font.identity.file_face_index();
+
+    let mut svc = make_svc();
+    let Some(fontdb_id) = svc.font_system.db().faces().find_map(|candidate| {
+        (fontdb_face_file(candidate).as_deref() == Some(file.as_str())
+            && candidate.index == face_index)
+            .then_some(candidate.id)
+    }) else {
+        debug!("skipping: fontdb has no face for the platform file");
+        return;
+    };
+    let Some(from_shaping) = svc.resolved_font_from_fontdb_id(fontdb_id, 14.0) else {
+        debug!("skipping: fontdb face has no replayable file");
+        return;
+    };
+    let via_face = svc
+        .resolved_font_for_face("Monospace", 400, false, 14.0)
+        .expect("realized primary font");
+    if via_face.id != from_shaping.id {
+        debug!("skipping: fontdb identity differs from the platform identity");
+        return;
+    }
+    assert_eq!(
+        via_face, face.font,
+        "shaping-first realization must not change the face record"
+    );
+}
+
+#[test]
+fn shaping_selected_face_reuses_the_realized_face_record() {
+    // `resolved_font_from_fontdb_id` builds from file metadata rather than the
+    // platform selection; when shaping lands on the face's own fontdb face it
+    // must still publish the face's record.
+    let mut svc = make_svc();
+    let Some(primary) = svc.materialized_font_for_face("Monospace", 400, false, 14.0) else {
+        return;
+    };
+    let Some(fontdb_id) = primary.source.fontdb_id() else {
+        debug!("skipping: primary face is a bitmap font");
+        return;
+    };
+    let Some(from_shaping) = svc.resolved_font_from_fontdb_id(fontdb_id, 14.0) else {
+        debug!("skipping: fontdb face has no replayable file");
+        return;
+    };
+    if from_shaping.id != primary.font.id {
+        debug!("skipping: fontdb identity differs from the platform identity");
+        return;
+    }
+    assert_eq!(from_shaping, primary.font);
 }
 
 #[cfg(target_os = "linux")]
@@ -1469,7 +1682,15 @@ fn ascii_character_resolution_keeps_primary_face_that_lacks_the_glyph() {
 
     assert_eq!(resolved.identity.file_path.as_deref(), Some(file.as_str()));
     assert_eq!(resolved.identity.file_face_index(), face_index);
-    assert_eq!(resolved.source, FontResolutionSource::FacePrimary);
+    assert_eq!(
+        svc.materialized_font_for_realized_face_char(
+            ' ',
+            RealizedFaceFontSelection::same_fontset(requested_family, 400, false, 10.0),
+        )
+        .expect("materialized primary face")
+        .resolution,
+        FontResolutionSource::FacePrimary
+    );
 
     let selected = svc
         .select_font_for_char(' ', requested_family, 400, false, 10.0)
@@ -2649,10 +2870,6 @@ fn resolved_font_for_face_yields_an_exact_replayable_identity() {
             assert!(!asset.bytes().is_empty());
         }
     }
-    assert_eq!(
-        font.source,
-        neomacs_display_protocol::font::FontResolutionSource::FacePrimary
-    );
     assert!(font.ascent_px > 0.0, "resolved font carries real metrics");
 }
 
@@ -3089,10 +3306,6 @@ fn realize_frame_char_fonts_stamps_cjk_fallback() {
         .get(&font_id)
         .expect("char fallback font published in frame font table");
     assert_eq!(font.id, font_id);
-    assert_eq!(
-        font.source,
-        neomacs_display_protocol::font::FontResolutionSource::FontsetFallback
-    );
     // The layout-side selection agrees with the char-selection oracle path.
     let selected = service
         .as_mut()

--- a/crates/neomacs-layout-engine/src/font/metrics_test.rs
+++ b/crates/neomacs-layout-engine/src/font/metrics_test.rs
@@ -887,7 +887,7 @@ struct FixedNativeMemoryFontBackend {
 struct NoCandidateFontBackend;
 
 struct NativeMetricsPrimaryBackend {
-    candidate: crate::font_backend::PlatformFontCandidate,
+    candidates: Vec<crate::font_backend::PlatformFontCandidate>,
     metrics: crate::font_backend::PlatformFontDesignMetrics,
 }
 
@@ -912,9 +912,11 @@ impl crate::font_backend::FontBackend for NativeMetricsPrimaryBackend {
         &self,
         _query: &crate::font_backend::FontCandidateQuery,
     ) -> Vec<crate::font_backend::FontCandidate> {
-        vec![crate::font_backend::FontCandidate {
-            matched: self.candidate.clone(),
-        }]
+        self.candidates
+            .iter()
+            .cloned()
+            .map(|matched| crate::font_backend::FontCandidate { matched })
+            .collect()
     }
 
     fn design_metrics(
@@ -1658,7 +1660,7 @@ fn native_metrics_fixture_service(
     );
     svc.font_resolver
         .replace_backend(Box::new(NativeMetricsPrimaryBackend {
-            candidate: platform_file_candidate(
+            candidates: vec![platform_file_candidate(
                 identity,
                 crate::font_backend::PlatformFontMetadata {
                     foundry: None,
@@ -1672,7 +1674,7 @@ fn native_metrics_fixture_service(
                     design_metrics: None,
                     size: crate::font_backend::PlatformFontSize::Scalable,
                 },
-            ),
+            )],
             metrics: design_metrics,
         }));
     (svc, fontdb_id, family, design_metrics)
@@ -1718,6 +1720,58 @@ fn shaping_first_realization_publishes_the_native_face_metrics() {
             )
         );
     }
+}
+
+#[test]
+fn shaping_recovers_native_metrics_for_the_exact_nonpreferred_family_member() {
+    let (mut svc, fontdb_id, family, native) = native_metrics_fixture_service(Vec::new());
+    let exact = svc
+        .font_resolver
+        .resolve_primary(
+            &family,
+            400,
+            FontSlant::Normal,
+            FontWidth::Normal,
+            svc.selection_size(10.6),
+        )
+        .expect("fixture platform identity");
+    let mut condensed = platform_file_candidate(exact.identity.clone(), exact.metadata.clone());
+    condensed.metadata.width = Some(FontWidth::Condensed);
+    condensed.metadata.design_metrics = None;
+    // The other file is the normal-width family winner, but shaping has
+    // already selected the fixture file. A second style-selection pass must
+    // neither hide that file's native metrics nor substitute this candidate.
+    let normal = platform_file_candidate(
+        ResolvedFontIdentity::from_platform_file_with_variations(
+            FontBackendKind::CoreText,
+            "/fonts/other-normal-member.ttf",
+            0,
+            Some("OtherNormalMember".to_owned()),
+            Vec::new(),
+        ),
+        exact.metadata,
+    );
+    svc.font_resolver
+        .replace_backend(Box::new(NativeMetricsPrimaryBackend {
+            candidates: vec![normal, condensed],
+            metrics: native,
+        }));
+
+    let selected = svc
+        .resolved_font_from_fontdb_id(fontdb_id, 10.6)
+        .expect("shaping-selected exact font");
+    assert_eq!(
+        selected.identity, exact.identity,
+        "do not select another family member"
+    );
+    assert_eq!(
+        selected.space_advance_px, 6.0,
+        "GNU macfont rounds the native 600/1000 em advance at 10.6 px to 6 px"
+    );
+    assert_eq!(
+        selected.ascent_px, 11.0,
+        "retain native ascent, not file ascent"
+    );
 }
 
 #[test]

--- a/crates/neomacs-layout-engine/src/font/metrics_test.rs
+++ b/crates/neomacs-layout-engine/src/font/metrics_test.rs
@@ -1472,24 +1472,14 @@ fn scalable_color_bitmap_keeps_exact_platform_identity_at_requested_size() {
     assert_eq!(resolved.pixel_size, 14.0);
 }
 
-fn fixture_record(
-    id: ResolvedFontId,
-    identity: &ResolvedFontIdentity,
-    replay: &FontReplay,
-    pixel_size: f32,
-    family: &str,
-) -> ResolvedFont {
-    ResolvedFont {
-        id,
-        identity: identity.clone(),
-        replay: replay.clone(),
+fn fixture_properties(pixel_size: f32, family: &str) -> FontInstanceProperties {
+    FontInstanceProperties {
         family: family.to_owned(),
         full_name: None,
         postscript_name: None,
         weight: 400,
         slant: FontSlantKind::Normal,
         width: 5,
-        pixel_size,
         ascent_px: pixel_size,
         descent_px: 0.0,
         space_advance_px: pixel_size * 0.6,
@@ -1515,10 +1505,11 @@ fn resolved_font_ids_name_a_complete_realized_instance() {
         spacing: neomacs_display_protocol::font::FixedFontSpacing::MonospaceOrCharacterCell,
     };
     let intern = |svc: &mut FontMetricsService, replay: FontReplay, size: f32| {
-        svc.intern_resolved_font(identity.clone(), replay, size, |id, identity, replay| {
-            fixture_record(id, &identity, &replay, size, "fixed")
-        })
-        .id
+        svc.font_instances
+            .intern(identity.clone(), replay, size, || {
+                fixture_properties(size, "fixed")
+            })
+            .id
     };
 
     let first = intern(&mut svc, strike(0), 13.0);
@@ -1539,17 +1530,36 @@ fn interner_owns_the_record_published_under_an_id() {
     let mut svc = make_svc();
     let identity = ResolvedFontIdentity::from_file("/fonts/one.ttf", 0, None);
     let replay = swash_replay_for(&identity);
-    let first = svc.intern_resolved_font(
-        identity.clone(),
-        replay.clone(),
-        12.0,
-        |id, identity, replay| fixture_record(id, &identity, &replay, 12.0, "First Family"),
-    );
-    let second = svc.intern_resolved_font(identity, replay, 12.0, |id, identity, replay| {
-        fixture_record(id, &identity, &replay, 12.0, "Second Family")
+    let first = svc
+        .font_instances
+        .intern(identity.clone(), replay.clone(), 12.0, || {
+            fixture_properties(12.0, "First Family")
+        });
+    let second = svc.font_instances.intern(identity, replay, 12.0, || {
+        fixture_properties(12.0, "Second Family")
     });
     assert_eq!(second, first);
     assert_eq!(second.family, "First Family");
+}
+
+#[test]
+fn font_instance_key_controls_the_published_size() {
+    let mut svc = make_svc();
+    let identity = ResolvedFontIdentity::from_file("/fonts/one.ttf", 0, None);
+    let replay = swash_replay_for(&identity);
+    // The observation type cannot supply key fields. Even deliberately large
+    // metrics must be published under the size chosen by the instance owner.
+    let font = svc
+        .font_instances
+        .intern(identity.clone(), replay.clone(), 12.0, || {
+            fixture_properties(99.0, "Fixture")
+        });
+    assert_eq!(font.identity, identity);
+    assert_eq!(font.replay, replay);
+    assert_eq!(
+        font.pixel_size, 12.0,
+        "the record must describe its interned key, not a builder's size"
+    );
 }
 
 #[test]
@@ -1567,18 +1577,16 @@ fn catalog_advance_republishes_records_under_stable_ids() {
         }));
     let identity = ResolvedFontIdentity::from_file("/fonts/replaced.ttf", 0, None);
     let replay = swash_replay_for(&identity);
-    let before = svc.intern_resolved_font(
-        identity.clone(),
-        replay.clone(),
-        12.0,
-        |id, identity, replay| fixture_record(id, &identity, &replay, 12.0, "Version 1"),
-    );
-    let pinned = svc.intern_resolved_font(
-        identity.clone(),
-        replay.clone(),
-        12.0,
-        |id, identity, replay| fixture_record(id, &identity, &replay, 12.0, "Version 2"),
-    );
+    let before = svc
+        .font_instances
+        .intern(identity.clone(), replay.clone(), 12.0, || {
+            fixture_properties(12.0, "Version 1")
+        });
+    let pinned = svc
+        .font_instances
+        .intern(identity.clone(), replay.clone(), 12.0, || {
+            fixture_properties(12.0, "Version 2")
+        });
     assert_eq!(
         pinned, before,
         "within one generation the first record stands"
@@ -1586,13 +1594,17 @@ fn catalog_advance_republishes_records_under_stable_ids() {
 
     pending.store(true, std::sync::atomic::Ordering::Release);
     assert!(svc.synchronize_font_catalog().changed());
-    let after = svc.intern_resolved_font(identity, replay, 12.0, |id, identity, replay| {
-        fixture_record(id, &identity, &replay, 12.0, "Version 2")
+    let after = svc.font_instances.intern(identity, replay, 12.0, || {
+        fixture_properties(12.0, "Version 2")
     });
     assert_eq!(after.id, before.id, "the id survives the catalog advance");
     assert_eq!(
         after.family, "Version 2",
         "the record is rebuilt from the new file"
+    );
+    assert_eq!(
+        before.family, "Version 1",
+        "old snapshots retain their records"
     );
 }
 

--- a/crates/neomacs-layout-engine/src/font/metrics_test.rs
+++ b/crates/neomacs-layout-engine/src/font/metrics_test.rs
@@ -910,10 +910,16 @@ impl crate::font_backend::FontBackend for NativeMetricsPrimaryBackend {
 
     fn list_candidates(
         &self,
-        _query: &crate::font_backend::FontCandidateQuery,
+        query: &crate::font_backend::FontCandidateQuery,
     ) -> Vec<crate::font_backend::FontCandidate> {
         self.candidates
             .iter()
+            .filter(|candidate| {
+                query
+                    .scope
+                    .queried_family()
+                    .is_none_or(|family| candidate.metadata.family == family)
+            })
             .cloned()
             .map(|matched| crate::font_backend::FontCandidate { matched })
             .collect()
@@ -1784,6 +1790,42 @@ fn shaping_recovers_native_metrics_for_the_exact_nonpreferred_family_member() {
         selected.ascent_px, 11.0,
         "retain native ascent, not file ascent"
     );
+}
+
+#[test]
+fn shaping_recovers_native_metrics_through_a_synthetic_pinned_family() {
+    let (mut svc, _, native_family, _) = native_metrics_fixture_service(Vec::new());
+    let fixture = test_font_path(neomacs_test_fonts::spleen_2_2_0().woff());
+    let pinned_family = svc
+        .pin_file_as_family(&fixture, 0)
+        .expect("pin exact fixture");
+    assert_ne!(
+        pinned_family, native_family,
+        "exercise a synthetic family name"
+    );
+    let fontdb_id = svc
+        .font_system
+        .db()
+        .faces()
+        .find(|face| {
+            face.families
+                .iter()
+                .any(|(family, _)| family == pinned_family)
+        })
+        .expect("pinned fontdb face")
+        .id;
+    let selected = svc
+        .resolved_font_from_fontdb_id(fontdb_id, 10.6)
+        .expect("shaping-selected pinned face");
+    assert_eq!(
+        selected.identity.file_path.as_deref(),
+        Some(fixture.as_str())
+    );
+    assert_eq!(
+        selected.ascent_px, 11.0,
+        "a synthetic family must not hide exact native metrics"
+    );
+    assert_eq!(selected.space_advance_px, 6.0);
 }
 
 #[test]

--- a/crates/neomacs-layout-engine/src/font/mod.rs
+++ b/crates/neomacs-layout-engine/src/font/mod.rs
@@ -5,6 +5,7 @@ pub mod font_match;
 #[cfg(target_os = "linux")]
 pub mod fontconfig;
 pub(crate) mod frame_metrics;
+mod instance;
 pub mod metrics;
 pub mod policy;
 pub mod probe;

--- a/crates/neomacs-layout-engine/src/font/resolver.rs
+++ b/crates/neomacs-layout-engine/src/font/resolver.rs
@@ -13,7 +13,7 @@ use crate::font_backend::{
     FontSelectionSize, PlatformFontCandidate, PlatformFontMatch, PlatformFontSize,
     RequiredFontCoverage, TextDirection,
 };
-use neomacs_display_protocol::font::FontBackendKind;
+use neomacs_display_protocol::font::{FontBackendKind, ResolvedFontIdentity};
 use neovm_core::emacs_core::font::alternative_font_families;
 use neovm_core::emacs_core::fontset::{
     FontSpecEntry, StoredFontSpec, fontset_generation, matching_entries_for_char,
@@ -147,6 +147,7 @@ pub struct FontResolver {
     >,
     primary_cache: Mutex<HashMap<PrimaryCacheKey, Option<PlatformFontMatch>>>,
     char_cache: Mutex<HashMap<CharCacheKey, Option<PlatformFontMatch>>>,
+    exact_cache: Mutex<HashMap<ExactFontCacheKey, Option<PlatformFontMatch>>>,
 }
 
 impl FontResolver {
@@ -157,6 +158,7 @@ impl FontResolver {
             capability_cache: Mutex::new(HashMap::default()),
             primary_cache: Mutex::new(HashMap::default()),
             char_cache: Mutex::new(HashMap::default()),
+            exact_cache: Mutex::new(HashMap::default()),
         }
     }
 
@@ -350,6 +352,55 @@ impl FontResolver {
         selected
     }
 
+    /// Observe an already selected face without running style selection again.
+    ///
+    /// GNU opens the selected entity in `font_open_entity`; it does not choose
+    /// another family member to obtain its metrics. FAMILY scopes discovery,
+    /// but the full identity alone authorizes native finalization/observation.
+    /// Cache misses too, since shaping can select faces absent from the native
+    /// catalog. Both outcomes expire with the catalog's other observations.
+    pub(crate) fn observe_exact_font(
+        &self,
+        identity: &ResolvedFontIdentity,
+        family: &str,
+    ) -> Option<PlatformFontMatch> {
+        let family = FontFamilyName::new(family)?;
+        let key = ExactFontCacheKey {
+            identity: identity.clone(),
+            family: family.clone(),
+        };
+        if let Ok(cache) = self.exact_cache.lock()
+            && let Some(cached) = cache.get(&key)
+        {
+            return cached.clone();
+        }
+        let query = FontCandidateQuery {
+            scope: FontCandidateScope::Family(family),
+            required: RequiredFontCoverage::Any,
+            charset_ranges: Vec::new(),
+            languages: Vec::new(),
+            requested_weight: 400,
+            requested_slant: FontSlant::Normal,
+            requested_width: FontWidth::Normal,
+            direction: TextDirection::LeftToRight,
+        };
+        let matched = self
+            .backend
+            .list_candidates(&query)
+            .into_iter()
+            .filter(|candidate| candidate.matched.identity == *identity)
+            .find_map(|candidate| {
+                self.backend
+                    .finalize_match(candidate.matched)
+                    .filter(|matched| matched.identity == *identity)
+            })
+            .map(|matched| self.with_native_metrics(matched));
+        if let Ok(mut cache) = self.exact_cache.lock() {
+            cache.insert(key, matched.clone());
+        }
+        matched
+    }
+
     /// Resolve the first usable fontset entry for a non-ASCII character.
     pub fn resolve_for_char(
         &self,
@@ -525,6 +576,10 @@ impl FontResolver {
             .get_mut()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clear();
+        self.exact_cache
+            .get_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
         self.capability_cache
             .get_mut()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -605,11 +660,21 @@ impl FontResolver {
             .get_mut()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clear();
+        self.exact_cache
+            .get_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
         self.capability_cache
             .get_mut()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clear();
     }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct ExactFontCacheKey {
+    identity: ResolvedFontIdentity,
+    family: FontFamilyName,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/neomacs-layout-engine/src/font/resolver.rs
+++ b/crates/neomacs-layout-engine/src/font/resolver.rs
@@ -147,7 +147,7 @@ pub struct FontResolver {
     >,
     primary_cache: Mutex<HashMap<PrimaryCacheKey, Option<PlatformFontMatch>>>,
     char_cache: Mutex<HashMap<CharCacheKey, Option<PlatformFontMatch>>>,
-    exact_cache: Mutex<HashMap<ExactFontCacheKey, Option<PlatformFontMatch>>>,
+    exact_cache: Mutex<HashMap<ResolvedFontIdentity, Option<PlatformFontMatch>>>,
 }
 
 impl FontResolver {
@@ -355,8 +355,9 @@ impl FontResolver {
     /// Observe an already selected face without running style selection again.
     ///
     /// GNU opens the selected entity in `font_open_entity`; it does not choose
-    /// another family member to obtain its metrics. FAMILY scopes discovery,
-    /// but the full identity alone authorizes native finalization/observation.
+    /// another family member to obtain its metrics. FAMILY is only a discovery
+    /// hint: pinned fontdb faces can carry synthetic family names. The full
+    /// identity alone authorizes native finalization/observation.
     /// Cache misses too, since shaping can select faces absent from the native
     /// catalog. Both outcomes expire with the catalog's other observations.
     pub(crate) fn observe_exact_font(
@@ -364,18 +365,13 @@ impl FontResolver {
         identity: &ResolvedFontIdentity,
         family: &str,
     ) -> Option<PlatformFontMatch> {
-        let family = FontFamilyName::new(family)?;
-        let key = ExactFontCacheKey {
-            identity: identity.clone(),
-            family: family.clone(),
-        };
         if let Ok(cache) = self.exact_cache.lock()
-            && let Some(cached) = cache.get(&key)
+            && let Some(cached) = cache.get(identity)
         {
             return cached.clone();
         }
-        let query = FontCandidateQuery {
-            scope: FontCandidateScope::Family(family),
+        let mut query = FontCandidateQuery {
+            scope: FontCandidateScope::All,
             required: RequiredFontCoverage::Any,
             charset_ranges: Vec::new(),
             languages: Vec::new(),
@@ -384,19 +380,26 @@ impl FontResolver {
             requested_width: FontWidth::Normal,
             direction: TextDirection::LeftToRight,
         };
-        let matched = self
-            .backend
-            .list_candidates(&query)
+        let mut scopes = FontFamilyName::new(family)
+            .map(FontCandidateScope::Family)
             .into_iter()
-            .filter(|candidate| candidate.matched.identity == *identity)
-            .find_map(|candidate| {
+            .chain(std::iter::once(FontCandidateScope::All));
+        let matched = scopes
+            .find_map(|scope| {
+                query.scope = scope;
                 self.backend
-                    .finalize_match(candidate.matched)
-                    .filter(|matched| matched.identity == *identity)
+                    .list_candidates(&query)
+                    .into_iter()
+                    .filter(|candidate| candidate.matched.identity == *identity)
+                    .find_map(|candidate| {
+                        self.backend
+                            .finalize_match(candidate.matched)
+                            .filter(|matched| matched.identity == *identity)
+                    })
             })
             .map(|matched| self.with_native_metrics(matched));
         if let Ok(mut cache) = self.exact_cache.lock() {
-            cache.insert(key, matched.clone());
+            cache.insert(identity.clone(), matched.clone());
         }
         matched
     }
@@ -669,12 +672,6 @@ impl FontResolver {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clear();
     }
-}
-
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-struct ExactFontCacheKey {
-    identity: ResolvedFontIdentity,
-    family: FontFamilyName,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/neomacs-layout-engine/src/font/resolver_test.rs
+++ b/crates/neomacs-layout-engine/src/font/resolver_test.rs
@@ -600,3 +600,59 @@ fn native_entity_open_is_completed_with_backend_metrics() {
     assert_eq!(opened.metrics.ascent, 16);
     assert_eq!(probes.load(Ordering::Relaxed), 1);
 }
+
+#[test]
+fn exact_native_observations_are_cached_until_the_catalog_advances() {
+    let probes = Arc::new(AtomicUsize::new(0));
+    let mut selected = candidate("Fixture", 400, FontSlant::Normal, 100);
+    selected.matched.metadata.design_metrics = None;
+    let identity = selected.matched.identity.clone();
+    let mut resolver = FontResolver::new(Box::new(MetricBackend {
+        candidates: vec![selected],
+        probes: Arc::clone(&probes),
+    }));
+
+    let first = resolver
+        .observe_exact_font(&identity, "Fixture")
+        .expect("native face");
+    let again = resolver
+        .observe_exact_font(&identity, "Fixture")
+        .expect("cached native face");
+    assert_eq!(first, again);
+    assert_eq!(
+        probes.load(Ordering::Relaxed),
+        1,
+        "do not reopen on a cache hit"
+    );
+
+    resolver.clear_caches();
+    let refreshed = resolver
+        .observe_exact_font(&identity, "Fixture")
+        .expect("fresh native face");
+    assert_eq!(refreshed.identity, identity);
+    assert_eq!(
+        probes.load(Ordering::Relaxed),
+        2,
+        "catalog refresh reopens the exact face"
+    );
+}
+
+#[test]
+fn an_exact_native_miss_does_not_survive_backend_replacement() {
+    let selected = candidate("Fixture", 400, FontSlant::Normal, 100);
+    let identity = selected.matched.identity.clone();
+    let mut resolver = FontResolver::new(Box::new(CandidateBackend {
+        candidates: Vec::new(),
+    }));
+    assert!(resolver.observe_exact_font(&identity, "Fixture").is_none());
+    resolver.replace_backend(Box::new(CandidateBackend {
+        candidates: vec![selected],
+    }));
+    assert_eq!(
+        resolver
+            .observe_exact_font(&identity, "Fixture")
+            .expect("new catalog face")
+            .identity,
+        identity
+    );
+}

--- a/crates/neomacs-renderer-wgpu/src/glyph_atlas/glyph_atlas_test.rs
+++ b/crates/neomacs-renderer-wgpu/src/glyph_atlas/glyph_atlas_test.rs
@@ -258,7 +258,7 @@ fn default_metrics_accept_explicit_default_font_size() {
 #[test]
 fn renderer_reopens_the_exact_physical_bitmap_strike_without_rescaling() {
     use neomacs_display_protocol::font::{
-        FontResolutionSource, FontSlantKind, ResolvedFont, ResolvedFontId, ResolvedFontIdentity,
+        FontSlantKind, ResolvedFont, ResolvedFontId, ResolvedFontIdentity,
     };
     use neomacs_display_protocol::geometry::DeviceScale;
     use neomacs_font_materializer::{FixedFontSpacing, FontMaterializer, FontOpenRequest};
@@ -293,7 +293,6 @@ fn renderer_reopens_the_exact_physical_bitmap_strike_without_rescaling() {
         descent_px: metrics.descent_px,
         space_advance_px: metrics.space_advance_px,
         glyph_advance: Default::default(),
-        source: FontResolutionSource::FacePrimary,
     };
 
     let mut cache = BitmapFontReplayCache::new().expect("renderer bitmap replay cache");
@@ -488,9 +487,7 @@ fn atlas_sampling_policy_selects_distinct_wgpu_bind_groups() {
 #[test]
 fn renderer_keeps_missing_ascii_on_primary_font() {
     use neomacs_display_protocol::face::Face;
-    use neomacs_display_protocol::font::{
-        FontResolutionSource, FontSlantKind, ResolvedFont, ResolvedFontId,
-    };
+    use neomacs_display_protocol::font::{FontSlantKind, ResolvedFont, ResolvedFontId};
     use neomacs_layout_engine::font::metrics::FontMetricsService;
 
     let requested_family = "Symbols Nerd Font Mono";
@@ -540,7 +537,6 @@ fn renderer_keeps_missing_ascii_on_primary_font() {
         descent_px: 2.0,
         space_advance_px: 5.0,
         glyph_advance: Default::default(),
-        source: FontResolutionSource::FacePrimary,
     };
     atlas.install_frame_fonts(
         &Default::default(),
@@ -615,9 +611,7 @@ fn renderer_uses_layouts_published_fixed_cell_advance() {
 #[tracing_test::traced_test]
 fn renderer_replays_named_instance_weight_on_the_exact_raw_face() {
     use cosmic_text::{Buffer, Metrics, Shaping};
-    use neomacs_display_protocol::font::{
-        FontResolutionSource, FontSlantKind, ResolvedFont, ResolvedFontId,
-    };
+    use neomacs_display_protocol::font::{FontSlantKind, ResolvedFont, ResolvedFontId};
     use neomacs_layout_engine::font::metrics::FontMetricsService;
 
     let Some(resolved) =
@@ -652,7 +646,6 @@ fn renderer_replays_named_instance_weight_on_the_exact_raw_face() {
         descent_px: 0.0,
         space_advance_px: 0.0,
         glyph_advance: Default::default(),
-        source: FontResolutionSource::FacePrimary,
     };
 
     let attrs = atlas
@@ -682,7 +675,7 @@ fn renderer_replays_named_instance_weight_on_the_exact_raw_face() {
 #[test]
 fn renderer_exact_attrs_reject_an_unopenable_identity() {
     use neomacs_display_protocol::font::{
-        FontResolutionSource, FontSlantKind, ResolvedFont, ResolvedFontId, ResolvedFontIdentity,
+        FontSlantKind, ResolvedFont, ResolvedFontId, ResolvedFontIdentity,
     };
 
     let Some(mut atlas) = try_test_atlas() else {
@@ -704,7 +697,6 @@ fn renderer_exact_attrs_reject_an_unopenable_identity() {
         descent_px: 0.0,
         space_advance_px: 0.0,
         glyph_advance: Default::default(),
-        source: FontResolutionSource::FacePrimary,
     };
 
     assert!(atlas.exact_attrs_for_resolved_font(&font).is_none());
@@ -713,7 +705,7 @@ fn renderer_exact_attrs_reject_an_unopenable_identity() {
 #[test]
 fn renderer_replays_the_same_decoded_woff_face_as_layout() {
     use neomacs_display_protocol::font::{
-        FontResolutionSource, FontSlantKind, ResolvedFont, ResolvedFontId, ResolvedFontIdentity,
+        FontSlantKind, ResolvedFont, ResolvedFontId, ResolvedFontIdentity,
     };
 
     let Some(mut atlas) = try_test_atlas() else {
@@ -737,7 +729,6 @@ fn renderer_replays_the_same_decoded_woff_face_as_layout() {
         descent_px: 4.0,
         space_advance_px: 8.0,
         glyph_advance: Default::default(),
-        source: FontResolutionSource::FacePrimary,
     };
     atlas.install_frame_fonts(
         &Default::default(),
@@ -766,8 +757,7 @@ fn renderer_replays_the_same_decoded_woff_face_as_layout() {
 fn renderer_replays_a_native_memory_asset_in_its_own_font_system() {
     use cosmic_text::{Buffer, Metrics, Shaping};
     use neomacs_display_protocol::font::{
-        FontBackendKind, FontMemoryAsset, FontResolutionSource, FontSlantKind, ResolvedFont,
-        ResolvedFontId,
+        FontBackendKind, FontMemoryAsset, FontSlantKind, ResolvedFont, ResolvedFontId,
     };
     use std::sync::Arc;
 
@@ -815,7 +805,6 @@ fn renderer_replays_a_native_memory_asset_in_its_own_font_system() {
         descent_px: 4.0,
         space_advance_px: 8.0,
         glyph_advance: Default::default(),
-        source: FontResolutionSource::FacePrimary,
     };
     atlas.install_frame_fonts(
         &Default::default(),
@@ -856,8 +845,7 @@ fn renderer_replays_a_native_memory_asset_in_its_own_font_system() {
 #[test]
 fn reused_resolved_font_id_invalidates_renderer_identity_caches() {
     use neomacs_display_protocol::font::{
-        FontResolutionSource, FontSlantKind, ResolvedFont, ResolvedFontId, ResolvedFontIdentity,
-        ResolvedFontTable,
+        FontSlantKind, ResolvedFont, ResolvedFontId, ResolvedFontIdentity, ResolvedFontTable,
     };
 
     let Some(mut atlas) = try_test_atlas() else {
@@ -881,7 +869,6 @@ fn reused_resolved_font_id_invalidates_renderer_identity_caches() {
             descent_px: 0.0,
             space_advance_px: 0.0,
             glyph_advance: Default::default(),
-            source: FontResolutionSource::FacePrimary,
         }
     };
     let mut first = ResolvedFontTable::new();

--- a/crates/neomacs-renderer-wgpu/src/glyph_atlas/mod.rs
+++ b/crates/neomacs-renderer-wgpu/src/glyph_atlas/mod.rs
@@ -225,7 +225,6 @@ fn frame_font_bindings_identity(
         font.descent_px.to_bits().hash(&mut hasher);
         font.space_advance_px.to_bits().hash(&mut hasher);
         font.glyph_advance.hash(&mut hasher);
-        font.source.hash(&mut hasher);
     }
 
     let mut char_faces: Vec<_> = char_fonts.iter().collect();
@@ -1349,10 +1348,10 @@ impl WgpuGlyphAtlas {
         char_fonts: &CharFontTable,
         shaped_clusters: &ShapedClusterTable,
     ) {
-        if fonts.iter().any(|(id, incoming)| {
+        if let Some((id, incoming)) = fonts.iter().find(|(id, incoming)| {
             self.frame_fonts
                 .get(id)
-                .is_some_and(|existing| existing != incoming)
+                .is_some_and(|existing| existing != *incoming)
         }) {
             // ResolvedFontId is stable within one layout resolver. If a
             // resolver restart reuses an id, every cache that hashed or mapped
@@ -1360,6 +1359,9 @@ impl WgpuGlyphAtlas {
             // before the replacement becomes visible.
             tracing::warn!(
                 target: "font_boundary",
+                id = id.0,
+                ?incoming,
+                existing = ?self.frame_fonts[id],
                 "resolved font id was reused for a different realized instance; clearing renderer font caches"
             );
             self.clear();

--- a/crates/neomacs-renderer-wgpu/src/renderer/glyphs.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/glyphs.rs
@@ -48,11 +48,19 @@ pub(super) struct RenderedGlyphGeometry {
     cell: Rect,
     /// The clipped bitmap rectangle actually submitted for rendering.
     bitmap: Rect,
+    /// Unclipped ink bounds from the atlas bearings and snapped glyph origin.
+    /// Kept separately from submitted geometry so clipping is allowed, but
+    /// placement outside the rasterizer's horizontal bounds is not overhang.
+    raster_bounds: Rect,
 }
 
 impl RenderedGlyphGeometry {
-    pub(super) const fn new(cell: Rect, bitmap: Rect) -> Self {
-        Self { cell, bitmap }
+    pub(super) const fn new(cell: Rect, bitmap: Rect, raster_bounds: Rect) -> Self {
+        Self {
+            cell,
+            bitmap,
+            raster_bounds,
+        }
     }
 
     #[cfg(test)]
@@ -68,6 +76,7 @@ impl RenderedGlyphGeometry {
     pub(super) fn translated_y(mut self, dy: f32) -> Self {
         self.cell.y += dy;
         self.bitmap.y += dy;
+        self.raster_bounds.y += dy;
         self
     }
 
@@ -217,10 +226,20 @@ fn overlap_is_expected_on_axis(
         // following (preceding) glyphs while the overhang still exceeds their
         // summed `pixel_width`, so a bearing legitimately reaches past a
         // narrower intervening cell; the cells need not touch. GNU bounds
-        // that reach by the font's own bearing (`gui_get_glyph_overhangs`),
-        // which this diagnostic cannot see; the substitute below is that the
-        // reaching ink must start inside its own cell.
-        OverlapAxis::Horizontal => {}
+        // that reach by the font's own bearing (`gui_get_glyph_overhangs`).
+        // Our atlas supplies raster bearings, including combining ink wholly
+        // outside its cell. Submitted ink may be clipped but cannot extend
+        // outside those bounds and still be explained by those bearings.
+        OverlapAxis::Horizontal => {
+            for geometry in [a.geometry, b.geometry] {
+                if geometry.bitmap.x < geometry.raster_bounds.x - CHAR_OVERLAP_MIN_AXIS
+                    || geometry.bitmap.right()
+                        > geometry.raster_bounds.right() + CHAR_OVERLAP_MIN_AXIS
+                {
+                    return false;
+                }
+            }
+        }
         // Vertical overlap belongs to adjacent rows and must straddle the
         // boundary they share.
         OverlapAxis::Vertical => {
@@ -238,19 +257,11 @@ fn overlap_is_expected_on_axis(
 
     // Overhang is derived from the two rectangles. Keeping it out of stored
     // state makes a bitmap/cell pair with contradictory overhang impossible.
-    // Horizontally, a bitmap that lies wholly outside its own cell is
-    // displaced, not overhanging: GNU's `rbearing > width` / `lbearing < 0`
-    // describe ink that starts in the cell and extends past it. Vertical
-    // overlap is already bound to the shared row boundary above.
-    let starts_in_own_cell = |bitmap: AxisSpan, cell: AxisSpan| {
-        axis == OverlapAxis::Vertical
-            || (bitmap.start < cell.end + CHAR_OVERLAP_MIN_AXIS
-                && bitmap.end > cell.start - CHAR_OVERLAP_MIN_AXIS)
-    };
-    let before_extends_after_cell =
-        before_bitmap.end > before_cell.end && starts_in_own_cell(before_bitmap, before_cell);
-    let after_extends_before_cell =
-        after_bitmap.start < after_cell.start && starts_in_own_cell(after_bitmap, after_cell);
+    // GNU's lbearing < 0 / rbearing > width do not require ink to intersect
+    // its advance cell. The atlas-bound check above distinguishes a bearing
+    // from a placement error without imposing that invalid restriction.
+    let before_extends_after_cell = before_bitmap.end > before_cell.end;
+    let after_extends_before_cell = after_bitmap.start < after_cell.start;
     if !before_extends_after_cell && !after_extends_before_cell {
         return false;
     }

--- a/crates/neomacs-renderer-wgpu/src/renderer/glyphs.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/glyphs.rs
@@ -195,28 +195,62 @@ fn overlap_is_expected_on_axis(
     let a_bitmap = axis.project(a.geometry.bitmap);
     let b_bitmap = axis.project(b.geometry.bitmap);
     let overlap = axis.project(overlap);
-    let (before_cell, before_bitmap, after_cell, after_bitmap) =
-        if a_cell.start.total_cmp(&b_cell.start).is_le() {
-            (a_cell, a_bitmap, b_cell, b_bitmap)
-        } else {
-            (b_cell, b_bitmap, a_cell, a_bitmap)
-        };
+    // Order by cell start, then by cell end, so a zero-width cell sorts
+    // before the cell that begins where it sits regardless of argument order.
+    let (before_cell, before_bitmap, after_cell, after_bitmap) = if a_cell
+        .start
+        .total_cmp(&b_cell.start)
+        .then(a_cell.end.total_cmp(&b_cell.end))
+        .is_le()
+    {
+        (a_cell, a_bitmap, b_cell, b_bitmap)
+    } else {
+        (b_cell, b_bitmap, a_cell, a_bitmap)
+    };
 
-    if !approx_eq(before_cell.end, after_cell.start, CHAR_OVERLAP_MIN_AXIS) {
+    // Advance cells that intersect are a layout defect no bearing explains.
+    if before_cell.end > after_cell.start + CHAR_OVERLAP_MIN_AXIS {
         return false;
     }
-    let shared_cell_boundary = before_cell.end;
-    if axis == OverlapAxis::Vertical
-        && (overlap.start > shared_cell_boundary + CHAR_OVERLAP_MIN_AXIS
-            || overlap.end < shared_cell_boundary - CHAR_OVERLAP_MIN_AXIS)
-    {
-        return false;
+    match axis {
+        // GNU xdisp.c `right_overwritten` / `left_overwriting` walk the
+        // following (preceding) glyphs while the overhang still exceeds their
+        // summed `pixel_width`, so a bearing legitimately reaches past a
+        // narrower intervening cell; the cells need not touch. GNU bounds
+        // that reach by the font's own bearing (`gui_get_glyph_overhangs`),
+        // which this diagnostic cannot see; the substitute below is that the
+        // reaching ink must start inside its own cell.
+        OverlapAxis::Horizontal => {}
+        // Vertical overlap belongs to adjacent rows and must straddle the
+        // boundary they share.
+        OverlapAxis::Vertical => {
+            if !approx_eq(before_cell.end, after_cell.start, CHAR_OVERLAP_MIN_AXIS) {
+                return false;
+            }
+            let shared_cell_boundary = before_cell.end;
+            if overlap.start > shared_cell_boundary + CHAR_OVERLAP_MIN_AXIS
+                || overlap.end < shared_cell_boundary - CHAR_OVERLAP_MIN_AXIS
+            {
+                return false;
+            }
+        }
     }
 
     // Overhang is derived from the two rectangles. Keeping it out of stored
     // state makes a bitmap/cell pair with contradictory overhang impossible.
-    let before_extends_after_cell = before_bitmap.end > before_cell.end;
-    let after_extends_before_cell = after_bitmap.start < after_cell.start;
+    // Horizontally, a bitmap that lies wholly outside its own cell is
+    // displaced, not overhanging: GNU's `rbearing > width` / `lbearing < 0`
+    // describe ink that starts in the cell and extends past it. Vertical
+    // overlap is already bound to the shared row boundary above.
+    let starts_in_own_cell = |bitmap: AxisSpan, cell: AxisSpan| {
+        axis == OverlapAxis::Vertical
+            || (bitmap.start < cell.end + CHAR_OVERLAP_MIN_AXIS
+                && bitmap.end > cell.start - CHAR_OVERLAP_MIN_AXIS)
+    };
+    let before_extends_after_cell =
+        before_bitmap.end > before_cell.end && starts_in_own_cell(before_bitmap, before_cell);
+    let after_extends_before_cell =
+        after_bitmap.start < after_cell.start && starts_in_own_cell(after_bitmap, after_cell);
     if !before_extends_after_cell && !after_extends_before_cell {
         return false;
     }

--- a/crates/neomacs-renderer-wgpu/src/renderer/glyphs.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/glyphs.rs
@@ -50,7 +50,7 @@ pub(super) struct RenderedGlyphGeometry {
     bitmap: Rect,
     /// Unclipped ink bounds from the atlas bearings and snapped glyph origin.
     /// Kept separately from submitted geometry so clipping is allowed, but
-    /// placement outside the rasterizer's horizontal bounds is not overhang.
+    /// placement outside the rasterizer's bounds is not overhang.
     raster_bounds: Rect,
 }
 
@@ -78,6 +78,13 @@ impl RenderedGlyphGeometry {
         self.bitmap.y += dy;
         self.raster_bounds.y += dy;
         self
+    }
+
+    fn submission_matches_raster(self) -> bool {
+        self.bitmap.x >= self.raster_bounds.x - CHAR_OVERLAP_MIN_AXIS
+            && self.bitmap.y >= self.raster_bounds.y - CHAR_OVERLAP_MIN_AXIS
+            && self.bitmap.right() <= self.raster_bounds.right() + CHAR_OVERLAP_MIN_AXIS
+            && self.bitmap.bottom() <= self.raster_bounds.bottom() + CHAR_OVERLAP_MIN_AXIS
     }
 
     fn overhang(self) -> GlyphOverhang {
@@ -169,6 +176,12 @@ fn classify_char_overlap(
     b: &RenderedCharBounds,
     overlap: Rect,
 ) -> CharOverlapClassification {
+    // Bearings explain only subsets of the rasterizer's ink. Validate both
+    // coordinates before either axis can explain an overlap: projecting onto
+    // the other axis must not hide an independently invalid placement.
+    if !a.geometry.submission_matches_raster() || !b.geometry.submission_matches_raster() {
+        return CharOverlapClassification::Unexpected;
+    }
     if overlap_is_expected_on_axis(a, b, overlap, OverlapAxis::Horizontal) {
         CharOverlapClassification::Expected(ExpectedCharOverlap::HorizontalOverhang)
     } else if overlap_is_expected_on_axis(a, b, overlap, OverlapAxis::Vertical) {
@@ -228,18 +241,9 @@ fn overlap_is_expected_on_axis(
         // narrower intervening cell; the cells need not touch. GNU bounds
         // that reach by the font's own bearing (`gui_get_glyph_overhangs`).
         // Our atlas supplies raster bearings, including combining ink wholly
-        // outside its cell. Submitted ink may be clipped but cannot extend
-        // outside those bounds and still be explained by those bearings.
-        OverlapAxis::Horizontal => {
-            for geometry in [a.geometry, b.geometry] {
-                if geometry.bitmap.x < geometry.raster_bounds.x - CHAR_OVERLAP_MIN_AXIS
-                    || geometry.bitmap.right()
-                        > geometry.raster_bounds.right() + CHAR_OVERLAP_MIN_AXIS
-                {
-                    return false;
-                }
-            }
-        }
+        // outside its cell. The caller has validated submitted ink against
+        // those bounds independently of the overlap axis.
+        OverlapAxis::Horizontal => {}
         // Vertical overlap belongs to adjacent rows and must straddle the
         // boundary they share.
         OverlapAxis::Vertical => {

--- a/crates/neomacs-renderer-wgpu/src/renderer/glyphs.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/glyphs.rs
@@ -222,7 +222,7 @@ fn overlap_is_expected_on_axis(
         return false;
     }
     match axis {
-        // GNU xdisp.c `right_overwritten` / `left_overwriting` walk the
+        // GNU xdisp.c `right_overwritten` / `left_overwritten` walk the
         // following (preceding) glyphs while the overhang still exceeds their
         // summed `pixel_width`, so a bearing legitimately reaches past a
         // narrower intervening cell; the cells need not touch. GNU bounds

--- a/crates/neomacs-renderer-wgpu/src/renderer/glyphs_test.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/glyphs_test.rs
@@ -819,6 +819,99 @@ fn char_overlap_classifies_font_overhang_separately() {
 }
 
 #[test]
+fn char_overlap_classifies_overhang_past_a_narrower_intervening_cell_separately() {
+    // A Nerd Font icon keeps the family's 9 px advance but draws 15 px wide,
+    // so its right overhang crosses the 4 px cell after it and lands in the
+    // next one. GNU `right_overwritten` walks following glyphs while the
+    // overhang still exceeds their summed widths: the reach is one glyph's
+    // bearing, not a collision between two cells.
+    let mut icon = with_bitmap(
+        char_bounds("\u{f48a}", 49.0, 1188.0, 9.0, 20.0),
+        Rect::new(49.0, 1192.5, 15.0, 10.0),
+    );
+    icon.slot_id.col = 6;
+    let mut r = with_bitmap(
+        char_bounds("R", 62.0, 1188.0, 9.0, 20.0),
+        Rect::new(63.0, 1192.0, 7.5, 11.0),
+    );
+    r.slot_id.col = 8;
+
+    let overlap = char_overlap(&icon, &r).expect("overhang overlap");
+    assert_eq!(overlap.bounds, Rect::new(63.0, 1192.5, 1.0, 10.0));
+    assert_eq!(
+        overlap.classification,
+        CharOverlapClassification::Expected(ExpectedCharOverlap::HorizontalOverhang)
+    );
+}
+
+#[test]
+fn char_overlap_keeps_a_bitmap_displaced_from_its_own_cell_a_collision() {
+    // Ink that never touches its own advance cell is a placement defect (an
+    // x-offset, scale or slot bug), whatever it lands on. GNU overhang is
+    // `rbearing > width` / `lbearing < 0`: ink that starts in the cell.
+    let a = with_bitmap(
+        char_bounds("A", 0.0, 0.0, 9.0, 12.0),
+        Rect::new(0.5, 0.0, 8.0, 12.0),
+    );
+    let mut displaced = with_bitmap(
+        char_bounds("B", 18.0, 0.0, 9.0, 12.0),
+        Rect::new(1.0, 0.0, 7.0, 12.0),
+    );
+    displaced.slot_id.col = 2;
+
+    let overlap = char_overlap(&a, &displaced).expect("bitmap collision");
+    assert_eq!(
+        overlap.classification,
+        CharOverlapClassification::Unexpected
+    );
+}
+
+#[test]
+fn char_overlap_classifies_ink_starting_at_its_cell_edge_as_overhang() {
+    // GNU `lbearing >= width` (ink wholly right of the advance, e.g. a
+    // zero-width combining mark's cell) is still a bearing; the own-cell rule
+    // tolerates the shared threshold rather than demanding ink strictly inside.
+    let mut mark = with_bitmap(
+        char_bounds("\u{0301}", 9.0, 0.0, 0.0, 12.0),
+        Rect::new(9.0, 0.0, 4.0, 12.0),
+    );
+    mark.slot_id.col = 1;
+    let mut next = char_bounds("a", 9.0, 0.0, 9.0, 12.0);
+    next.slot_id.col = 2;
+    // Cells: mark 9..9 (zero width), a 9..18 — they touch, do not intersect.
+    for (a, b) in [(&mark, &next), (&next, &mark)] {
+        let overlap = char_overlap(a, b).expect("mark ink over the next glyph");
+        assert_eq!(
+            overlap.classification,
+            CharOverlapClassification::Expected(ExpectedCharOverlap::HorizontalOverhang),
+            "classification must not depend on argument order"
+        );
+    }
+}
+
+#[test]
+fn char_overlap_keeps_overlapping_cells_a_collision() {
+    // Two advance cells that intersect are a layout defect regardless of how
+    // far either bitmap reaches: overhang never explains the cells themselves.
+    let mut icon = with_bitmap(
+        char_bounds("\u{f48a}", 49.0, 1188.0, 9.0, 20.0),
+        Rect::new(49.0, 1192.5, 15.0, 10.0),
+    );
+    icon.slot_id.col = 6;
+    let mut r = with_bitmap(
+        char_bounds("R", 55.0, 1188.0, 9.0, 20.0),
+        Rect::new(56.0, 1192.0, 7.5, 11.0),
+    );
+    r.slot_id.col = 7;
+
+    let overlap = char_overlap(&icon, &r).expect("bitmap collision");
+    assert_eq!(
+        overlap.classification,
+        CharOverlapClassification::Unexpected
+    );
+}
+
+#[test]
 fn char_overlap_horizontal_overhang_requires_one_logical_row() {
     let first = with_bitmap(
         char_bounds("f", 0.0, 0.0, 9.0, 12.0),

--- a/crates/neomacs-renderer-wgpu/src/renderer/glyphs_test.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/glyphs_test.rs
@@ -585,6 +585,7 @@ fn vertical_bar_cursor_aligned_to_its_glyph_cell_is_not_a_mismatch() {
         geometry: RenderedGlyphGeometry::new(
             Rect::new(233.0, 123.0, 13.0, 18.0),
             Rect::new(233.5, 125.5, 12.5, 13.0),
+            Rect::new(233.5, 125.5, 12.5, 13.0),
         ),
     }];
 
@@ -769,12 +770,13 @@ fn char_bounds(label: &str, x: f32, y: f32, width: f32, height: f32) -> Rendered
         geometry: RenderedGlyphGeometry::new(
             Rect::new(x, y, width, height),
             Rect::new(x, y, width, height),
+            Rect::new(x, y, width, height),
         ),
     }
 }
 
 fn with_bitmap(mut bounds: RenderedCharBounds, bitmap: Rect) -> RenderedCharBounds {
-    bounds.geometry = RenderedGlyphGeometry::new(bounds.geometry.cell, bitmap);
+    bounds.geometry = RenderedGlyphGeometry::new(bounds.geometry.cell, bitmap, bitmap);
     bounds
 }
 
@@ -845,18 +847,74 @@ fn char_overlap_classifies_overhang_past_a_narrower_intervening_cell_separately(
 }
 
 #[test]
+fn char_overlap_accepts_combining_ink_wholly_left_of_its_advance() {
+    // JetBrainsMono Nerd Font Regular, U+0338 at 15 px: advance 0,
+    // outline x=-7.35..-1.65. GNU lbearing < 0 permits all the ink to
+    // lie left of the cell. Baseline y=15; preceding R advances 9 px.
+    let r = with_bitmap(
+        char_bounds("R", 0.0, 0.0, 9.0, 20.0),
+        Rect::new(1.395, 4.05, 6.78, 10.95),
+    );
+    let mut mark = with_bitmap(
+        char_bounds("\u{0338}", 9.0, 0.0, 0.0, 20.0),
+        Rect::new(1.65, 5.1, 5.7, 11.55),
+    );
+    mark.slot_id.col = 1;
+    for (a, b) in [(&r, &mark), (&mark, &r)] {
+        assert_eq!(
+            char_overlap(a, b).unwrap().classification,
+            CharOverlapClassification::Expected(ExpectedCharOverlap::HorizontalOverhang),
+        );
+    }
+}
+
+#[test]
+fn char_overlap_rejects_placement_outside_raster_bounds_even_inside_own_cell() {
+    let a = char_bounds("A", 0.0, 0.0, 9.0, 12.0);
+    let mut b = with_bitmap(
+        char_bounds("B", 9.0, 0.0, 9.0, 12.0),
+        Rect::new(9.0, 0.0, 8.0, 12.0),
+    );
+    b.slot_id.col = 1;
+    // A downstream placement error moves B left of its rasterizer bounds.
+    // Most of B's ink still lies inside its advance cell.
+    b.geometry.bitmap.x -= 2.0;
+    assert_eq!(
+        char_overlap(&a, &b).unwrap().classification,
+        CharOverlapClassification::Unexpected,
+    );
+}
+
+#[test]
+fn char_overlap_accepts_overhang_clipped_away_from_its_own_cell() {
+    let mut icon = with_bitmap(
+        char_bounds("icon", 0.0, 0.0, 9.0, 12.0),
+        Rect::new(0.0, 0.0, 24.0, 12.0),
+    );
+    // Only the portion of the original raster to the right of x=10 survives.
+    icon.geometry.bitmap = Rect::new(10.0, 0.0, 14.0, 12.0);
+    let mut next = char_bounds("R", 13.0, 0.0, 9.0, 12.0);
+    next.slot_id.col = 2;
+    assert_eq!(
+        char_overlap(&icon, &next).unwrap().classification,
+        CharOverlapClassification::Expected(ExpectedCharOverlap::HorizontalOverhang),
+    );
+}
+
+#[test]
 fn char_overlap_keeps_a_bitmap_displaced_from_its_own_cell_a_collision() {
-    // Ink that never touches its own advance cell is a placement defect (an
-    // x-offset, scale or slot bug), whatever it lands on. GNU overhang is
-    // `rbearing > width` / `lbearing < 0`: ink that starts in the cell.
+    // The font's raster belongs at x=19, but the submitted bitmap is shifted
+    // to x=1. It is the mismatch with the raster bearings, not separation
+    // from the advance cell, that proves a placement defect.
     let a = with_bitmap(
         char_bounds("A", 0.0, 0.0, 9.0, 12.0),
         Rect::new(0.5, 0.0, 8.0, 12.0),
     );
     let mut displaced = with_bitmap(
         char_bounds("B", 18.0, 0.0, 9.0, 12.0),
-        Rect::new(1.0, 0.0, 7.0, 12.0),
+        Rect::new(19.0, 0.0, 7.0, 12.0),
     );
+    displaced.geometry.bitmap.x = 1.0;
     displaced.slot_id.col = 2;
 
     let overlap = char_overlap(&a, &displaced).expect("bitmap collision");
@@ -868,9 +926,8 @@ fn char_overlap_keeps_a_bitmap_displaced_from_its_own_cell_a_collision() {
 
 #[test]
 fn char_overlap_classifies_ink_starting_at_its_cell_edge_as_overhang() {
-    // GNU `lbearing >= width` (ink wholly right of the advance, e.g. a
-    // zero-width combining mark's cell) is still a bearing; the own-cell rule
-    // tolerates the shared threshold rather than demanding ink strictly inside.
+    // A zero-width glyph can draw at or beyond its cell edge; GNU's bearing
+    // conditions do not require ink strictly inside the advance cell.
     let mut mark = with_bitmap(
         char_bounds("\u{0301}", 9.0, 0.0, 0.0, 12.0),
         Rect::new(9.0, 0.0, 4.0, 12.0),

--- a/crates/neomacs-renderer-wgpu/src/renderer/glyphs_test.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/glyphs_test.rs
@@ -1027,6 +1027,30 @@ fn char_overlap_classifies_adjacent_vertical_overhang_separately() {
     );
 }
 
+#[test]
+fn char_overlap_vertical_overhang_cannot_hide_horizontal_raster_displacement() {
+    let upper = with_bitmap(
+        char_bounds("upper", 0.0, 0.0, 10.0, 10.0),
+        Rect::new(0.0, 0.0, 10.0, 12.0),
+    );
+    let mut lower = with_bitmap(
+        char_bounds("lower", 0.0, 10.0, 10.0, 10.0),
+        Rect::new(0.0, 9.0, 10.0, 11.0),
+    );
+    lower.slot_id.row = upper.slot_id.row + 1;
+    lower.geometry.bitmap.x -= 4.0;
+
+    for (a, b) in [(&upper, &lower), (&lower, &upper)] {
+        assert_eq!(
+            char_overlap(a, b)
+                .expect("displaced raster overlap")
+                .classification,
+            CharOverlapClassification::Unexpected,
+            "a valid vertical bearing cannot explain horizontal placement outside the raster"
+        );
+    }
+}
+
 fn adjacent_vertical_overhang_bounds() -> (RenderedCharBounds, RenderedCharBounds) {
     let mut upper = with_bitmap(
         char_bounds("│", 861.0, 76.0, 9.0, 19.0),

--- a/crates/neomacs-renderer-wgpu/src/renderer/layer_text.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/layer_text.rs
@@ -360,6 +360,7 @@ impl row_reuse::RowTessellator for LiveRowTessellator<'_, '_> {
                         let glyph_y = (y_int as f32 - metrics.bearing_y) / sf;
                         let glyph_w = content_rect.width() as f32 / sf;
                         let glyph_h = content_rect.height() as f32 / sf;
+                        let raster_bounds = Rect::new(glyph_x, glyph_y, glyph_w, glyph_h);
 
                         let tex_u_min = uv.min()[0];
                         let tex_u_max = uv.max()[0];
@@ -449,6 +450,7 @@ impl row_reuse::RowTessellator for LiveRowTessellator<'_, '_> {
                                 geometry: RenderedGlyphGeometry::new(
                                     Rect::new(*x, *y, *width, *height),
                                     Rect::new(glyph_x, glyph_y, glyph_w, glyph_h),
+                                    raster_bounds,
                                 ),
                             });
                         }

--- a/crates/neomacs-renderer-wgpu/src/renderer/row_reuse_test.rs
+++ b/crates/neomacs-renderer-wgpu/src/renderer/row_reuse_test.rs
@@ -268,6 +268,7 @@ impl RowTessellator for FakeTessellator<'_> {
                 geometry: RenderedGlyphGeometry::new(
                     Rect::new(*x, *y, *width, *height),
                     Rect::new(*x, *y, 8.0, 12.0),
+                    Rect::new(*x, *y, 8.0, 12.0),
                 ),
             });
         }

--- a/crates/neovm-core/src/emacs_core/display/font/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/font/tests/mod.rs
@@ -1703,8 +1703,8 @@ fn query_font_uses_opened_object_metrics_without_a_font_file() {
 #[test]
 fn opened_font_retains_exact_backend_identity_and_variations() {
     use neomacs_display_protocol::font::{
-        FontFileAsset, FontOutlineAsset, FontReplay, FontResolutionSource, FontSlantKind,
-        FontVariationCoord, ResolvedFont, ResolvedFontId, ResolvedFontIdentity,
+        FontFileAsset, FontOutlineAsset, FontReplay, FontSlantKind, FontVariationCoord,
+        ResolvedFont, ResolvedFontId, ResolvedFontIdentity,
     };
 
     crate::test_utils::init_test_tracing();
@@ -1744,7 +1744,6 @@ fn opened_font_retains_exact_backend_identity_and_variations() {
                 descent_px: 6.0,
                 space_advance_px: 9.0,
                 glyph_advance: Default::default(),
-                source: FontResolutionSource::FacePrimary,
             },
             foundry: Some(LispString::from_utf8("TEST")),
             slant: FontSlant::Normal,

--- a/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
@@ -2251,7 +2251,7 @@ pub(crate) fn test_resolved_opened_font(
 ) -> ResolvedOpenedFont {
     use neomacs_display_protocol::font::{
         FontBackendKind, FontFileAsset, FontMemoryAsset, FontOutlineAsset, FontReplay,
-        FontResolutionSource, FontSlantKind, ResolvedFont, ResolvedFontId, ResolvedFontIdentity,
+        FontSlantKind, ResolvedFont, ResolvedFontId, ResolvedFontIdentity,
     };
     use std::sync::Arc;
 
@@ -2309,7 +2309,6 @@ pub(crate) fn test_resolved_opened_font(
             descent_px: metrics.descent as f32,
             space_advance_px: metrics.space_width as f32,
             glyph_advance: Default::default(),
-            source: FontResolutionSource::FacePrimary,
         },
         foundry: foundry.map(crate::heap_types::LispString::from_utf8),
         slant,


### PR DESCRIPTION
## Recovery of #356

This preserves @tag-und-nacht's original contribution from #356, rebased onto current `main`, together with four tested follow-up commits.

I made a sequencing mistake while handling the original PR: I switched checkouts while a push using `HEAD` was still running its pre-push hook. The fork branch ended up at `main`, and GitHub closed the empty PR. Closing it removed maintainer push access, and GitHub would not reopen it without new commits on that branch. This replacement preserves the work; no changes were lost.

## Changes

- Publish one canonical resolved-font record per identity, replay, and pixel size within a catalog generation. A typed interner owns IDs and key fields; request provenance stays on layout handles.
- Recover native metrics by exact identity without repeating style selection. Family names are hints, including synthetic pinned names; cache hits and misses until catalog invalidation.
- Recognize legitimate glyph overhang across narrower intervening cells, while rejecting submitted bitmap displacement on either axis before classifying overhang.
- Add failing-first regressions after studying GNU `font_open_entity`, `font_clear_cache`, `macfont` metrics, and `xdisp` overhang traversal.

## Verification

- `cargo fmt --all --check` and `cargo check --workspace --all-targets`: passed.
- Fresh development binary build: passed.
- Focused font metrics/resolver tests: 125 passed.
- Full layout/renderer/display-protocol tests: 3,727 passed, 24 failed, 3 skipped. The 24 failures also occur on unchanged `main`; no new failures remain.
- Real Linux/X11 GUI smoke: passed. Three font-selection oracle tests still fail, but their GNU and Neomacs result files are byte-for-byte identical to unchanged-main results.
- Native macOS and Windows runtime validation was not available here. No tests or expectations were weakened.

Final review found no confirmed specification defects or introduced hard standards violations. Retention of retired in-memory font bytes is inherited from `main` and remains a separate follow-up.
