### PR TITLE
fix(font): use opened font metrics for SVG tag sizing

### DIFF
--- a/crates/neomacs-gui-tests/fixtures/image-size-oracle.el
+++ b/crates/neomacs-gui-tests/fixtures/image-size-oracle.el
@@ -4,8 +4,17 @@
 ;; (the GUI test harness starts Xvfb and sets DISPLAY). Computes a battery
 ;; of image probes and prin1's them to the file named by
 ;; NEOMACS_GUI_IMAGE_RESULT, so the Rust test can diff the two editors'
-;; results. Probes are pixel-only (font-independent) so a mismatch always
-;; points at image code, never at font selection.
+;; results. Raster probes are pixel-only; SVG text probes also check the
+;; opened-font metrics used by packages such as svg-lib (issue #360).
+
+(require 'svg)
+
+;; A missing font must fail setup, not turn the metrics oracle into matching
+;; nils (or matching errors caught by neomacs-image-oracle-cell).
+(let ((info (font-info "Noto Sans-7")))
+  (unless (and (vectorp info) (> (aref info 2) 0)
+               (> (aref info 8) 0) (> (aref info 11) 0))
+    (error "The SVG font oracle requires an openable Noto Sans font")))
 
 (defconst neomacs-image-oracle-png-b64
   ;; A 5x3 solid-red PNG; the decoded bytes are the ground truth both
@@ -43,7 +52,103 @@
         (let ((img (create-image d 'png t)))
           (image-size img t)
           (image-flush img)
-          (image-size img t)))))))
+          (image-size img t))))
+     (neomacs-image-oracle-cell
+      :svg-named-font-metrics
+      (lambda ()
+        ;; svg-lib obtains the SVG's font-size, baseline, and character
+        ;; width from font-info, not from the selected window's font.
+        ;; Include point and explicit-pixel names, and query twice with
+        ;; different default faces to expose accidental frame-font reuse.
+        (let ((height (face-attribute 'default :height)))
+          (unwind-protect
+              (mapcar
+               (lambda (default-height)
+                 (set-face-attribute 'default nil :height default-height)
+                 (mapcar
+                  (lambda (name)
+                    (let ((info (font-info name)))
+                      (seq-subseq info 2 12)))
+                  '("Noto Sans-7" "Noto Sans-12" "Noto Sans-20"
+                    "Noto Sans:pixelsize=9" "Noto Sans-7:dpi=144"
+                    "Noto Sans")))
+               '(120 200))
+            (set-face-attribute 'default nil :height height)))))
+     (neomacs-image-oracle-cell
+      :svg-window-font-metrics
+      (lambda ()
+        ;; svg-lib sizes the tag background from window-font-*, which in
+        ;; turn reopen the realized name returned by face-font.
+        (let ((height (face-attribute 'default :height))
+              (family (face-attribute 'default :family)))
+          (unwind-protect
+              (mapcar
+               (lambda (default-height)
+                 (set-face-attribute 'default nil :family "Noto Sans"
+                                     :height default-height)
+                 (let ((info (font-info (face-font 'default))))
+                   (list (aref info 2) (aref info 3) (aref info 11)
+                         (window-font-width) (window-font-height))))
+               '(120 200))
+            (set-face-attribute 'default nil :family family :height height)))))
+     (neomacs-image-oracle-cell
+      :svg-font-spec-and-entity
+      (lambda ()
+        (let ((spec (font-spec :family "Noto Sans" :size 20
+                               :weight 'normal :slant 'normal :width 'normal)))
+          (mapcar (lambda (font) (seq-subseq (font-info font) 2 12))
+                  (list spec (find-font spec))))))
+     (neomacs-image-oracle-cell
+      :font-spec-frame-styles
+      (lambda ()
+        (let ((frame (selected-frame))
+              (weight (face-attribute 'default :weight))
+              (other (make-frame '((visibility . nil)
+                                   (font . "Noto Sans-12:weight=bold")))))
+          (unwind-protect
+              (progn
+                (set-face-attribute 'default frame :weight 'normal)
+                (set-face-attribute 'default other :weight 'bold)
+                (mapcar
+                 (lambda (target)
+                   ;; Realize the modified default before font-info reads
+                   ;; GNU's cached DEFAULT_FACE_ID for this frame.
+                   (face-font 'default target)
+                   (mapcar
+                    (lambda (spec-weight)
+                      (aref (font-info (font-spec :family "Noto Sans" :weight spec-weight)
+                                       target)
+                            0))
+                    '(normal bold)))
+                 (list frame other)))
+            (delete-frame other t)
+            (set-face-attribute 'default frame :weight weight)))))
+     (neomacs-image-oracle-cell
+      :missing-font
+      (lambda ()
+        (list (font-info "NeomacsIssue360NonexistentFamily-7")
+              (font-info (font-spec :family "NeomacsIssue360NonexistentFamily")))))
+     (neomacs-image-oracle-cell
+      :unspecified-font-family
+      (lambda () (seq-subseq (font-info (font-spec)) 0 12)))
+     (neomacs-image-oracle-cell
+      :svg-tag
+      (lambda ()
+        ;; Exercise svg-lib's public font-info -> SVG text -> image path
+        ;; without a network package dependency. Explicit 1:1 scaling keeps
+        ;; this probe about fonts, independently of default image scaling.
+        (let* ((info (font-info "Noto Sans-7"))
+               (svg (svg-create 80 24)))
+          (svg-rectangle svg 0 0 80 24 :fill "purple" :rx 8)
+          (svg-text svg "TODO" :font-family "Noto Sans"
+                    :font-size (aref info 2) :fill "white"
+                    :x (- 40 (* 2 (aref info 11))) :y (aref info 8))
+          (let ((image (svg-image svg :scale 1 :ascent 79)))
+            (with-current-buffer (get-buffer-create "*SVG tag oracle*")
+              (erase-buffer)
+              (insert-image image)
+              (switch-to-buffer (current-buffer)))
+            (list (plist-get (cdr image) :data) (image-size image t)))))))))
 
 (defun neomacs-image-oracle-write ()
   (let ((path (getenv "NEOMACS_GUI_IMAGE_RESULT")))

--- a/crates/neomacs-layout-engine/src/font/fontconfig.rs
+++ b/crates/neomacs-layout-engine/src/font/fontconfig.rs
@@ -1119,6 +1119,50 @@ pub(crate) fn fc_list_candidates(
     required_char: Option<u32>,
     langs: &[String],
 ) -> Vec<ListedFont> {
+    fc_query_candidates(
+        family,
+        query_charset_ranges,
+        required_char,
+        langs,
+        FcQueryKind::List,
+    )
+}
+
+#[cfg(unix)]
+pub(crate) fn fc_match_candidate(
+    family: Option<&str>,
+    query_charset_ranges: &[(u32, u32)],
+    langs: &[String],
+) -> Option<ListedFont> {
+    fc_query_candidates(
+        family,
+        query_charset_ranges,
+        None,
+        langs,
+        FcQueryKind::Match,
+    )
+    .into_iter()
+    // Like GNU ftfont_match, do not silently substitute a missing family.
+    .find(|candidate| {
+        family.is_none_or(|family| candidate.matched.family.eq_ignore_ascii_case(family))
+    })
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy)]
+enum FcQueryKind {
+    List,
+    Match,
+}
+
+#[cfg(unix)]
+fn fc_query_candidates(
+    family: Option<&str>,
+    query_charset_ranges: &[(u32, u32)],
+    required_char: Option<u32>,
+    langs: &[String],
+    kind: FcQueryKind,
+) -> Vec<ListedFont> {
     if fontconfig_handle().is_none() {
         return Vec::new();
     }
@@ -1220,6 +1264,30 @@ pub(crate) fn fc_list_candidates(
         };
         let _keep_charset_alive = query_charset;
         let _keep_langset_alive = query_langset;
+        if matches!(kind, FcQueryKind::Match) {
+            // GNU ftfont_match uses this pattern without weight/slant/width
+            // fields; Fontconfig supplies its native defaults. Enumeration
+            // below deliberately keeps the unsubstituted FcFontList path.
+            if unsafe {
+                fontconfig_sys::FcConfigSubstitute(
+                    ptr::null_mut(),
+                    pattern.0,
+                    fontconfig_sys::FcMatchPattern,
+                )
+            } == 0
+            {
+                continue;
+            }
+            unsafe { fontconfig_sys::FcDefaultSubstitute(pattern.0) };
+            let mut result = fontconfig_sys::FcResultNoMatch;
+            let matched = FcPatternGuard(unsafe {
+                fontconfig_sys::FcFontMatch(ptr::null_mut(), pattern.0, &mut result)
+            });
+            if let Some(candidate) = listed_font_from_raw_pattern(matched.0) {
+                candidates.push(candidate);
+            }
+            continue;
+        }
         let projection = if required_char.is_some() && query_charset_ranges.is_empty() {
             GnuEntityProjection::MetadataAndCharset
         } else {

--- a/crates/neomacs-layout-engine/src/font/resolver.rs
+++ b/crates/neomacs-layout-engine/src/font/resolver.rs
@@ -1,10 +1,11 @@
 //! Shared GNU-compatible font selection policy.
 //!
 //! GNU Emacs keeps fontset lookup and entity scoring in `fontset.c`/`font.c`;
-//! platform drivers only list/open entities and answer coverage questions.
-//! [`FontResolver`] preserves that split.  A [`FontBackend`] may use
-//! Fontconfig, CoreText, or DirectWrite to discover candidates, but it never
-//! decides which fontset entry or style wins.
+//! platform drivers list/open entities and answer coverage questions.
+//! [`FontResolver`] owns fontset and enumerated-candidate selection across
+//! Fontconfig, CoreText, and DirectWrite. GNU's separate driver `match`
+//! operation is explicit: its native winner bypasses enumeration's style
+//! filters without changing shared fontset selection.
 
 use crate::font::policy::GnuFontPolicy;
 use crate::font::selection::{CandidateSelectionScore, candidate_selection_score};
@@ -14,6 +15,7 @@ use crate::font_backend::{
     RequiredFontCoverage, TextDirection,
 };
 use neomacs_display_protocol::font::{FontBackendKind, ResolvedFontIdentity};
+use neovm_core::emacs_core::eval::FontSpecSelection;
 use neovm_core::emacs_core::font::alternative_font_families;
 use neovm_core::emacs_core::fontset::{
     FontSpecEntry, StoredFontSpec, fontset_generation, matching_entries_for_char,
@@ -23,11 +25,12 @@ use neovm_core::face::{FontSlant, FontWeight, FontWidth};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::sync::Mutex;
 
-/// Platform-neutral request for GNU `list-fonts` / `find-font` entity
-/// discovery.  Optional fields remain optional all the way to the native
-/// adapter; no platform is selected by the caller.
+/// Platform-neutral request for GNU entity enumeration or driver matching.
+/// Optional fields remain optional all the way to the native adapter; no
+/// platform is selected by the caller.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct FontEntityQuery {
+    selection: FontSpecSelection,
     family: Option<FontFamilyName>,
     registry: Option<String>,
     language: Option<String>,
@@ -38,6 +41,11 @@ pub struct FontEntityQuery {
 }
 
 impl FontEntityQuery {
+    pub fn with_selection(mut self, selection: FontSpecSelection) -> Self {
+        self.selection = selection;
+        self
+    }
+
     pub fn new(family: Option<FontFamilyName>) -> Self {
         Self {
             family,
@@ -241,9 +249,21 @@ impl FontResolver {
             requested_width: query.width.unwrap_or(FontWidth::Normal),
             direction: TextDirection::for_char(representative),
         };
-        let selected = self
-            .backend
-            .list_candidates(&candidate_query)
+        let candidates = match query.selection {
+            FontSpecSelection::Enumerate => self.backend.list_candidates(&candidate_query),
+            FontSpecSelection::DriverMatch => {
+                match self.backend.match_font_spec(&candidate_query) {
+                    crate::font_backend::FontDriverMatch::Native(candidate) => {
+                        return Some(ResolvedFontEntity {
+                            matched: self.backend.finalize_match(candidate?.matched)?,
+                            registry: Some("iso10646-1".to_owned()),
+                        });
+                    }
+                    crate::font_backend::FontDriverMatch::Enumerated(candidates) => candidates,
+                }
+            }
+        };
+        let selected = candidates
             .into_iter()
             .enumerate()
             .filter(|(_, candidate)| {

--- a/crates/neomacs-layout-engine/src/font/resolver_test.rs
+++ b/crates/neomacs-layout-engine/src/font/resolver_test.rs
@@ -205,6 +205,10 @@ fn windows_entity_policy_keeps_gnus_relaxed_weight_match() {
 }
 
 impl FontBackend for CandidateBackend {
+    fn match_font_spec(&self, _query: &FontCandidateQuery) -> crate::font_backend::FontDriverMatch {
+        crate::font_backend::FontDriverMatch::Native(self.candidates.first().cloned())
+    }
+
     fn kind(&self) -> FontBackendKind {
         FontBackendKind::Fontconfig
     }
@@ -230,6 +234,29 @@ impl FontBackend for CandidateBackend {
     fn poll_catalog_change(&mut self) -> crate::font::catalog::FontCatalogChange {
         crate::font::catalog::FontCatalogChange::Unchanged
     }
+}
+
+#[test]
+fn native_driver_match_is_not_rejected_by_enumeration_style_filters() {
+    let resolver = FontResolver::new(Box::new(CandidateBackend {
+        candidates: vec![
+            candidate("Fixture Sans", 400, FontSlant::Normal, 0),
+            candidate("Fixture Sans", 700, FontSlant::Italic, 0),
+        ],
+    }));
+    let query = FontEntityQuery::new(FontFamilyName::new("Fixture Sans"))
+        .with_weight(700)
+        .with_slant(FontSlant::Italic)
+        .with_selection(FontSpecSelection::DriverMatch);
+    let entity = resolver
+        .resolve_entity(&query)
+        .expect("native driver winner");
+    assert_eq!(entity.matched.weight(), Some(400));
+    assert_eq!(entity.matched.slant(), FontSlant::Normal);
+    assert_eq!(
+        entity.matched.file_path(),
+        Some("/fixture/Fixture Sans-400.ttf")
+    );
 }
 
 fn candidate(family: &str, weight: u16, slant: FontSlant, spacing: i32) -> FontCandidate {

--- a/crates/neomacs-layout-engine/src/font/sizing.rs
+++ b/crates/neomacs-layout-engine/src/font/sizing.rs
@@ -6,7 +6,7 @@
 //! into the CoreText and DirectWrite catalogs.
 
 use neomacs_display_protocol::{DisplayObservation, Dpi, XServerKind};
-use neovm_core::emacs_core::display_host::FrameFontSize;
+use neovm_core::emacs_core::display_host::{FontOpeningSize, FrameFontSize};
 use neovm_core::face::{Face, FaceHeight};
 
 pub use super::frame_metrics::GraphicFontSizePx;
@@ -241,6 +241,32 @@ impl FontSizing {
             }
         };
         GraphicFontSizePx::new(pixels)
+    }
+
+    /// Resolve a query's opening size without consulting the frame font or
+    /// applying backing scale (GNU font.c font_pixel_size/font_open_entity).
+    pub fn font_opening_size_px(self, size: FontOpeningSize) -> std::num::NonZeroU32 {
+        let pixels = match size {
+            FontOpeningSize::SmallestUsable => 1,
+            FontOpeningSize::Pixels(pixels) => return pixels,
+            FontOpeningSize::NamedDefault { frame_fontsize } => {
+                let points = match self.scale {
+                    LogicalFontScale::GnuCocoaPoint => {
+                        frame_fontsize.map(|size| size.get() as f32).unwrap_or(0.0)
+                    }
+                    _ => 12.0,
+                };
+                // font_open_for_lface keeps the frame's fractional DPI.
+                points_to_layout_pixels(points, self.layout_dpi()) as u32
+            }
+            FontOpeningSize::Points { size, dpi } => points_to_layout_pixels(
+                size.get() as f32,
+                // font_pixel_size stores FRAME_RES in an integer first.
+                dpi.map(|dpi| dpi.get() as f32)
+                    .unwrap_or_else(|| self.layout_dpi().trunc()),
+            ) as u32,
+        };
+        std::num::NonZeroU32::new(pixels).unwrap_or(std::num::NonZeroU32::MIN)
     }
 
     /// GNU `PIXEL_TO_POINT(pixel_size * 10, FRAME_RES(frame))` for one

--- a/crates/neomacs-layout-engine/src/font/sizing_test.rs
+++ b/crates/neomacs-layout-engine/src/font/sizing_test.rs
@@ -5,7 +5,98 @@ use super::{
 use neomacs_display_protocol::{
     DisplayHeightGeometry, DisplayObservation, Dpi, X11DisplayObservation, XServerKind,
 };
-use neovm_core::emacs_core::display_host::FrameFontSize;
+use neovm_core::emacs_core::display_host::{FontOpeningSize, FrameFontSize, PositiveFontScalar};
+
+#[test]
+fn font_info_point_size_uses_gnu_integer_dpi_but_unsized_names_do_not() {
+    // GNU font.c font_pixel_size truncates FRAME_RES to int before the
+    // POINT_TO_PIXEL conversion; font_open_for_lface's default does not.
+    let sizing = FontSizing::for_layout_dpi(99.9);
+    assert_eq!(
+        sizing
+            .font_opening_size_px(FontOpeningSize::Points {
+                size: PositiveFontScalar::new(12.0).unwrap(),
+                dpi: None,
+            })
+            .get(),
+        16,
+    );
+    assert_eq!(
+        sizing
+            .font_opening_size_px(FontOpeningSize::NamedDefault {
+                frame_fontsize: None
+            })
+            .get(),
+        17,
+    );
+    assert_eq!(
+        FontSizing::for_layout_dpi(95.9)
+            .font_opening_size_px(FontOpeningSize::Points {
+                size: PositiveFontScalar::new(20.0).unwrap(),
+                dpi: None,
+            })
+            .get(),
+        26,
+    );
+}
+
+#[test]
+fn font_info_explicit_dpi_and_pixels_override_display_dpi() {
+    for sizing in [FontSizing::gnu_cocoa(), FontSizing::for_layout_dpi(99.9)] {
+        assert_eq!(
+            sizing
+                .font_opening_size_px(FontOpeningSize::Points {
+                    size: PositiveFontScalar::new(7.0).unwrap(),
+                    dpi: std::num::NonZeroU32::new(144),
+                })
+                .get(),
+            14,
+        );
+        assert_eq!(
+            sizing
+                .font_opening_size_px(FontOpeningSize::Pixels(
+                    std::num::NonZeroU32::new(9).unwrap()
+                ))
+                .get(),
+            9,
+        );
+        assert_eq!(
+            sizing
+                .font_opening_size_px(FontOpeningSize::SmallestUsable)
+                .get(),
+            1
+        );
+    }
+}
+
+#[test]
+fn font_info_unsized_name_uses_native_default_policy() {
+    let request = FontOpeningSize::NamedDefault {
+        frame_fontsize: PositiveFontScalar::new(14.0),
+    };
+    assert_eq!(
+        FontSizing::gnu_cocoa().font_opening_size_px(request).get(),
+        14
+    );
+    assert_eq!(
+        FontSizing::windows_dip()
+            .font_opening_size_px(request)
+            .get(),
+        16
+    );
+    assert_eq!(
+        FontSizing::wayland().font_opening_size_px(request).get(),
+        16
+    );
+    assert_eq!(
+        FontSizing::gnu_cocoa()
+            .font_opening_size_px(FontOpeningSize::NamedDefault {
+                frame_fontsize: None
+            })
+            .get(),
+        1,
+    );
+}
 
 fn x11_observation(
     server: XServerKind,

--- a/crates/neomacs-layout-engine/src/font_backend.rs
+++ b/crates/neomacs-layout-engine/src/font_backend.rs
@@ -511,7 +511,19 @@ pub struct FontCandidate {
     pub matched: PlatformFontCandidate,
 }
 
+/// A driver-selected entity must not pass through the list operation's
+/// style filters again. Backends using shared selection provide candidates
+/// instead, preserving their platform-specific enumeration policy.
+pub enum FontDriverMatch {
+    Native(Option<FontCandidate>),
+    Enumerated(Vec<FontCandidate>),
+}
+
 pub trait FontBackend: Send {
+    fn match_font_spec(&self, query: &FontCandidateQuery) -> FontDriverMatch {
+        FontDriverMatch::Enumerated(self.list_candidates(query))
+    }
+
     /// Native platform implementation represented by this adapter.
     fn kind(&self) -> FontBackendKind;
 

--- a/crates/neomacs-layout-engine/src/font_backend/linux/mod.rs
+++ b/crates/neomacs-layout-engine/src/font_backend/linux/mod.rs
@@ -93,6 +93,25 @@ pub struct FontconfigBackend {
 }
 
 impl FontBackend for FontconfigBackend {
+    fn match_font_spec(&self, query: &FontCandidateQuery) -> super::FontDriverMatch {
+        let matched = crate::font::fontconfig::fc_match_candidate(
+            query.scope.queried_family(),
+            &query.charset_ranges,
+            &query.languages,
+        )
+        .and_then(|candidate| {
+            Some(FontCandidate {
+                matched: PlatformFontCandidate::from_fontconfig(
+                    candidate.matched,
+                    candidate.foundry,
+                    candidate.width,
+                    candidate.spacing,
+                )?,
+            })
+        });
+        super::FontDriverMatch::Native(matched)
+    }
+
     fn kind(&self) -> FontBackendKind {
         FontBackendKind::Fontconfig
     }

--- a/crates/neomacs/src/main.rs
+++ b/crates/neomacs/src/main.rs
@@ -1948,7 +1948,8 @@ impl DisplayHost for PrimaryWindowDisplayHost {
             .as_ref()
             .and_then(LispString::as_utf8_str)
             .and_then(neomacs_layout_engine::font_backend::FontFamilyName::new);
-        let mut query = neomacs_layout_engine::font::resolver::FontEntityQuery::new(family);
+        let mut query = neomacs_layout_engine::font::resolver::FontEntityQuery::new(family)
+            .with_selection(request.selection);
         if let Some(registry) = request.registry.as_ref().and_then(LispString::as_utf8_str) {
             query = query.with_registry(registry);
         }
@@ -2013,7 +2014,7 @@ impl DisplayHost for PrimaryWindowDisplayHost {
         &mut self,
         request: FontEntityMetricsRequest,
     ) -> Result<Option<ResolvedFontEntityMetrics>, String> {
-        let pixel_size = request.pixel_size.max(1);
+        let pixel_size = self.font_sizing.font_opening_size_px(request.size).get();
         let family = request
             .family
             .as_ref()

--- a/crates/neovm-core/src/emacs_core/display/display_host/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/display_host/mod.rs
@@ -197,6 +197,27 @@ impl FrameFontSize {
     }
 }
 
+/// Size used to open a font for a Lisp query, not to resize a frame.
+///
+/// GNU opens an unsized scalable entity at the smallest usable size, whereas
+/// a named font can request pixels or points. Point conversion belongs to the
+/// display host; neither the selected frame's font nor backing scale supplies
+/// substitute metrics. An explicit font-spec DPI overrides the display DPI.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FontOpeningSize {
+    SmallestUsable,
+    Pixels(NonZeroU32),
+    /// An unsized name uses GNU's moderate default, except on Cocoa where
+    /// the native frame's `fontsize` parameter supplies the default points.
+    NamedDefault {
+        frame_fontsize: Option<PositiveFontScalar>,
+    },
+    Points {
+        size: PositiveFontScalar,
+        dpi: Option<NonZeroU32>,
+    },
+}
+
 /// Typed request crossing from frame-local face state into native font
 /// selection. The embedded face carries style; `size` is its sole sizing
 /// authority and therefore cannot disagree with `Face::height`.
@@ -388,7 +409,16 @@ pub trait DisplayHost {
             return Ok(None);
         };
         let weight = request.weight.map(|weight| f32::from(weight.css_weight()));
-        let metrics = self.probe_font_px_metrics(file, 0, request.pixel_size, weight)?;
+        let pixel_size = match request.size {
+            FontOpeningSize::SmallestUsable => 0,
+            FontOpeningSize::Pixels(size) => size.get(),
+            // A file-only adapter has no display resolution. Native hosts
+            // must resolve point requests using their own font-sizing policy.
+            FontOpeningSize::Points { .. } | FontOpeningSize::NamedDefault { .. } => {
+                return Ok(None);
+            }
+        };
+        let metrics = self.probe_font_px_metrics(file, 0, pixel_size, weight)?;
         Ok(metrics.map(|metrics| ResolvedFontEntityMetrics {
             metrics,
             file: request.file,

--- a/crates/neovm-core/src/emacs_core/display/font/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/font/mod.rs
@@ -31,7 +31,7 @@ use super::xfaces::{
     runtime_face_table_from_frame_lisp_faces, set_lisp_face_vector_attr,
 };
 
-use super::display_host::{FrameFontRequest, FrameFontSize};
+use super::display_host::{FontOpeningSize, FrameFontRequest, FrameFontSize, PositiveFontScalar};
 use super::intern::{intern, resolve_sym};
 use super::value::*;
 use crate::buffer::{Buffer, CharPos0, EmacsBytePos, LispCharPos1};
@@ -2229,6 +2229,7 @@ fn font_spec_resolve_request(
     });
 
     Ok(super::eval::FontSpecResolveRequest {
+        selection: super::eval::FontSpecSelection::Enumerate,
         frame_id: find_font_frame_id(eval, frame)?,
         family,
         registry,
@@ -2253,6 +2254,13 @@ pub(crate) fn find_font(eval: &mut super::eval::Context, args: Vec<Value>) -> Ev
     }
 
     let request = font_spec_resolve_request(eval, &args[0], args.get(1))?;
+    match_font_spec_request(eval, request)
+}
+
+fn match_font_spec_request(
+    eval: &mut super::eval::Context,
+    request: super::eval::FontSpecResolveRequest,
+) -> EvalResult {
     let Some(host) = eval.display_host.as_mut() else {
         return Ok(Value::NIL);
     };
@@ -3047,24 +3055,24 @@ fn gnu_style_first_name(
         .map(|row| row[0])
 }
 
-/// `font-info` for a font ENTITY, following GNU font.c `Ffont_info`: open
-/// the entity via `font_open_entity` (a scalable entity's size 0 probes
-/// upward from 1px until the font is "manageable") and report the OPENED
-/// font's metrics — the tiny pixelsize=1 numbers — not the frame's realized
-/// font. Names: element 0 is the entity XLFD with the probed pixel size,
-/// element 1 the fontconfig-style name `font_unparse_fcname` builds.
+/// Open an entity at the requested size and report the actual metrics,
+/// following GNU font.c `font_open_entity`. A fixed-size entity takes
+/// precedence over the request; SmallestUsable probes upward from 1px.
+/// The returned names describe that opened font, never the frame font.
 fn font_info_vector_for_entity(
     eval: &mut super::eval::Context,
     frame_id: crate::window::FrameId,
     entity: &Value,
+    requested_size: FontOpeningSize,
 ) -> Option<Value> {
     let elems = entity.as_vector_data()?.clone();
-    let px = font_vector_get_flexible(&elems, "size")
+    let size = font_vector_get_flexible(&elems, "size")
         .and_then(|value| match value.kind() {
-            ValueKind::Fixnum(n) if n > 0 => Some(n as u32),
+            ValueKind::Fixnum(n) => u32::try_from(n).ok().and_then(std::num::NonZeroU32::new),
             _ => None,
         })
-        .unwrap_or(0);
+        .map(FontOpeningSize::Pixels)
+        .unwrap_or(requested_size);
     let text_field = |name| {
         font_vector_get_flexible(&elems, name).and_then(|value| font_value_text_lisp_string(&value))
     };
@@ -3082,7 +3090,7 @@ fn font_info_vector_for_entity(
                 slant: font_vector_get_flexible(&elems, "slant").and_then(font_slant_from_value),
                 width: font_vector_get_flexible(&elems, "width")
                     .and_then(|value| value.as_symbol_name().and_then(FontWidth::from_symbol)),
-                pixel_size: px,
+                size,
             })
             .ok()
         })
@@ -3203,18 +3211,6 @@ fn otf_capability_to_lisp(caps: &super::eval::FontOtfCapability) -> Value {
     )
 }
 
-/// Capability for any font VALUE carrying a `:file`, else nil.
-fn font_value_otf_capability(eval: &mut super::eval::Context, font_like: &Value) -> Value {
-    let Some(file) = font_value_fields(font_like)
-        .and_then(|fields| font_vector_get_flexible(fields, "file"))
-        .filter(|value| value.is_string())
-        .and_then(|value| value.as_utf8_str().map(|s| s.to_owned()))
-    else {
-        return Value::NIL;
-    };
-    otf_capability_lisp(eval, &file)
-}
-
 /// Lisp form of one GSUB/GPOS side: list of `(SCRIPT (LANGSYS FEATURES...)
 /// ...)`, default langsys printed as `nil`; `nil` for an empty side —
 /// mirroring GNU `hbfont_otf_features`.
@@ -3244,49 +3240,6 @@ fn otf_side_to_lisp(side: &super::eval::OtfSideCapability) -> Value {
         })
         .collect();
     Value::list(scripts)
-}
-
-fn font_info_vector_for_runtime_font(
-    font_like: &Value,
-    frame: &crate::window::Frame,
-    capability: Value,
-) -> Value {
-    let opened_name = font_name_value(font_like).unwrap_or_else(|| Value::string(""));
-    let full_name = opened_name;
-    let file = match font_like.kind() {
-        ValueKind::Veclike(VecLikeType::Vector | VecLikeType::Font) if is_font(font_like) => {
-            font_value_fields(font_like)
-                .and_then(|elems| font_vector_get_flexible(elems, "file"))
-                .filter(|value| value.is_string())
-                .unwrap_or(Value::NIL)
-        }
-        _ => Value::NIL,
-    };
-    let size = frame.font_pixel_size.max(1.0).round() as i64;
-    let height = frame.char_height.max(1.0).round() as i64;
-    let average_width = frame.char_width.max(1.0).round() as i64;
-    let space_width = average_width;
-    let max_width = average_width;
-    let ascent = ((height as f32) * 0.75).round() as i64;
-    let descent = (height - ascent).max(0);
-    let default_ascent = ascent;
-
-    Value::vector(vec![
-        opened_name,
-        full_name,
-        Value::fixnum(size),
-        Value::fixnum(height),
-        Value::fixnum(0),
-        Value::fixnum(0),
-        Value::fixnum(default_ascent),
-        Value::fixnum(max_width),
-        Value::fixnum(ascent),
-        Value::fixnum(descent),
-        Value::fixnum(space_width),
-        Value::fixnum(average_width),
-        file,
-        capability,
-    ])
 }
 
 pub(crate) fn resolve_font_match(
@@ -3578,20 +3531,71 @@ pub(crate) fn internal_char_font(eval: &mut super::eval::Context, args: Vec<Valu
     ))
 }
 
+/// GNU Ffont_info has distinct opening semantics for these four inputs.
+/// In particular, a named font honors its requested size, but a scalable
+/// entity (including one matched from a spec) is opened at its smallest size.
+enum FontInfoTarget {
+    Named(Value),
+    Spec(Value),
+    Entity(Value),
+    Opened(OpenedFont),
+}
+
+impl FontInfoTarget {
+    fn decode(value: Value) -> Option<Self> {
+        if value.is_string() {
+            Some(Self::Named(value))
+        } else if is_font_spec(&value) {
+            Some(Self::Spec(value))
+        } else if is_font_entity(&value) {
+            Some(Self::Entity(value))
+        } else {
+            OpenedFont::decode(value).map(Self::Opened)
+        }
+    }
+}
+
+fn named_font_opening_size(spec: Value, frame: &crate::window::Frame) -> FontOpeningSize {
+    let fields = font_value_fields(&spec).expect("parsed font spec");
+    let dpi = font_vector_get_flexible(fields, "dpi")
+        .and_then(|value| value.as_int())
+        .and_then(|value| u32::try_from(value).ok())
+        .and_then(std::num::NonZeroU32::new);
+    match font_vector_get_flexible(fields, "size") {
+        Some(value) if value.is_fixnum() => value
+            .as_int()
+            .and_then(|value| u32::try_from(value).ok())
+            .and_then(std::num::NonZeroU32::new)
+            .map(FontOpeningSize::Pixels)
+            .unwrap_or(FontOpeningSize::SmallestUsable),
+        Some(value) if value.is_float() => PositiveFontScalar::new(value.xfloat())
+            .map(|size| FontOpeningSize::Points { size, dpi })
+            .unwrap_or(FontOpeningSize::SmallestUsable),
+        // Keep the default distinct from an explicit point size: GNU uses
+        // different DPI conversion and NS frame policy for unsized names.
+        _ => FontOpeningSize::NamedDefault {
+            frame_fontsize: frame.parameter("fontsize").and_then(|value| {
+                let points = match value.kind() {
+                    ValueKind::Fixnum(points) => points as f64,
+                    ValueKind::Float => value.xfloat(),
+                    _ => return None,
+                };
+                PositiveFontScalar::new(points)
+            }),
+        },
+    }
+}
+
 pub(crate) fn font_info(eval: &mut super::eval::Context, args: Vec<Value>) -> EvalResult {
     expect_min_args("font-info", &args, 1)?;
     expect_max_args("font-info", &args, 2)?;
 
-    if !(args[0].is_string()
-        || is_font(&args[0])
-        || is_font_entity(&args[0])
-        || is_font_object(&args[0]))
-    {
-        return Err(signal(
+    let target = FontInfoTarget::decode(args[0]).ok_or_else(|| {
+        signal(
             LispCondition::WrongTypeArgument,
             vec![Value::symbol("stringp"), args[0]],
-        ));
-    }
+        )
+    })?;
 
     let frame_id = match args.get(1) {
         None => super::window_cmds::ensure_selected_frame_id(eval),
@@ -3617,33 +3621,46 @@ pub(crate) fn font_info(eval: &mut super::eval::Context, args: Vec<Value>) -> Ev
         return Ok(Value::NIL);
     }
 
-    if let Some(opened) = OpenedFont::decode(args[0]) {
-        return Ok(opened.info_vector());
-    }
-    if is_font_entity(&args[0]) {
-        // GNU opens the font itself (font_open_entity for entities; a
-        // font-at object is already opened at its pixel size) and reports
-        // the OPENED font's metrics; only fall back to the frame font when
-        // the value can't be probed (no file, unreadable, ...).
-        if let Some(info) = font_info_vector_for_entity(eval, frame_id, &args[0]) {
-            return Ok(info);
+    let (entity, size) = match target {
+        FontInfoTarget::Opened(opened) => return Ok(opened.info_vector()),
+        FontInfoTarget::Entity(entity) => (entity, FontOpeningSize::SmallestUsable),
+        FontInfoTarget::Spec(spec) => {
+            // GNU font_matching_entity replaces all three style slots with
+            // this frame's default-face attributes, even explicit spec
+            // styles. It does not inherit the frame's font family.
+            let defaults =
+                runtime_face_table_from_frame_lisp_faces(eval, frame_id, false).resolve("default");
+            let mut request =
+                font_spec_resolve_request(eval, &spec, Some(&Value::make_frame(frame_id.0)))?;
+            request.weight = Some(defaults.weight.unwrap_or(FontWeight::NORMAL));
+            request.selection = super::eval::FontSpecSelection::DriverMatch;
+            request.slant = Some(defaults.slant.unwrap_or(FontSlant::Normal));
+            request.width = Some(defaults.width.unwrap_or(FontWidth::Normal));
+            (
+                match_font_spec_request(eval, request)?,
+                FontOpeningSize::SmallestUsable,
+            )
         }
-    }
-    // GNU attaches (opentype . caps) to font-info for OPENED fonts too
-    // (font-at objects); compute it from the font's file before borrowing
-    // the frame.
-    let capability = font_value_otf_capability(eval, &args[0]);
-    let frame = eval
-        .frames
-        .get(frame_id)
-        .ok_or_else(|| signal("error", vec![Value::string("No selected frame")]))?;
-    if args[0].is_string() || is_font(&args[0]) {
-        Ok(font_info_vector_for_runtime_font(
-            &args[0], frame, capability,
-        ))
-    } else {
-        Ok(Value::NIL)
-    }
+        FontInfoTarget::Named(name) => {
+            // Share the GNU font-name parser with font-spec, including
+            // fontconfig/Pango names and XLFD pixel/point units.
+            let text = font_string_text(&name).expect("validated font name");
+            let spec = font_spec_from_name(&text)
+                .ok_or_else(|| signal("error", vec![Value::string("Invalid font name"), name]))?;
+            let size =
+                named_font_opening_size(spec, eval.frames.get(frame_id).expect("validated frame"));
+            // GNU font_open_by_spec prefers normal styles, independent of
+            // the frame face, but preserves the name's explicit styles.
+            let mut request =
+                font_spec_resolve_request(eval, &spec, Some(&Value::make_frame(frame_id.0)))?;
+            request.weight.get_or_insert(FontWeight::NORMAL);
+            request.slant.get_or_insert(FontSlant::Normal);
+            request.width.get_or_insert(FontWidth::Normal);
+            let entity = match_font_spec_request(eval, request)?;
+            (entity, size)
+        }
+    };
+    Ok(font_info_vector_for_entity(eval, frame_id, &entity, size).unwrap_or(Value::NIL))
 }
 
 pub(crate) fn query_font(_eval: &mut super::eval::Context, args: Vec<Value>) -> EvalResult {

--- a/crates/neovm-core/src/emacs_core/display/font/tests/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/font/tests/mod.rs
@@ -440,6 +440,31 @@ impl DisplayHost for CapturingFindFontDisplayHost {
         *self.last_request.borrow_mut() = Some(request);
         Ok(self.matched.clone())
     }
+
+    fn probe_font_entity_metrics(
+        &mut self,
+        _request: FontEntityMetricsRequest,
+    ) -> Result<Option<ResolvedFontEntityMetrics>, String> {
+        // This host advertises a synthetic native entity, not a real file.
+        // Supply its opening capability explicitly: font-info must never
+        // fabricate frame metrics when a backend cannot open an entity.
+        Ok(self
+            .matched
+            .as_ref()
+            .map(|matched| ResolvedFontEntityMetrics {
+                metrics: FontPxProbeResult {
+                    pixel_size: 1,
+                    height: 2,
+                    ascent: 1,
+                    descent: 1,
+                    max_width: 1,
+                    space_width: 1,
+                    average_width: 1,
+                },
+                file: matched.file.clone(),
+                capability: None,
+            }))
+    }
 }
 
 impl DisplayHost for NativeFontEntityDisplayHost {
@@ -599,6 +624,8 @@ fn find_font_eval_requests_exact_registry_match_from_display_host() {
     );
     let info = font_info(&mut eval, vec![font]).unwrap();
     let values = info.as_vector_data().expect("font info vector");
+    assert_eq!(values[2].as_int(), Some(1));
+    assert_eq!(values[3].as_int(), Some(2));
     assert_eq!(
         values[12].as_utf8_str(),
         Some("/tmp/NotoSansMonoCJKsc-Regular.otf")

--- a/crates/neovm-core/src/emacs_core/display/xfaces/mod.rs
+++ b/crates/neovm-core/src/emacs_core/display/xfaces/mod.rs
@@ -343,13 +343,13 @@ use strum::{EnumIter, EnumString, IntoEnumIterator, IntoStaticStr};
 use super::error::{Flow, LispCondition, signal};
 use super::font::{
     FrameFontRealization, alternative_font_family_alist, alternative_font_registry_alist,
-    default_face_font_attr_affects_frame_font, face_remapping_for_current_buffer,
-    font_name_for_face, font_name_value, font_string_text, font_value_fields, font_value_text,
-    font_vector_get_flexible, frame_device_designator_p, frame_id_from_designator,
-    frame_parameter_for_face_attribute, is_font, is_font_entity, is_font_spec,
-    live_frame_designator_in_state, live_frame_font_attribute_fallback,
-    opened_font_from_resolved_match, publish_face_attribute_to_frame_parameter, resolve_font_match,
-    resolve_live_frame_font_request, sync_live_default_face_font_state, sync_live_frame_font_state,
+    default_face_font_attr_affects_frame_font, face_remapping_for_current_buffer, font_name_value,
+    font_string_text, font_value_fields, font_value_text, font_vector_get_flexible,
+    frame_device_designator_p, frame_id_from_designator, frame_parameter_for_face_attribute,
+    is_font, is_font_entity, is_font_spec, live_frame_designator_in_state,
+    live_frame_font_attribute_fallback, opened_font_from_resolved_match,
+    publish_face_attribute_to_frame_parameter, resolve_font_match, resolve_live_frame_font_request,
+    sync_live_default_face_font_state, sync_live_frame_font_state,
 };
 
 use super::intern::intern;
@@ -4442,27 +4442,30 @@ pub(crate) fn builtin_face_font(eval: &mut super::eval::Context, args: Vec<Value
 
     let face_name = resolve_face_name_for_domain(eval, &args[0], false)?;
     let remapping = face_remapping_for_current_buffer(eval);
+    let face_table = runtime_face_table_from_frame_lisp_faces(eval, frame_id, false);
     let face = if remapping.is_empty() {
-        eval.face_table.resolve(&face_name)
+        face_table.resolve(&face_name)
     } else {
-        eval.face_table
-            .resolve_with_remapping(&face_name, &remapping)
+        face_table.resolve_with_remapping(&face_name, &remapping)
     };
-    if let Some(character) = args.get(2).filter(|value| !value.is_nil()) {
+    let character = if let Some(character) = args.get(2).filter(|value| !value.is_nil()) {
         let code = super::builtins::expect_character_code(character)? as u32;
         let Some(ch) = crate::emacs_core::emacs_char::EmacsChar::from_code(code) else {
-            return Ok(font_name_for_face(&face));
+            return Ok(Value::NIL);
         };
-        let fontset_base_face = eval.face_table.resolve("default");
-        if let Some(matched) = resolve_font_match(eval, frame_id, ch, &face, &fontset_base_face) {
-            return Ok(
-                font_name_value(&opened_font_from_resolved_match(&face, &matched))
-                    .unwrap_or(Value::NIL),
-            );
-        }
-    }
-
-    Ok(font_name_for_face(&face))
+        ch
+    } else {
+        // GNU Fface_font reports the realized ASCII font when CHARACTER is
+        // omitted. An unresolved face's height is in tenths of points, not
+        // an XLFD pixel size; fabricating a name corrupts window-font-*.
+        crate::emacs_core::emacs_char::EmacsChar::from_char('M')
+    };
+    let fontset_base_face = face_table.resolve("default");
+    Ok(
+        resolve_font_match(eval, frame_id, character, &face, &fontset_base_face)
+            .and_then(|matched| font_name_value(&opened_font_from_resolved_match(&face, &matched)))
+            .unwrap_or(Value::NIL),
+    )
 }
 
 /// `(internal-face-x-get-resource RESOURCE CLASS FRAME)` -- validate arguments and

--- a/crates/neovm-core/src/emacs_core/display/xfaces/tests/builtins.rs
+++ b/crates/neovm-core/src/emacs_core/display/xfaces/tests/builtins.rs
@@ -1605,9 +1605,37 @@ fn face_font_eval_returns_font_name_on_live_gui_frame() {
     frame.char_width = 8.0;
     frame.char_height = 16.0;
 
+    // A GUI frame alone cannot supply a realized font. Its host opens a
+    // distinct 14px face here, so fabricated 16px frame metrics cannot pass.
+    install_font_at_display_host(&mut eval, "Test Mono");
     let result = builtin_face_font(&mut eval, vec![Value::symbol("default")]).unwrap();
     assert!(result.is_string());
     assert!(result.as_utf8_str().is_some_and(|name| !name.is_empty()));
+    let spec = font_spec(vec![Value::keyword("name"), result]).unwrap();
+    assert_eq!(
+        font_get(vec![spec, Value::keyword("size")])
+            .unwrap()
+            .as_int(),
+        Some(14)
+    );
+    assert_eq!(
+        font_get(vec![spec, Value::keyword("family")])
+            .unwrap()
+            .as_symbol_name(),
+        Some("Test Mono")
+    );
+}
+
+#[test]
+fn face_font_returns_nil_when_the_host_cannot_realize_the_face() {
+    let mut eval = Context::new();
+    ensure_selected_gui_frame(&mut eval);
+    eval.set_display_host(Box::new(LiveFrameFontDisplayHost { realized: None }));
+    assert!(
+        builtin_face_font(&mut eval, vec![Value::symbol("default")])
+            .unwrap()
+            .is_nil()
+    );
 }
 
 #[test]

--- a/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
+++ b/crates/neovm-core/src/emacs_core/runtime/eval/mod.rs
@@ -23,9 +23,9 @@ use super::command_observation::{
 use super::custom::CustomManager;
 use super::debug_on_call::DebugOnCallCode;
 pub use super::display_host::{
-    DisplayHost, FrameFontRequest, FrameFontSize, GraphicalFaceAttribute, TerminalCreateRequest,
-    TerminalDisplayTarget, TerminalFloatPlacement, TerminalGridSize, TerminalId,
-    XwidgetScriptRequestId,
+    DisplayHost, FontOpeningSize, FrameFontRequest, FrameFontSize, GraphicalFaceAttribute,
+    TerminalCreateRequest, TerminalDisplayTarget, TerminalFloatPlacement, TerminalGridSize,
+    TerminalId, XwidgetScriptRequestId,
 };
 use super::error::*;
 use super::interactive::InteractiveRegistry;
@@ -2179,6 +2179,7 @@ pub struct GuiFrameHostSize {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FontSpecResolveRequest {
+    pub selection: FontSpecSelection,
     pub frame_id: crate::window::FrameId,
     pub family: Option<crate::heap_types::LispString>,
     pub registry: Option<crate::heap_types::LispString>,
@@ -2186,6 +2187,16 @@ pub struct FontSpecResolveRequest {
     pub weight: Option<FontWeight>,
     pub slant: Option<FontSlant>,
     pub width: Option<FontWidth>,
+}
+
+/// GNU separates entity listing/selection from the font driver's `match`
+/// operation. A driver match is authoritative, not another style-filtered
+/// list (notably, ftfont_match deliberately omits Fontconfig style fields).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FontSpecSelection {
+    #[default]
+    Enumerate,
+    DriverMatch,
 }
 
 /// One exact opened font shared by layout, frame geometry, and Lisp font
@@ -2391,7 +2402,7 @@ pub struct FontPxProbeResult {
 /// A native entity is not necessarily file-backed: CoreText can identify an
 /// exact face by PostScript name and provide its metrics without exposing a
 /// path that a portable parser can reopen.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FontEntityMetricsRequest {
     pub frame_id: crate::window::FrameId,
     pub family: Option<crate::heap_types::LispString>,
@@ -2401,7 +2412,7 @@ pub struct FontEntityMetricsRequest {
     pub weight: Option<FontWeight>,
     pub slant: Option<FontSlant>,
     pub width: Option<FontWidth>,
-    pub pixel_size: u32,
+    pub size: FontOpeningSize,
 }
 
 /// Complete native answer for `font-info` on a font entity.


### PR DESCRIPTION
## Summary

Correct the oversized SVG tag text reported in #360 by reporting metrics from the requested opened font instead of substituting frame metrics.

- Follow GNU `Ffont_info`, `font_open_by_spec`, `font_pixel_size`, `Fface_font`, and `ftfont_match` semantics.
- Use `FontInfoTarget`, `FontOpeningSize`, and `FontSpecSelection` enums to distinguish input kinds, point/pixel/default sizing, and native driver matching versus enumeration.
- Return realized, frame-local font names from `face-font`, so `window-font-*` reopens the correct font rather than interpreting face height in tenths of points as an XLFD pixel size.
- Extend the live GNU GUI oracle for named fonts, specs/entities, DPI conversion, frame-local faces, unavailable fonts, and SVG tag construction. Existing assertions remain intact.

## Reproduction and TDD

Studied GNU Emacs 31.1 source first. Reproduced the original `svg-tag-mode` configuration and observed the regression fail before the fix, including with an optimized pre-change executable. At approximately 96 DPI, `IBM Plex Mono-7` incorrectly reported a 21px frame font instead of GNU's 9px opened font. After the fix, the tested named-font metrics and window-font metrics match GNU exactly.

## Validation

Validation was performed before the four newer main commits, against base `a845c57b0` plus this change:

- `cargo xtask fresh-build --release`: passed, including matched runtime images and Lisp bytecode.
- `cargo fmt --all --check`: passed.
- `cargo check --workspace --all-targets`: passed.
- Core/layout tests: 12,120 passed, 25 failures reproduced without this change; 56 skipped.
- GUI suite, driving the finished **release editor** with dev-mode test harnesses: 21 passed, 4 failures reproduced with the pre-change release executable.
- The new GNU SVG/font oracle and resize-presentation test pass with the fixed release editor.

The four baseline GUI failures are the oversized-xwidget test and the three existing font-selection oracles (result structure, italic entity order, and semi-light tie). The latest main already includes a byte-boolean-vars test update and bootstrap-cache fingerprinting changes; the counts above are historical validation results, not a claim about current main.

## Remaining limitation

The original package still exposes a separate fractional SVG image-sizing difference: Neomacs reports 69×24 where GNU reports 68×23. This change fixes the oversized text and its font metrics; it does not claim complete pixel parity or change the image-scaling policy.

Refs #360.
