### PR TITLE
fix(input): let a macOS Option chord reach Emacs as the key the user pressed

### DIFF
--- a/crates/neomacs-display-runtime/src/render_thread/frame_windows.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/frame_windows.rs
@@ -55,6 +55,12 @@ pub(crate) struct GuiFrameNativeWindowState {
 pub(super) struct NativeTextInputPolicy {
     pub(super) ime_allowed_on_create: bool,
     pub(super) initial_cursor_area: ImeCursorArea,
+    /// Whether the Option key delivers a command modifier instead of the
+    /// layout's composed character.  This is GNU's `ns-alternate-modifier`,
+    /// whose default is `meta` (`src/nsterm.m`), so Emacs reads an Option
+    /// chord from `charactersIgnoringModifiers` and never from the composed
+    /// `characters`.
+    pub(super) option_key_is_meta: bool,
 }
 
 impl NativeTextInputPolicy {
@@ -67,10 +73,12 @@ impl NativeTextInputPolicy {
                 width: 1,
                 height: 1,
             },
+            option_key_is_meta: true,
         }
     }
 
     pub(super) fn apply_to_window(self, window: &Window) {
+        apply_option_key_policy(window, self.option_key_is_meta);
         window.set_ime_allowed(self.ime_allowed_on_create);
         window.set_ime_cursor_area(
             PhysicalPosition::new(
@@ -84,6 +92,42 @@ impl NativeTextInputPolicy {
         );
     }
 }
+
+/// Make Option a command modifier the way GNU's `ns-alternate-modifier`
+/// default does.
+///
+/// macOS composes an Option chord in the window server, so AppKit hands over
+/// the composed character: Option+X arrives as `≈`, Option+Shift+, as `¯`.
+/// GNU never reads that.  `keyDown:` takes its code from
+/// `[theEvent charactersIgnoringModifiers]` (`src/nsterm.m`), which applies
+/// Shift but not Option, and re-derives it with `ns_get_shifted_character` --
+/// `UCKeyTranslate` with only the shift-like modifier bits -- when a
+/// control-like modifier is also down.  With the default
+/// `ns-alternate-modifier` of `meta` those two agree, because Option is then
+/// never shift-like, so `nil_or_none` is false and only `shiftKey` is passed.
+///
+/// `OptionAsAlt::Both` is winit's name for exactly that: it rewrites the
+/// `NSEvent` so `characters` becomes `charactersIgnoringModifiers` whenever
+/// Option is down and Control and Command are not.  It has to happen here,
+/// at the window, rather than while translating a `KeyEvent`, because winit
+/// applies it before `interpretKeyEvents` -- so an Option chord that lands on
+/// a dead key (Option+E on the US layout) stops opening a preedit and starts
+/// arriving as a key event at all.
+#[cfg(target_os = "macos")]
+fn apply_option_key_policy(window: &Window, option_key_is_meta: bool) {
+    use winit::platform::macos::{OptionAsAlt, WindowExtMacOS};
+
+    window.set_option_as_alt(if option_key_is_meta {
+        OptionAsAlt::Both
+    } else {
+        OptionAsAlt::None
+    });
+}
+
+/// No other window system composes an Option/Alt chord into a different
+/// character, so Alt already reaches Emacs as a bare modifier there.
+#[cfg(not(target_os = "macos"))]
+fn apply_option_key_policy(_window: &Window, _option_key_is_meta: bool) {}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) struct ActivePresentationTransition {

--- a/crates/neomacs-display-runtime/src/render_thread/frame_windows_test.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/frame_windows_test.rs
@@ -40,6 +40,18 @@ fn gui_text_input_policy_enables_native_ime_on_window_creation() {
     );
 }
 
+#[test]
+fn gui_text_input_policy_makes_the_option_key_a_command_modifier() {
+    let policy = NativeTextInputPolicy::for_gui_frame();
+
+    assert!(
+        policy.option_key_is_meta,
+        "GNU's ns-alternate-modifier defaults to meta, so an Option chord must \
+         reach Emacs as the layout's shifted base key (M-<), never as the \
+         character macOS composes from it (M-¯)"
+    );
+}
+
 #[cfg(feature = "neo-term")]
 #[test]
 fn terminal_expansion_replacement_is_atomic_and_invalidates_the_scene() {

--- a/crates/neomacs-display-runtime/src/render_thread/window_events.rs
+++ b/crates/neomacs-display-runtime/src/render_thread/window_events.rs
@@ -8,10 +8,6 @@ use crate::thread_comm::InputEvent;
 use winit::event::{ElementState, KeyEvent, WindowEvent};
 use winit::event_loop::ActiveEventLoop;
 use winit::keyboard::{Key, NamedKey};
-// `key_without_modifiers` (the layout base key, before macOS Option composition
-// / shift): the winit equivalent of GNU's `charactersIgnoringModifiers`.
-// Available on macOS, X11, and Wayland — the platforms neomacs targets.
-use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
 use winit::window::WindowId;
 
 impl RenderApp {
@@ -245,12 +241,6 @@ impl RenderApp {
             }
 
             WindowEvent::KeyboardInput { event, .. } => {
-                // macOS composes Option+key at the OS level (Option+x -> ≈), so
-                // winit's `logical_key` is the composed character. When a
-                // command modifier is active we want the layout base key
-                // (M-x, not M-≈), mirroring GNU's `charactersIgnoringModifiers`.
-                // Capture it before destructuring the event.
-                let key_without_mods = event.key_without_modifiers();
                 let KeyEvent {
                     logical_key,
                     state,
@@ -387,25 +377,14 @@ impl RenderApp {
                         }
                     }
                     if !handled_via_text {
-                        // With a command modifier (Ctrl/Meta/Super) and no
-                        // shift, translate the layout BASE key so a macOS
-                        // Option-composed character (Option+x -> ≈) resolves to
-                        // M-x, not M-≈ (issue: no M-x on macOS). GNU does the
-                        // same via `charactersIgnoringModifiers`. Off macOS and
-                        // for un-composed keys `key_without_modifiers` equals
-                        // `logical_key`, so this is a no-op there; the
-                        // shift+command case keeps the composed key (winit's
-                        // base strips shift too, which M-x itself never needs).
-                        let command_like = self.modifiers
-                            & (NEOMACS_CTRL_MASK | NEOMACS_META_MASK | NEOMACS_SUPER_MASK)
-                            != 0;
-                        let effective_key =
-                            if command_like && self.modifiers & NEOMACS_SHIFT_MASK == 0 {
-                                &key_without_mods
-                            } else {
-                                &logical_key
-                            };
-                        let mut keysym = Self::translate_key(effective_key);
+                        // `logical_key` is the layout's key with Shift applied
+                        // and no command modifier folded in, which is what GNU
+                        // reads for a command chord. macOS is the one window
+                        // system that would compose an Option chord into
+                        // another character first, and the frame window asks
+                        // it not to (`apply_option_key_policy`), so no
+                        // per-event substitution is needed here.
+                        let mut keysym = Self::translate_key(&logical_key);
                         if keysym == 0 && self.modifiers != 0 {
                             use winit::keyboard::KeyCode;
                             use winit::keyboard::PhysicalKey;

--- a/crates/neovm-core/src/keyboard_test.rs
+++ b/crates/neovm-core/src/keyboard_test.rs
@@ -1582,6 +1582,23 @@ fn keysym_meta_shift_letter_consumes_shift_into_uppercase() {
 }
 
 #[test]
+fn keysym_meta_shift_punctuation_consumes_shift_into_the_shifted_character() {
+    crate::test_utils::init_test_tracing();
+    // The frontend reports the shifted character together with the Shift bit
+    // that produced it. GNU folds that Shift into the character for every
+    // ordinary chord, so `beginning-of-buffer` is reached by `M-<`, never by
+    // an `M-S-<` that no keymap binds.
+    let event = keysym_to_key_event('<' as u32, RENDER_META_MASK | RENDER_SHIFT_MASK).unwrap();
+    assert_eq!(event.key, Key::Char('<'));
+    assert!(event.modifiers.meta);
+    assert!(!event.modifiers.shift);
+    assert_eq!(event.to_description(), "M-<");
+
+    let event = keysym_to_key_event('>' as u32, RENDER_META_MASK | RENDER_SHIFT_MASK).unwrap();
+    assert_eq!(event.to_description(), "M->");
+}
+
+#[test]
 fn keysym_ctrl_uppercase_without_shift_treats_caps_lock_as_unshifted() {
     crate::test_utils::init_test_tracing();
     let event = keysym_to_key_event('F' as u32, RENDER_CTRL_MASK).unwrap();


### PR DESCRIPTION
Fixes #357.

## The bug

`M-<` printed `M-¯ is undefined` and `M->` printed `M-˘ is undefined` on macOS, so `beginning-of-buffer` and `end-of-buffer` were unreachable from the keyboard.

macOS composes an Option chord in the window server, so AppKit hands the application the *composed* character. winit reports that as `KeyEvent::logical_key` whenever Option is held and neither Control nor Command is (winit-0.30.13 `macos/event.rs:135`). The reporter's trace shows it exactly:

```
ModifiersChanged: shift=true ctrl=false alt=true super=false
KeyboardInput: logical_key=Character("¯") physical_key=Code(Comma) mods=5
msg = M-¯ is undefined
```

`key_without_modifiers()` — the value the old workaround substituted — is no help on macOS: it is `get_modifierless_char`, i.e. `UCKeyTranslate` with `modifiers = 0`, so it strips Shift as well as Option. That is precisely why the workaround had to exclude Shift, and why every Option+Shift chord stayed broken.

## What GNU does

`keyDown:` takes its code from `[theEvent charactersIgnoringModifiers]` (`src/nsterm.m`), which applies Shift but not Option, and re-derives it with `ns_get_shifted_character` — `UCKeyTranslate` with only the shift-like modifier bits — when a control-like modifier is also down. Under the default `ns-alternate-modifier` of `meta` (`src/nsterm.m:11571`) Option is never shift-like, so `nil_or_none` is false, only `shiftKey` is passed, and the two agree: the value GNU binds against is plain `charactersIgnoringModifiers`.

## The fix

Ask the window for the same thing at creation time, through `NativeTextInputPolicy` — the seam both frame-window creation sites already use. winit's `OptionAsAlt::Both` rewrites the `NSEvent` so `characters` becomes `charactersIgnoringModifiers` under exactly the guard `alt && !control && !super` (`macos/view.rs:1109-1141`), which is GNU's rule.

This belongs at the window rather than in `KeyEvent` translation, because winit applies the rewrite **before** `interpretKeyEvents` (`macos/view.rs:458` vs `:468`). That reaches a second class of chord a translation-time fix structurally could not: on the US layout `Option+E/I/N/U/\`` are dead keys, so AppKit turned them into marked text and winit queued *no* `KeyboardInput` at all — `M-e` (forward-sentence), `M-i` (tab-to-tab-stop) and `M-u` (upcase-word) were swallowed entirely, and the live preedit then suppressed the following keystroke too.

Before → after on a US layout:

| chord | before | after |
| --- | --- | --- |
| `M-<` | `M-¯ is undefined` | `beginning-of-buffer` |
| `M->` | `M-˘ is undefined` | `end-of-buffer` |
| `M-u` | no event at all | `upcase-word` |

and likewise every other Option+Shift chord: `M-{` `M-}` `M-|` `M-:` `M-?` `M-"` `M-~` `M-_` `M-(` `M-)`.

The second commit retires the `key_without_modifiers()` substitution. Its only premise was the macOS composition, which no longer happens; it was never load-bearing elsewhere (X11/Wayland put AltGr on `Mod5`/`ISO_Level3_Shift`, which winit does not map to `alt_key`; winit's Windows backend already clears Control and Alt for an AltGr chord).

## Tradeoff

Option stops typing composed characters (`Option+E` then `A` gives `a`, not `á`). That is what `ns-alternate-modifier` = meta means upstream, so it is a parity choice — but neomacs does not implement `ns-alternate-modifier` yet, so a user who wants composition currently has no escape hatch. `option_key_is_meta` is the field that variable would drive, and winit's four-variant `OptionAsAlt` maps onto GNU's axis (`Both` / `None` / `OnlyLeft` / `OnlyRight`). Worth a follow-up issue.

## Verification

- `cargo nextest run --release -p neomacs-display-runtime`: 895/895 green (baseline 894 + 1 new test)
- new `neovm-core` test pins the endpoint: keysym `0x3C`/`0x3E` with `META|SHIFT` → `M-<` / `M->`
- the macOS-gated function type-checks clean for `aarch64-apple-darwin` (the workspace cannot be cross-checked from Linux — `libz-sys` needs a C toolchain), so the `macos-aarch64` job in `ci.yml` is the real gate here

**Not runtime-verified on macOS** — the behavioural claim rests on reading winit and GNU sources, so it wants one manual check on a Mac before release.