### PR TITLE
fix(tty): link the library that actually defines the termcap symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3736,10 +3736,10 @@ dependencies = [
  "neomacs-display-protocol",
  "neomacs-display-runtime",
  "neomacs-layout-engine",
+ "neomacs-terminfo",
  "neomacs-video-model",
  "neomacs-webview",
  "neovm-core",
- "pkg-config",
  "rustix 1.1.4",
  "serde",
  "serde_json",
@@ -3978,6 +3978,15 @@ dependencies = [
  "tracing-test",
  "wgpu",
  "wgpu-hal",
+]
+
+[[package]]
+name = "neomacs-terminfo"
+version = "0.0.17"
+dependencies = [
+ "pkg-config",
+ "regex",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/neomacs",
+    "crates/neomacs-terminfo",
     "crates/neomacs-allocator",
     "crates/neomacs-diagnostics",
     "crates/neomacs-display-protocol",
@@ -85,6 +86,7 @@ unsafe_op_in_unsafe_fn = "warn"
 
 [workspace.dependencies]
 # Internal crates
+neomacs-terminfo = { path = "crates/neomacs-terminfo" }
 neomacs-allocator = { path = "crates/neomacs-allocator" }
 neovm-core = { path = "crates/neovm-core", default-features = false }
 neovm-host-abi = { path = "crates/neovm-host-abi" }
@@ -322,6 +324,7 @@ static_assertions = "1.1"
 which = "7.0"
 bindgen = "0.72"
 pkg-config = "0.3"
+regex = "1.12"
 
 # OS pipe
 os_pipe = "1.2.3"

--- a/crates/neomacs-display-protocol/src/tty_capabilities.rs
+++ b/crates/neomacs-display-protocol/src/tty_capabilities.rs
@@ -157,7 +157,7 @@ pub enum TtyItalicRendition<'a> {
 /// terminfo library.
 ///
 /// Nothing in this crate can expand a terminfo format string: the expander IS
-/// ncurses' `tparm`, and only `neomacs-bin` links it.  A parameterized
+/// ncurses' `tparm`, linked and guarded by `neomacs-terminfo`.  A parameterized
 /// capability string is inert without one, which is why the two travel
 /// together and [`TtyColorCapabilities`] has no constructor that takes a
 /// string alone.  Re-implementing terminfo's stack language on the display

--- a/crates/neomacs-terminfo/Cargo.toml
+++ b/crates/neomacs-terminfo/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "neomacs-terminfo"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Owned terminal capability snapshots and numeric expansion"
+links = "neomacs_terminfo"
+
+[dependencies]
+regex.workspace = true
+
+[build-dependencies]
+pkg-config.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/neomacs-terminfo/README.md
+++ b/crates/neomacs-terminfo/README.md
@@ -1,0 +1,34 @@
+# neomacs-terminfo
+
+Private safe interface to ncurses capability snapshots and numeric expansion.
+Editor policy stays in `neomacs`. Only `src/native.rs` permits unsafe code.
+
+`Database::load` copies requested values under the same lock used for expansion.
+Snapshots own their bytes; ncurses owns its terminal cache. `expand_numeric`
+validates a conservative numeric grammar with regex, then calls native tparm
+with nine C long arguments. It rejects string-consuming directives. Native
+variables follow the current ncurses terminal context, not individual snapshots.
+This crate must be the sole owner of ncurses access in the process.
+
+Builds use pkg-config on Linux/macOS. Direct consumers can read
+`DEP_NEOMACS_TERMINFO_RUNTIME_LIBDIRS` in their build script to preserve runtime
+search paths. The fallback without pkg-config assumes an unsplit native library.
+Other platforms return `UnsupportedPlatform`.
+
+Validation (requires ncurses development libraries, tic, and cargo-nextest):
+
+```sh
+cargo nextest run -p neomacs-terminfo --locked
+python3 crates/neomacs-terminfo/tests/linkage.py
+```
+
+See [design](../../docs/design/neomacs-terminfo-decision.md) and
+[native contracts and research](../../docs/design/terminfo-native-research.md).
+
+Numeric division and remainder require an immediately preceding nonnegative
+literal divisor, such as `%{256}%/`. Computed divisors are rejected because
+native signed division can trap on INT_MIN / -1. Constants are validated on
+directive boundaries so escaped literal text is preserved.
+
+Division programs also have a conservative total-push limit to ensure the
+literal divisor fits ncurses' stack (19 explicit or 10 implicit pushes).

--- a/crates/neomacs-terminfo/build.rs
+++ b/crates/neomacs-terminfo/build.rs
@@ -1,0 +1,34 @@
+#![forbid(unsafe_code)]
+
+fn main() {
+    let target = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let candidates: &[&str] = match target.as_str() {
+        "linux" => &["ncursesw", "ncurses"],
+        "macos" => &["ncurses", "ncursesw"],
+        _ => return,
+    };
+    for name in candidates {
+        if let Ok(library) = pkg_config::Config::new().probe(name) {
+            // This crate's own test executables also need non-system libraries
+            // at runtime. These flags do not propagate to consumer executables.
+            for path in &library.link_paths {
+                println!("cargo:rustc-link-arg=-Wl,-rpath,{}", path.display());
+            }
+            // Native libraries belong to this library target. Executable rpaths
+            // are packaging policy: convey paths to direct consumers via links
+            // metadata instead of assuming link-arg propagates through an rlib.
+            let paths = std::env::join_paths(library.link_paths)
+                .expect("ncurses library paths must be representable in a search path");
+            println!("cargo:runtime_libdirs={}", paths.to_string_lossy());
+            return;
+        }
+    }
+    println!("cargo:rustc-link-lib={}", candidates[0]);
+    println!(
+        "cargo:warning=pkg-config could not describe ncurses (tried {}); \
+         assuming unsplit -l{}. Install ncurses development files and pkg-config \
+         if linking fails with undefined termcap/terminfo symbols.",
+        candidates.join(", "),
+        candidates[0]
+    );
+}

--- a/crates/neomacs-terminfo/src/lib.rs
+++ b/crates/neomacs-terminfo/src/lib.rs
@@ -1,0 +1,110 @@
+//! Terminal capabilities without native handles or borrowed native buffers.
+//!
+//! Load a finite set of queries into an owned snapshot. All ncurses operations
+//! are serialized, including copying their results. This crate must be the only
+//! owner of ncurses access in the process; independent FFI callers cannot share
+//! its lock. No terminal I/O, renderer policy, or environment mutation occurs.
+#![deny(unsafe_code)]
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+mod numeric;
+pub use numeric::expand_numeric;
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[allow(unsafe_code)]
+mod native;
+
+/// String names occupy distinct namespaces: `us` is termcap, `smul` terminfo.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StringCapability<'a> {
+    Termcap(&'a str),
+    Terminfo(&'a str),
+}
+
+/// Boolean names also have distinct namespaces (`RGB` is terminfo).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FlagCapability<'a> {
+    Termcap(&'a str),
+    Terminfo(&'a str),
+}
+
+/// The values a caller wants to retain from a terminal entry.
+#[derive(Clone, Copy, Debug)]
+pub enum Query<'a> {
+    String(StringCapability<'a>),
+    TermcapNumber(&'a str),
+    Flag(FlagCapability<'a>),
+}
+
+/// Loading/expansion failures are distinct from missing individual capabilities.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Error {
+    UnsupportedPlatform,
+    InvalidName,
+    TerminalNotFound,
+    DatabaseUnavailable,
+    InvalidNumericFormat,
+    NativeStatePoisoned,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::UnsupportedPlatform => "terminfo is unavailable on this platform",
+            Self::InvalidName => "terminal or capability name is empty or contains NUL",
+            Self::TerminalNotFound => "terminal entry was not found",
+            Self::DatabaseUnavailable => "terminfo database could not be opened",
+            Self::InvalidNumericFormat => "unsupported or malformed numeric terminfo format",
+            Self::NativeStatePoisoned => "native terminfo state was interrupted by a panic",
+        })
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// A Rust-owned snapshot. Reading it never touches ncurses or another entry.
+/// Queries not requested at load time return the same absence as missing values.
+#[derive(Clone, Debug, Default)]
+pub struct Database {
+    termcap_strings: BTreeMap<String, Vec<u8>>,
+    terminfo_strings: BTreeMap<String, Vec<u8>>,
+    numbers: BTreeMap<String, i32>,
+    termcap_flags: BTreeMap<String, bool>,
+    terminfo_flags: BTreeMap<String, bool>,
+}
+
+impl Database {
+    pub fn load(term: &str, queries: &[Query<'_>]) -> Result<Self, Error> {
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        {
+            native::load(term, queries)
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            let _ = (term, queries);
+            Err(Error::UnsupportedPlatform)
+        }
+    }
+
+    pub fn string(&self, capability: StringCapability<'_>) -> Option<&[u8]> {
+        let (map, name) = match capability {
+            StringCapability::Termcap(name) => (&self.termcap_strings, name),
+            StringCapability::Terminfo(name) => (&self.terminfo_strings, name),
+        };
+        map.get(name).map(Vec::as_slice)
+    }
+
+    pub fn termcap_number(&self, name: &str) -> Option<i32> {
+        self.numbers.get(name).copied()
+    }
+
+    pub fn flag(&self, capability: FlagCapability<'_>) -> bool {
+        let (map, name) = match capability {
+            FlagCapability::Termcap(name) => (&self.termcap_flags, name),
+            FlagCapability::Terminfo(name) => (&self.terminfo_flags, name),
+        };
+        map.get(name).copied().unwrap_or(false)
+    }
+}

--- a/crates/neomacs-terminfo/src/native.rs
+++ b/crates/neomacs-terminfo/src/native.rs
@@ -1,0 +1,141 @@
+//! The complete unsafe surface. ncurses owns/caches the selected terminal;
+//! Rust owns only snapshots. See README.md for native contracts and validation.
+use std::ffi::{CStr, CString, c_char, c_int, c_long, c_void};
+use std::sync::Mutex;
+
+use crate::{Database, Error, FlagCapability, Query, StringCapability};
+
+static NATIVE: Mutex<()> = Mutex::new(());
+
+unsafe extern "C" {
+    fn tgetent(buffer: *mut c_char, term: *const c_char) -> c_int;
+    fn tgetstr(name: *const c_char, area: *mut *mut c_char) -> *mut c_char;
+    fn tigetstr(name: *const c_char) -> *mut c_char;
+    fn tgetnum(name: *const c_char) -> c_int;
+    fn tgetflag(name: *const c_char) -> c_int;
+    fn tigetflag(name: *const c_char) -> c_int;
+    fn set_curterm(term: *mut c_void) -> *mut c_void;
+    fn tparm(format: *const c_char, ...) -> *mut c_char;
+}
+
+fn name(value: &str) -> Result<CString, Error> {
+    if value.is_empty() {
+        return Err(Error::InvalidName);
+    }
+    CString::new(value).map_err(|_| Error::InvalidName)
+}
+
+pub(super) fn load(term: &str, queries: &[Query<'_>]) -> Result<Database, Error> {
+    let term = name(term)?;
+    let names = queries
+        .iter()
+        .map(|query| {
+            name(match query {
+                Query::String(StringCapability::Termcap(n) | StringCapability::Terminfo(n))
+                | Query::TermcapNumber(n)
+                | Query::Flag(FlagCapability::Termcap(n) | FlagCapability::Terminfo(n)) => n,
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let _guard = NATIVE.lock().map_err(|_| Error::NativeStatePoisoned)?;
+    // SAFETY: this crate exclusively owns ncurses access under NATIVE. Detach
+    // the previous current terminal so tgetent does not reuse it. Its cache
+    // still owns that allocation and reclaims it on the next tgetent, including
+    // failure. Reusing the null buffer selects the same bounded cache slot.
+    // Do not del_curterm: that would leave tgetent's cache with a dangling owner.
+    // ncurses ignores the buffer (this is not a generic BSD termcap binding).
+    let status = unsafe {
+        set_curterm(std::ptr::null_mut());
+        tgetent(std::ptr::null_mut(), term.as_ptr())
+    };
+    match status {
+        1 => {}
+        0 => return Err(Error::TerminalNotFound),
+        _ => return Err(Error::DatabaseUnavailable),
+    }
+    let mut result = Database::default();
+    for (query, name) in queries.iter().zip(&names) {
+        match query {
+            Query::String(capability) => {
+                let (map, key, raw) = match capability {
+                    StringCapability::Termcap(key) => {
+                        // SAFETY: NUL-terminated name, active terminal, and
+                        // exclusive access. NULL area prevents unbounded writes
+                        // to a caller buffer; ncurses retains the returned data.
+                        let raw = unsafe { tgetstr(name.as_ptr(), std::ptr::null_mut()) };
+                        (&mut result.termcap_strings, key, raw)
+                    }
+                    StringCapability::Terminfo(key) => {
+                        // SAFETY: same name/state invariants as above.
+                        let raw = unsafe { tigetstr(name.as_ptr()) };
+                        (&mut result.terminfo_strings, key, raw)
+                    }
+                };
+                if raw.is_null() || raw as isize == -1 {
+                    continue;
+                }
+                // SAFETY: successful string lookup returns a NUL-terminated
+                // allocation, valid until another native operation changes it.
+                // The shared lock stays held through copying into owned bytes.
+                let value = unsafe { CStr::from_ptr(raw) }.to_bytes().to_vec();
+                map.insert((*key).to_owned(), value);
+            }
+            Query::TermcapNumber(key) => {
+                // SAFETY: valid name and active terminal under NATIVE.
+                let value = unsafe { tgetnum(name.as_ptr()) };
+                if value >= 0 {
+                    result.numbers.insert((*key).to_owned(), value);
+                }
+            }
+            Query::Flag(capability) => {
+                let (map, key, value) = match capability {
+                    FlagCapability::Termcap(key) => {
+                        // SAFETY: valid name and active terminal under NATIVE.
+                        (&mut result.termcap_flags, key, unsafe {
+                            tgetflag(name.as_ptr())
+                        })
+                    }
+                    FlagCapability::Terminfo(key) => {
+                        // SAFETY: same invariants; -1 means invalid name, not true.
+                        (&mut result.terminfo_flags, key, unsafe {
+                            tigetflag(name.as_ptr())
+                        })
+                    }
+                };
+                map.insert((*key).to_owned(), value > 0);
+            }
+        }
+    }
+    Ok(result)
+}
+
+// Only numeric.rs calls this function, after checking every directive (including
+// branches that are not taken). It is not part of the crate's public interface.
+pub(super) fn expand(format: &CStr, parameters: [i32; 9]) -> Result<Vec<u8>, Error> {
+    let _guard = NATIVE.lock().map_err(|_| Error::NativeStatePoisoned)?;
+    let p = parameters.map(c_long::from);
+    // SAFETY: the caller's complete numeric grammar excludes all conversions
+    // and operations that consume strings. Thus ncurses' parameter analysis
+    // cannot fetch a pointer from these nine C long slots. The format is live
+    // and NUL-terminated, and NATIVE protects state until the result is copied.
+    let raw = unsafe {
+        tparm(
+            format.as_ptr(),
+            p[0],
+            p[1],
+            p[2],
+            p[3],
+            p[4],
+            p[5],
+            p[6],
+            p[7],
+            p[8],
+        )
+    };
+    if raw.is_null() {
+        return Err(Error::InvalidNumericFormat);
+    }
+    // SAFETY: non-null tparm output is a NUL-terminated native buffer; no other
+    // native operation can reuse/free it while NATIVE is held.
+    Ok(unsafe { CStr::from_ptr(raw) }.to_bytes().to_vec())
+}

--- a/crates/neomacs-terminfo/src/numeric.rs
+++ b/crates/neomacs-terminfo/src/numeric.rs
@@ -1,0 +1,87 @@
+//! Numeric argument validation, not another terminfo interpreter.
+use crate::Error;
+use regex::bytes::Regex;
+use std::ffi::CString;
+use std::sync::LazyLock;
+
+// Recognize complete directives, including printf flags, before calling C.
+// In particular %s, %:10.2s and %l must never make numeric slots into pointers.
+// The grammar uses the mature regex engine; ncurses still interprets programs.
+// Numeric constants are additionally checked against the native signed domain.
+// Division/remainder are accepted only as part of an immediately preceding
+// nonnegative literal constant token. This excludes native INT_MIN / -1 traps
+// even when the program computes its operands. ncurses handles a zero divisor.
+static TOKEN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?x-u)(?:
+    [^%\x00]+ | %% | %[i+*&|^=><AO!~?te;-]
+    | %p[1-9] | %[Pg][a-zA-Z] | %'[^\x00]'
+    | %\{(?P<constant>[0-9]{1,10})\}(?:%[/m])?
+    | %(?::[-\x20\#]*)?[\x20\#]*(?:[0-9]{0,4}|10000)
+        (?:\.(?:[0-9]{1,4}|10000))?[doxXc]
+)",
+    )
+    .expect("fixed numeric terminfo grammar")
+});
+/// Expand a numeric terminfo program with nine signed parameter slots.
+///
+/// Native variable state is preserved across calls, as in GNU's tparam wrapper.
+/// Loading another entry selects ncurses' current terminal state. Each complete
+/// expansion and result copy is serialized with database loading.
+///
+/// String-consuming directives and malformed/unsupported numeric syntax return
+/// an error before the native call. This is a conservative numeric subset, not
+/// a general string-parameter tparm interface. Division/remainder require an
+/// immediately preceding nonnegative literal divisor (`%{256}%/`, for example).
+/// Computed divisors are unsupported. The interpreter remains ncurses.
+pub fn expand_numeric(sequence: &[u8], parameters: [i32; 9]) -> Result<Vec<u8>, Error> {
+    let mut end = 0;
+    let mut pushes = 0;
+    let mut explicit_parameters = false;
+    let mut division = false;
+    for token in TOKEN.captures_iter(sequence) {
+        let matched = token.get(0).expect("a capture has a full match");
+        if matched.start() != end {
+            return Err(Error::InvalidNumericFormat);
+        }
+        end = matched.end();
+        let directive = matched.as_bytes();
+        explicit_parameters |= directive.starts_with(b"%p");
+        pushes += usize::from(matches!(
+            directive.get(..2),
+            Some(b"%p" | b"%g" | b"%\'" | b"%{")
+        ));
+        division |= directive.starts_with(b"%{")
+            && (directive.ends_with(b"%/") || directive.ends_with(b"%m"));
+        if let Some(constant) = token.name("constant")
+            && std::str::from_utf8(constant.as_bytes())
+                .ok()
+                .and_then(|s| s.parse::<i32>().ok())
+                .is_none()
+        {
+            return Err(Error::InvalidNumericFormat);
+        }
+    }
+    if end != sequence.len() {
+        return Err(Error::InvalidNumericFormat);
+    }
+    // ncurses has 20 stack slots and drops pushes on overflow. A dropped
+    // literal could invalidate our divisor guarantee. Count every possible
+    // push across all branches, reserving space for up to nine implicit
+    // termcap parameters when no %p directive occurs. Arithmetic cannot grow
+    // a nonempty stack. This deliberately rejects unusually large programs.
+    let push_limit = if explicit_parameters { 19 } else { 10 };
+    if division && pushes > push_limit {
+        return Err(Error::InvalidNumericFormat);
+    }
+    let format = CString::new(sequence).map_err(|_| Error::InvalidNumericFormat)?;
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        crate::native::expand(&format, parameters)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = (format, parameters);
+        Err(Error::UnsupportedPlatform)
+    }
+}

--- a/crates/neomacs-terminfo/tests/capabilities.rs
+++ b/crates/neomacs-terminfo/tests/capabilities.rs
@@ -1,0 +1,219 @@
+#![forbid(unsafe_code)]
+#![cfg(any(target_os = "linux", target_os = "macos"))]
+
+use neomacs_terminfo::{Database, Error, FlagCapability, Query, StringCapability, expand_numeric};
+
+fn params(values: &[i32]) -> [i32; 9] {
+    let mut result = [0; 9];
+    result[..values.len()].copy_from_slice(values);
+    result
+}
+
+#[test]
+fn numeric_formats_match_gnu_rendering_inputs() {
+    for (format, values, expected) in [
+        (
+            b"\x1b[4:%p1%dm".as_slice(),
+            vec![3],
+            b"\x1b[4:3m".as_slice(),
+        ),
+        // GNU term.c deliberately includes an unmatched %; in its Tc literal.
+        (
+            b"\x1b[38;2;%p1%d;%p2%d;%p3%d%;m",
+            vec![17, 34, 51],
+            b"\x1b[38;2;17;34;51m",
+        ),
+        (
+            b"%p1%{65536}%/%d;%p1%{256}%/%{255}%&%d;%p1%{255}%&%d",
+            vec![0x123456],
+            b"18;52;86",
+        ),
+        (b"%?%p1%{8}%<%t3%p1%d%e38;5;%p1%d%;", vec![123], b"38;5;123"),
+        (b"%p1%!%d", vec![-1], b"0"),
+        (b"%p1%p2%A%d", vec![-1, 1], b"1"),
+        (b"%p1%{0}%/%d", vec![1], b"0"),
+        (b"%p1%{256}%m%d", vec![257], b"1"),
+        (b"%%{2147483648}", vec![], b"%{2147483648}"),
+        (b"%p1%{1}%+%d", vec![i32::MAX], b"-2147483648"),
+        (b"$%p1%d$<5>", vec![3], b"$3$<5>"),
+        (b"%p9%d", vec![0, 0, 0, 0, 0, 0, 0, 0, 9], b"9"),
+    ] {
+        assert_eq!(
+            expand_numeric(format, params(&values)).unwrap(),
+            expected,
+            "{format:?}"
+        );
+    }
+}
+
+#[test]
+fn malformed_and_string_formats_cannot_reach_native_varargs() {
+    for format in [
+        b"%p1%s".as_slice(),
+        b"%p1%p2%/%d",
+        b"%p1%p2%m%d",
+        b"%{0}%{2147483647}%-%{1}%-%{0}%{1}%-%/%d",
+        b"%?%{0}%t%p1%s%;",
+        b"%{2147483648}%/%d",
+        b"%p1%:10.2s",
+        b"%p1%l%d",
+        b"%p0%d",
+        b"%p",
+        b"%{",
+        b"%",
+        b"a\0b",
+        b"%p1%999999999999999999999999d",
+    ] {
+        assert_eq!(
+            expand_numeric(format, params(&[1])),
+            Err(Error::InvalidNumericFormat),
+            "{format:?}"
+        );
+    }
+}
+
+#[test]
+fn division_requires_room_for_the_literal_divisor() {
+    let mut format = b"%p1".repeat(20);
+    format.extend_from_slice(b"%{256}%/%d");
+    assert_eq!(
+        expand_numeric(&format, [0; 9]),
+        Err(Error::InvalidNumericFormat)
+    );
+}
+
+#[test]
+fn native_variables_work_within_numeric_programs() {
+    assert_eq!(
+        expand_numeric(b"%p1%PA%gA%d", params(&[42])).unwrap(),
+        b"42"
+    );
+}
+
+#[test]
+fn concurrent_expansion_preserves_owned_output() {
+    std::thread::scope(|scope| {
+        for number in 1..=8 {
+            scope.spawn(move || {
+                for _ in 0..200 {
+                    assert_eq!(
+                        expand_numeric(b"%p1%Pa%ga%d", params(&[number])).unwrap(),
+                        number.to_string().as_bytes()
+                    );
+                }
+            });
+        }
+    });
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn native_snapshots() {
+    // Launch an isolated process instead of mutating TERMINFO while Rust test
+    // threads run. Missing tic or malformed fixtures fail explicitly.
+    if std::env::var_os("NEOMACS_TERMINFO_FIXTURE_CHILD").is_none() {
+        let directory = tempfile::tempdir().unwrap();
+        let tic = std::process::Command::new("tic")
+            .args(["-x", "-o"])
+            .arg(directory.path())
+            .arg(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/tests/fixtures/terminals.src"
+            ))
+            .output()
+            .expect("ncurses tic is required for the fixture tests");
+        assert!(
+            tic.status.success(),
+            "{}",
+            String::from_utf8_lossy(&tic.stderr)
+        );
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", "native_snapshots", "--nocapture"])
+            .env("NEOMACS_TERMINFO_FIXTURE_CHILD", "1")
+            .env("TERMINFO", directory.path())
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return;
+    }
+    use StringCapability::{Termcap, Terminfo};
+    let mut queries = vec![
+        Query::String(Termcap("md")),
+        Query::String(Termcap("me")),
+        Query::String(Terminfo("sgr0")),
+        Query::String(Termcap("us")),
+        Query::String(Terminfo("Smulx")),
+        Query::String(Terminfo("smxx")),
+        Query::String(Terminfo("colors")), // Wrong type: (char *) -1.
+        Query::TermcapNumber("Co"),
+        Query::TermcapNumber("NC"),
+        Query::Flag(FlagCapability::Terminfo("RGB")),
+        Query::Flag(FlagCapability::Terminfo("Tc")),
+        Query::Flag(FlagCapability::Terminfo("colors")), // Wrong type: -1.
+        Query::Flag(FlagCapability::Termcap("Su")),
+    ];
+    // Native reads total more than the old fixed 32KiB tgetstr arena.
+    queries.extend(std::iter::repeat_n(Query::String(Termcap("md")), 2000));
+    let first = Database::load("neo-pr363-a", &queries).unwrap();
+    let second = Database::load("neo-pr363-b", &queries).unwrap();
+    assert_eq!(
+        first.string(Termcap("md")),
+        Some(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".as_slice())
+    );
+    assert_eq!(second.string(Termcap("md")), Some(b"BBBB".as_slice()));
+    // ncurses removes the alternate-character-set reset for termcap me.
+    assert_eq!(first.string(Termcap("me")), Some(b"\x1b[0m".as_slice()));
+    assert_eq!(
+        first.string(Terminfo("sgr0")),
+        Some(b"\x1b[m\x0f".as_slice())
+    );
+    assert_eq!(first.termcap_number("Co"), Some(256));
+    assert_eq!(second.termcap_number("Co"), Some(8));
+    assert_eq!(
+        first.string(Terminfo("Smulx")),
+        Some(b"\x1b[4:%p1%dm".as_slice())
+    );
+    assert_eq!(second.string(Terminfo("Smulx")), None);
+    assert_eq!(second.string(Termcap("us")), None);
+    assert!(first.flag(FlagCapability::Terminfo("RGB")));
+    assert!(first.flag(FlagCapability::Terminfo("Tc")));
+    assert!(first.flag(FlagCapability::Termcap("Su")));
+    assert!(!first.flag(FlagCapability::Terminfo("colors")));
+    assert_eq!(first.string(Terminfo("colors")), None);
+    assert!(matches!(
+        Database::load("", &queries),
+        Err(Error::InvalidName)
+    ));
+    assert!(matches!(
+        Database::load("bad\0name", &queries),
+        Err(Error::InvalidName)
+    ));
+    for _ in 0..30 {
+        assert!(matches!(
+            Database::load("neo-pr363-does-not-exist", &queries),
+            Err(Error::TerminalNotFound)
+        ));
+        assert_eq!(
+            Database::load("neo-pr363-a", &queries)
+                .unwrap()
+                .termcap_number("Co"),
+            Some(256)
+        );
+    }
+    std::thread::scope(|scope| {
+        for (name, colors) in [("neo-pr363-a", 256), ("neo-pr363-b", 8)] {
+            let queries = &queries;
+            scope.spawn(move || {
+                for _ in 0..20 {
+                    let database = Database::load(name, queries).unwrap();
+                    assert_eq!(database.termcap_number("Co"), Some(colors));
+                }
+            });
+        }
+    });
+}

--- a/crates/neomacs-terminfo/tests/fixtures/terminals.src
+++ b/crates/neomacs-terminfo/tests/fixtures/terminals.src
@@ -1,0 +1,12 @@
+# Deterministic ncurses entries for snapshot and namespace tests.
+neo-pr363-a|Neomacs terminfo fixture A,
+	am, bce, colors#256, ncv#3,
+	bold=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+	smul=\E[4m, sgr0=\E[m^O, smacs=^N, rmacs=^O,
+	sgr=\E[0%?%p1%p6%|%t;1%;%?%p2%t;4%;%?%p1%p3%|%t;7%;%?%p4%t;5%;m%?%p9%t\016%e\017%;,
+	setaf=\E[38;5;%p1%dm,
+	Smulx=\E[4:%p1%dm, smxx=\E[9m,
+	RGB, Tc, Su,
+neo-pr363-b|Neomacs terminfo fixture B,
+	colors#8, bold=BBBB,
+	smul@, Smulx@,

--- a/crates/neomacs-terminfo/tests/linkage.py
+++ b/crates/neomacs-terminfo/tests/linkage.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Linux Cargo linkage regression: split/unsplit and shared/static ncurses.
+
+Run from the repository: python3 crates/neomacs-terminfo/tests/linkage.py
+Uses isolated miniature consumers, real Cargo/rustc/linker invocations, and
+synthetic native libraries. No environment or files in the caller are changed.
+"""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+CRATE = Path(__file__).resolve().parents[1]
+
+
+def run(args, directory, env=None):
+    result = subprocess.run(args, cwd=directory, env=env, capture_output=True, text=True)
+    if result.returncode:
+        raise RuntimeError(f"{' '.join(map(str, args))}\n{result.stdout}\n{result.stderr}")
+    return result.stdout
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix="neomacs-linkage-") as temp:
+        root = Path(temp)
+        for split in (False, True):
+            for static in (False, True):
+                case = root / f"{'split' if split else 'unsplit'}-{'static' if static else 'shared'}"
+                case.mkdir()
+                lib = case / "native"
+                lib.mkdir()
+                (lib / "terminfo.c").write_text('''
+int tgetent(char *buffer, const char *term) { return 1; }
+void *set_curterm(void *term) { return 0; }
+char *tgetstr(const char *name, char **area) { return "fixture"; }
+char *tigetstr(const char *name) { return "fixture"; }
+int tgetnum(const char *name) { return 256; }
+int tgetflag(const char *name) { return 1; }
+int tigetflag(const char *name) { return 1; }
+char *tparm(const char *format, ...) { return "expanded"; }
+''')
+                (lib / "empty.c").write_text("int ncurses_placeholder(void) { return 0; }\n")
+                names = [("ncursesw", "empty" if split else "terminfo")]
+                if split:
+                    names.append(("tinfow", "terminfo"))
+                for name, source in names:
+                    obj = lib / f"{source}.o"
+                    run(["cc", "-fPIC", "-c", str(lib / f"{source}.c"), "-o", str(obj)], case)
+                    if static:
+                        run(["ar", "crs", str(lib / f"lib{name}.a"), str(obj)], case)
+                    else:
+                        run(["cc", "-shared", str(obj), "-o", str(lib / f"lib{name}.so")], case)
+                flags = " ".join(f"-l{name}" for name, _ in names)
+                (lib / "ncursesw.pc").write_text(
+                    f"Name: ncursesw\nDescription: synthetic linkage fixture\nVersion: 6.6\nLibs: -L{lib} {flags}\n"
+                )
+                (case / "Cargo.toml").write_text(
+                    '[package]\nname="link-consumer"\nversion="0.0.0"\nedition="2024"\n'
+                    f'[dependencies]\nneomacs-terminfo={{path={json.dumps(str(CRATE))}}}\n[workspace]\n'
+                )
+                (case / "build.rs").write_text('''
+fn main() {
+    if let Some(paths) = std::env::var_os("DEP_NEOMACS_TERMINFO_RUNTIME_LIBDIRS") {
+        for path in std::env::split_paths(&paths) {
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{}", path.display());
+        }
+    }
+}
+''')
+                (case / "src").mkdir()
+                (case / "src/lib.rs").write_text('#[path="main.rs"] pub mod startup;\n')
+                (case / "src/main.rs").write_text('''
+use neomacs_terminfo::{Database, Query, StringCapability};
+fn main() {
+    assert_eq!(neomacs_terminfo::expand_numeric(b"%p1%d", [0; 9]).unwrap(), b"expanded");
+    let db = Database::load("fixture", &[Query::String(StringCapability::Termcap("md"))]).unwrap();
+    assert_eq!(db.string(StringCapability::Termcap("md")), Some(b"fixture".as_slice()));
+}
+#[test] fn native_dependency() { main(); }
+''')
+                env = dict(os.environ, PKG_CONFIG_LIBDIR=str(lib), PKG_CONFIG_PATH=str(lib),
+                           CARGO_TARGET_DIR=str(case / "target"))
+                env.pop("NCURSESW_DYNAMIC", None)
+                # Ensure static metadata is exercised when requested.
+                env["NCURSESW_STATIC"] = "1" if static else "0"
+                if not static:
+                    env.pop("NCURSESW_STATIC", None)
+                    env["NCURSESW_DYNAMIC"] = "1"
+                run(["cargo", "build", "--release", "--offline"], case, env)
+                runtime_env = dict(env)
+                runtime_env.pop("LD_LIBRARY_PATH", None)
+                run([str(case / "target/release/link-consumer")], case, runtime_env)
+                run(["cargo", "nextest", "run", "--offline"], case, env)
+                print(f"{case.name}: release executable and library/binary tests passed", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/neomacs/Cargo.toml
+++ b/crates/neomacs/Cargo.toml
@@ -73,6 +73,7 @@ path = "src/bin/cmdproxy/main.rs"
 
 
 [dependencies]
+neomacs-terminfo.workspace = true
 neomacs-display-protocol.workspace = true
 neomacs-video-model.workspace = true
 neomacs-display-runtime = { workspace = true, default-features = false }
@@ -104,7 +105,6 @@ stacker.workspace = true
 rustix = { workspace = true, features = ["pty", "termios"] }
 
 [build-dependencies]
-pkg-config.workspace = true
 vergen-gitcl.workspace = true
 
 [lints]

--- a/crates/neomacs/build.rs
+++ b/crates/neomacs/build.rs
@@ -190,46 +190,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
-    let candidates: &[&str] = match target_os.as_str() {
-        "linux" => &["ncursesw", "ncurses"],
-        "macos" => &["ncurses", "ncursesw"],
-        _ => return Ok(()),
-    };
-
-    // The termcap/terminfo entry points (tgetent, tigetstr, tparm, ...) are in
-    // libtinfo(w) rather than libncurses(w) wherever ncurses is configured
-    // --with-termlib, and no linker resolves them through ncurses' transitive
-    // DT_NEEDED. pkg-config knows which layout this system has, so replay its
-    // whole answer instead of guessing a library name.
-    //
-    // These go out as `rustc-link-arg`, not `rustc-link-lib`: Cargo applies
-    // link-lib to this package's library target, but the caller
-    // (`terminal_capabilities`) is a module of the `neomacs` binary.
-    for name in candidates {
-        let Ok(library) = pkg_config::Config::new().probe(name) else {
-            continue;
-        };
-        for path in &library.link_paths {
-            println!("cargo:rustc-link-arg=-L{}", path.display());
+    // Native linkage belongs to neomacs-terminfo. Runtime lookup remains an
+    // executable packaging concern (not propagated from a dependency's rlib).
+    if let Some(paths) = env::var_os("DEP_NEOMACS_TERMINFO_RUNTIME_LIBDIRS") {
+        for path in env::split_paths(&paths) {
             println!("cargo:rustc-link-arg=-Wl,-rpath,{}", path.display());
         }
-        for lib in &library.libs {
-            println!("cargo:rustc-link-arg=-l{lib}");
-        }
-        return Ok(());
     }
-
-    // No pkg-config: link the bare ncurses name and warn, since the split
-    // cannot be detected and guessing wrong fails at the final link.
-    println!("cargo:rustc-link-lib={}", candidates[0]);
-    println!("cargo:rustc-link-arg=-l{}", candidates[0]);
-    println!(
-        "cargo:warning=pkg-config could not describe ncurses (tried: {}); \
-         linking -l{} and assuming the terminfo entry points live there. \
-         If the link fails with undefined tgetent/tigetstr/tparm, install \
-         ncurses development files and pkg-config.",
-        candidates.join(", "),
-        candidates[0]
-    );
     Ok(())
 }

--- a/crates/neomacs/build.rs
+++ b/crates/neomacs/build.rs
@@ -196,15 +196,40 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         _ => return Ok(()),
     };
 
+    // The termcap/terminfo entry points (tgetent, tigetstr, tparm, ...) are in
+    // libtinfo(w) rather than libncurses(w) wherever ncurses is configured
+    // --with-termlib, and no linker resolves them through ncurses' transitive
+    // DT_NEEDED. pkg-config knows which layout this system has, so replay its
+    // whole answer instead of guessing a library name.
+    //
+    // These go out as `rustc-link-arg`, not `rustc-link-lib`: Cargo applies
+    // link-lib to this package's library target, but the caller
+    // (`terminal_capabilities`) is a module of the `neomacs` binary.
     for name in candidates {
-        if let Ok(library) = pkg_config::Config::new().probe(name) {
-            for path in library.link_paths {
-                println!("cargo:rustc-link-arg=-Wl,-rpath,{}", path.display());
-            }
-            return Ok(());
+        let Ok(library) = pkg_config::Config::new().probe(name) else {
+            continue;
+        };
+        for path in &library.link_paths {
+            println!("cargo:rustc-link-arg=-L{}", path.display());
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{}", path.display());
         }
+        for lib in &library.libs {
+            println!("cargo:rustc-link-arg=-l{lib}");
+        }
+        return Ok(());
     }
 
+    // No pkg-config: link the bare ncurses name and warn, since the split
+    // cannot be detected and guessing wrong fails at the final link.
     println!("cargo:rustc-link-lib={}", candidates[0]);
+    println!("cargo:rustc-link-arg=-l{}", candidates[0]);
+    println!(
+        "cargo:warning=pkg-config could not describe ncurses (tried: {}); \
+         linking -l{} and assuming the terminfo entry points live there. \
+         If the link fails with undefined tgetent/tigetstr/tparm, install \
+         ncurses development files and pkg-config.",
+        candidates.join(", "),
+        candidates[0]
+    );
     Ok(())
 }

--- a/crates/neomacs/src/termcap_input.rs
+++ b/crates/neomacs/src/termcap_input.rs
@@ -97,6 +97,21 @@ const XTERM_FALLBACK_KEYS: &[(&[u8], &str)] = &[
     (b"\x1b[21~", "f10"),
 ];
 
+/// Names to snapshot before native terminal selection can change. Reuse the
+/// same key table and numbered-key generator as input-decode-map population.
+pub(crate) fn terminal_key_capabilities() -> Vec<String> {
+    FKEY_TABLE
+        .iter()
+        .map(|(cap, _)| (*cap).to_owned())
+        .chain(
+            ["k;", "k0", "kN", "kP", "kH"]
+                .into_iter()
+                .map(str::to_owned),
+        )
+        .chain((11..64).filter_map(numbered_function_key_capability))
+        .collect()
+}
+
 pub(crate) fn seed_input_decode_map_from_terminal(eval: &mut Context) {
     let Some(term) = std::env::var("TERM")
         .ok()

--- a/crates/neomacs/src/terminal_capabilities.rs
+++ b/crates/neomacs/src/terminal_capabilities.rs
@@ -23,9 +23,9 @@ use neomacs_display_protocol::tty_capabilities::{
     TtyColorDepth, TtyColorSource, TtyDirectColorRoute, TtyNoColorVideo, TtyStyledUnderline,
 };
 
+// Deliberately no `#[link]`: which library defines these varies by system, so
+// `build.rs` resolves it with pkg-config and emits the link arguments.
 #[cfg(not(windows))]
-#[cfg_attr(target_os = "linux", link(name = "ncursesw"))]
-#[cfg_attr(target_os = "macos", link(name = "ncurses"))]
 unsafe extern "C" {
     fn tgetent(buffer: *mut c_char, term: *const c_char) -> c_int;
     fn tgetstr(capability: *const c_char, area: *mut *mut c_char) -> *mut c_char;

--- a/crates/neomacs/src/terminal_capabilities.rs
+++ b/crates/neomacs/src/terminal_capabilities.rs
@@ -8,137 +8,30 @@
 //! renderer, so `:slant italic` was emitted as an italic escape even on a
 //! terminal whose terminfo has no `sitm` — where GNU emits its dim fallback.
 //!
-//! This module owns the database handle so both halves ask the same terminfo
+//! This module requests an owned snapshot so both halves ask the same terminfo
 //! entry the same way.
-
-#[cfg(not(windows))]
-use std::ffi::{CStr, CString};
-#[cfg(not(windows))]
-use std::os::raw::c_char;
-#[cfg(not(windows))]
-use std::os::raw::c_int;
 
 use neomacs_display_protocol::tty_capabilities::{
     TerminfoExpander, TerminfoParameters, TtyAttributeCapabilities, TtyColorCapabilities,
     TtyColorDepth, TtyColorSource, TtyDirectColorRoute, TtyNoColorVideo, TtyStyledUnderline,
 };
 
-// Deliberately no `#[link]`: which library defines these varies by system, so
-// `build.rs` resolves it with pkg-config and emits the link arguments.
-#[cfg(not(windows))]
-unsafe extern "C" {
-    fn tgetent(buffer: *mut c_char, term: *const c_char) -> c_int;
-    fn tgetstr(capability: *const c_char, area: *mut *mut c_char) -> *mut c_char;
-    fn tgetnum(capability: *const c_char) -> c_int;
-    fn tgetflag(capability: *const c_char) -> c_int;
-    fn tigetstr(capability: *const c_char) -> *mut c_char;
-    /// GNU's `tparam`.  In a terminfo build `src/terminfo.c:43-55` defines
-    /// `tparam` as a thin wrapper over ncurses' `tparm` with the same four
-    /// integer arguments, so calling `tparm` here is calling what GNU calls.
-    fn tparm(string: *const c_char, ...) -> *mut c_char;
-}
-
-/// GNU `tparam (STRING, NULL, 0, ...)` — the three capabilities `turn_on_face`
-/// does not emit verbatim: `Smulx`, `setaf` and `setab`.
-///
-/// One function for all three because GNU makes one call for all three, and
-/// the only thing that varies is the parameter list, which
-/// [`TerminfoParameters`] names: `Smulx` and a non-`TF_rgb_separate` colour are
-/// GNU's one-argument call (src/term.c:2083, :2103), and a `TF_rgb_separate`
-/// colour is GNU's three-argument call (src/term.c:2101).
-///
-/// `tparm` does not need a terminal to have been set up: it is a function of
-/// the string, and measured so (`tmp/pw186/tparm_nosetup.c`).  `None` when the
-/// expansion fails, which for ncurses means the string is not a well-formed
-/// terminfo format -- GNU's `OUTPUT (tty, p)` would then have been handed a
-/// null pointer, so emitting nothing is its behaviour too.
-#[cfg(not(windows))]
-pub(crate) fn expand_capability_parameter(
-    sequence: &[u8],
-    parameters: TerminfoParameters,
-) -> Option<Vec<u8>> {
-    let sequence = CString::new(sequence).ok()?;
-    let (first, second, third) = match parameters {
-        // A palette subscript can exceed `c_int` only for a value Lisp could
-        // not have produced; `try_from` refusing it is the same "not a colour"
-        // answer `TerminalColor::from_tty_color_desc` gives.
-        TerminfoParameters::One(value) => (c_int::try_from(value).ok()?, 0, 0),
-        TerminfoParameters::Rgb { r, g, b } => (c_int::from(r), c_int::from(g), c_int::from(b)),
-    };
-    let expanded = unsafe {
-        tparm(
-            sequence.as_ptr(),
-            first,
-            second,
-            third,
-            0 as c_int,
-            0 as c_int,
-            0 as c_int,
-            0 as c_int,
-            0 as c_int,
-        )
-    };
-    if expanded.is_null() {
-        return None;
+/// The safe dependency validates numeric formats before invoking ncurses.
+fn expand_capability_parameter(sequence: &[u8], parameters: TerminfoParameters) -> Option<Vec<u8>> {
+    let mut values = [0; 9];
+    match parameters {
+        TerminfoParameters::One(value) => values[0] = i32::try_from(value).ok()?,
+        TerminfoParameters::Rgb { r, g, b } => {
+            values[..3].copy_from_slice(&[i32::from(r), i32::from(g), i32::from(b)]);
+        }
     }
-    let bytes = unsafe { CStr::from_ptr(expanded) }.to_bytes().to_vec();
-    (!bytes.is_empty()).then_some(bytes)
+    let expanded = neomacs_terminfo::expand_numeric(sequence, values).ok()?;
+    (!expanded.is_empty()).then_some(expanded)
 }
 
-#[cfg(windows)]
-pub(crate) fn expand_capability_parameter(
-    _sequence: &[u8],
-    _parameters: TerminfoParameters,
-) -> Option<Vec<u8>> {
-    None
-}
+const TERMINFO_EXPANDER: TerminfoExpander = TerminfoExpander::new(expand_capability_parameter);
 
-/// The expander the capability record carries, so that a `setaf` string and the
-/// thing that expands it are never separated.  See
-/// [`neomacs_display_protocol::tty_capabilities::TerminfoExpander`].
-pub(crate) const TERMINFO_EXPANDER: TerminfoExpander =
-    TerminfoExpander::new(expand_capability_parameter);
-
-/// Which of the two capability namespaces a string capability name lives in.
-///
-/// They do not overlap, and a name from one is invisible to the other.
-/// `tgetstr` resolves TERMCAP names, which are two letters and nothing else;
-/// `tigetstr` resolves TERMINFO names, which are the long ones.  `us` exists
-/// only for `tgetstr` (its terminfo spelling is `smul`) and `Smulx` exists only
-/// for `tigetstr` (it has no termcap spelling at all).
-///
-/// GNU splits its lookups the same way: `init_tty` reads `so`, `us`, `md`, `mh`
-/// and `ZH` with `tgetstr`, and reads the two long names with `tigetstr` --
-/// `smxx` at src/term.c:4587 and `Smulx` at :4694, each guarded by
-/// `#ifdef TERMINFO` with a `tgetstr` fallback for a build that has no terminfo
-/// at all.  GNU's own comment on that fallback doubts it:
-///
-/// ```text
-///   /* FIXME: Is calling tgetstr here for non-terminfo case correct,
-///      even though "smxx" is more than 2 characters?  */
-/// ```
-///
-/// (src/term.c:4591-4592.)  The doubt is right.  Measured against ncurses on
-/// tmux-256color, whose `infocmp -x` carries both long names:
-///
-/// ```text
-///   Smulx    tgetstr=null   tigetstr=FOUND
-///   smxx     tgetstr=null   tigetstr=FOUND
-///   us       tgetstr=FOUND  tigetstr=null
-/// ```
-///
-/// A `&str` capability name cannot carry that distinction, so a terminfo name
-/// asked of `tgetstr` answers "this terminal has no such capability" rather
-/// than failing, and the attribute is then silently never emitted for the rest
-/// of the program's life.  Naming the namespace in the type is what stops the
-/// next capability from being added to the wrong one.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum StringCapability<'a> {
-    /// A two-letter termcap name, read with `tgetstr`.
-    Termcap(&'a str),
-    /// A terminfo capability name, read with `tigetstr`.
-    Terminfo(&'a str),
-}
+pub(crate) use neomacs_terminfo::{FlagCapability, StringCapability};
 
 /// A source of terminal capabilities — terminfo in production, a table in tests.
 pub(crate) trait TerminalCapabilityDatabase {
@@ -151,15 +44,43 @@ pub(crate) trait TerminalCapabilityDatabase {
     /// two-letter termcap name, so there is no terminfo variant here.
     fn get_termcap_number(&mut self, cap: &str) -> Option<i32>;
 
-    /// A boolean capability (GNU `tgetflag`). Termcap two-letter names, e.g.
-    /// `ut` for back-color-erase (terminfo `bce`).
-    fn get_termcap_flag(&mut self, cap: &str) -> bool;
+    /// A boolean capability in its explicit namespace: termcap `ut` for
+    /// back-color-erase, or terminfo `RGB`/`Tc` for direct color.
+    fn get_flag(&mut self, cap: FlagCapability<'_>) -> bool;
 }
 
 pub(crate) fn open_terminal_capability_database(
     term: &str,
 ) -> Option<Box<dyn TerminalCapabilityDatabase>> {
-    open_platform_terminal_capability_database(term)
+    use StringCapability::{Termcap, Terminfo};
+    use neomacs_terminfo::Query;
+    // The application chooses what it needs; the dependency snapshots these
+    // queries together so later opens cannot change an existing database.
+    let mut queries = vec![Query::TermcapNumber("Co"), Query::TermcapNumber("NC")];
+    for name in ["Su", "xn", "am", "in", "ut"] {
+        queries.push(Query::Flag(FlagCapability::Termcap(name)));
+    }
+    for name in [
+        "so", "us", "md", "mh", "ZH", "me", "ue", "op", "AF", "AB", "Sf", "Sb", "cs", "cm", "SF",
+        "SR", "sf", "sr", "IC", "DC", "ce",
+    ] {
+        queries.push(Query::String(Termcap(name)));
+    }
+    for name in ["RGB", "Tc"] {
+        queries.push(Query::Flag(FlagCapability::Terminfo(name)));
+    }
+    for name in ["Smulx", "smxx", "setf24", "setb24", "setrgbf", "setrgbb"] {
+        queries.push(Query::String(Terminfo(name)));
+    }
+    let key_names = super::termcap_input::terminal_key_capabilities();
+    queries.extend(key_names.iter().map(|name| Query::String(Termcap(name))));
+    match neomacs_terminfo::Database::load(term, &queries) {
+        Ok(database) => Some(Box::new(database)),
+        Err(error) => {
+            tracing::debug!(%error, term, "could not load terminal capabilities");
+            None
+        }
+    }
 }
 
 /// Resolve what this terminal can render, reading the same capability names GNU
@@ -222,7 +143,7 @@ pub(crate) fn resolve_tty_attribute_capabilities(
         .filter(|value| !value.is_empty())
         .or_else(|| {
             database
-                .get_termcap_flag("Su")
+                .get_flag(FlagCapability::Termcap("Su"))
                 .then(|| b"\x1b[4:%p1%dm".to_vec())
         });
 
@@ -235,7 +156,7 @@ pub(crate) fn resolve_tty_attribute_capabilities(
         strike_through_sequence: sequence(database, Terminfo("smxx")),
         styled_underline: styled_underline_source.and_then(|smulx| {
             TtyStyledUnderline::expand_all(|style| {
-                expand_capability_parameter(&smulx, TerminfoParameters::One(u32::from(style)))
+                TERMINFO_EXPANDER.expand(&smulx, TerminfoParameters::One(u32::from(style)))
             })
         }),
         // GNU `TS_exit_attribute_mode = tgetstr ("me")` (src/term.c:4585) and
@@ -353,7 +274,7 @@ fn resolve_tty_color_entry(
     // spelling and take the packed pixel -- but it does replace the COUNT
     // (`tty->TN_max_colors = 16777216`, src/term.c:4651), which is the whole
     // content of the arm.
-    if database.get_termcap_flag("RGB") {
+    if database.get_flag(FlagCapability::Terminfo("RGB")) {
         return Some(TtyColorCapabilities::new(
             orig_pair,
             set_foreground,
@@ -371,7 +292,9 @@ fn resolve_tty_color_entry(
     // GNU's COLORTERM test is `strcasecmp (bg, "truecolor") == 0` -- an EXACT
     // match, case-insensitively.  A substring test would take this arm for
     // `COLORTERM=24bit`, which GNU does not read at all (ledger 193).
-    if database.get_termcap_flag("Tc") || colorterm.eq_ignore_ascii_case("truecolor") {
+    if database.get_flag(FlagCapability::Terminfo("Tc"))
+        || colorterm.eq_ignore_ascii_case("truecolor")
+    {
         return Some(TtyColorCapabilities::new(
             orig_pair,
             Some(b"\x1b[38;2;%p1%d;%p2%d;%p3%d%;m".to_vec()),
@@ -529,9 +452,9 @@ pub(crate) fn resolve_term_caps(
     };
 
     neomacs_display_runtime::backend::tty::rif::TermCaps {
-        right_margin: if database.get_termcap_flag("xn") {
+        right_margin: if database.get_flag(FlagCapability::Termcap("xn")) {
             RightMarginBehavior::MagicWrap
-        } else if database.get_termcap_flag("am") {
+        } else if database.get_flag(FlagCapability::Termcap("am")) {
             RightMarginBehavior::AutoWrap
         } else {
             RightMarginBehavior::NoAutoWrap
@@ -539,10 +462,11 @@ pub(crate) fn resolve_term_caps(
         scroll_region,
         insert_delete_char: termcap_cap_is(database, "IC", b"\x1b[%d@")
             && termcap_cap_is(database, "DC", b"\x1b[%dP"),
-        blank_tail: if !database.get_termcap_flag("in") && termcap_cap_is(database, "ce", b"\x1b[K")
+        blank_tail: if !database.get_flag(FlagCapability::Termcap("in"))
+            && termcap_cap_is(database, "ce", b"\x1b[K")
         {
             BlankTailMethod::EraseToEol {
-                back_color_erase: database.get_termcap_flag("ut"),
+                back_color_erase: database.get_flag(FlagCapability::Termcap("ut")),
             }
         } else {
             BlankTailMethod::WriteSpaces
@@ -586,91 +510,20 @@ use the Bourne shell command 'TERM=...; export TERM' (C-shell:\n\
     ))
 }
 
-#[cfg(not(windows))]
-struct UnixTermcapDatabase {
-    _termcap_buffer: Vec<c_char>,
-    _string_area: Vec<c_char>,
-    string_area_ptr: *mut c_char,
-}
-
-#[cfg(not(windows))]
-impl UnixTermcapDatabase {
-    fn open(term: &str) -> Option<Self> {
-        let term = CString::new(term).ok()?;
-        let mut termcap_buffer = vec![0 as c_char; 16384];
-        let ok = unsafe { tgetent(termcap_buffer.as_mut_ptr(), term.as_ptr()) };
-        if ok <= 0 {
-            return None;
-        }
-        let mut string_area = vec![0 as c_char; 32768];
-        let string_area_ptr = string_area.as_mut_ptr();
-        Some(Self {
-            _termcap_buffer: termcap_buffer,
-            _string_area: string_area,
-            string_area_ptr,
-        })
-    }
-}
-
-#[cfg(not(windows))]
-impl TerminalCapabilityDatabase for UnixTermcapDatabase {
+impl TerminalCapabilityDatabase for neomacs_terminfo::Database {
     fn get_string(&mut self, cap: StringCapability<'_>) -> Option<Vec<u8>> {
-        let raw = match cap {
-            StringCapability::Termcap(name) => {
-                let name = CString::new(name).ok()?;
-                unsafe { tgetstr(name.as_ptr(), &mut self.string_area_ptr) }
-            }
-            // `tgetent` is what sets ncurses' `cur_term`, so `tigetstr` reads
-            // the entry this database already opened; no second `setupterm` is
-            // needed.  `tigetstr` reports a name that is not a string
-            // capability as (char *) -1 rather than NULL, and that is not a
-            // capability this terminal has either.
-            StringCapability::Terminfo(name) => {
-                let name = CString::new(name).ok()?;
-                let raw = unsafe { tigetstr(name.as_ptr()) };
-                if raw as isize == -1 {
-                    return None;
-                }
-                raw
-            }
-        };
-        if raw.is_null() {
-            return None;
-        }
-        let bytes = unsafe { CStr::from_ptr(raw) }.to_bytes().to_vec();
-        (!bytes.is_empty()).then_some(bytes)
+        self.string(cap)
+            .filter(|value| !value.is_empty())
+            .map(<[u8]>::to_vec)
     }
 
     fn get_termcap_number(&mut self, cap: &str) -> Option<i32> {
-        let cap = CString::new(cap).ok()?;
-        let value = unsafe { tgetnum(cap.as_ptr()) };
-        (value != -1).then_some(value)
+        self.termcap_number(cap)
     }
 
-    fn get_termcap_flag(&mut self, cap: &str) -> bool {
-        let Ok(cap) = CString::new(cap) else {
-            return false;
-        };
-        unsafe { tgetflag(cap.as_ptr()) != 0 }
+    fn get_flag(&mut self, cap: FlagCapability<'_>) -> bool {
+        self.flag(cap)
     }
-}
-
-#[cfg(not(windows))]
-fn open_platform_terminal_capability_database(
-    term: &str,
-) -> Option<Box<dyn TerminalCapabilityDatabase>> {
-    UnixTermcapDatabase::open(term)
-        .map(|database| Box::new(database) as Box<dyn TerminalCapabilityDatabase>)
-}
-
-#[cfg(windows)]
-fn open_platform_terminal_capability_database(
-    _term: &str,
-) -> Option<Box<dyn TerminalCapabilityDatabase>> {
-    // GNU Emacs' native Windows console backend does not link termcap.
-    // nt/inc/ms-w32.h redirects tgetstr to sys_tgetstr, and
-    // src/w32console.c implements that hook as a NULL capability lookup.
-    None
 }
 
 #[cfg(test)]

--- a/crates/neomacs/src/terminal_capabilities_test.rs
+++ b/crates/neomacs/src/terminal_capabilities_test.rs
@@ -126,7 +126,10 @@ impl TerminalCapabilityDatabase for FakeCapabilityDatabase {
         self.numbers.get(cap).copied()
     }
 
-    fn get_termcap_flag(&mut self, cap: &str) -> bool {
+    fn get_flag(&mut self, cap: FlagCapability<'_>) -> bool {
+        let cap = match cap {
+            FlagCapability::Termcap(name) | FlagCapability::Terminfo(name) => name,
+        };
         self.flags.contains(cap)
     }
 }

--- a/crates/neomacs/src/tty_init_test.rs
+++ b/crates/neomacs/src/tty_init_test.rs
@@ -30,7 +30,7 @@ impl TerminalCapabilityDatabase for ColorBlockDatabase {
         (cap == "Co").then_some(self.colors).flatten()
     }
 
-    fn get_termcap_flag(&mut self, _cap: &str) -> bool {
+    fn get_flag(&mut self, _cap: super::super::terminal_capabilities::FlagCapability<'_>) -> bool {
         false
     }
 }

--- a/docs/design/neomacs-terminfo-decision.md
+++ b/docs/design/neomacs-terminfo-decision.md
@@ -1,0 +1,60 @@
+# Decision: neomacs-terminfo
+
+Date: 2026-09-09. PR #363 baseline: `7384bd804cae123e1ff0b3a95b423a7fbc9ca1de`.
+
+## Decision
+
+Use a small private `neomacs-terminfo` library to own ncurses discovery, native calls, owned capability snapshots, and numeric expansion. Keep editor policy in `neomacs`. Use published `pkg-config` and `regex` dependencies; do not vendor or fork an interpreter.
+
+The application compiles `main.rs` independently as a binary and through its library. Moving native calls into a dependency gives both targets the native linkage through Cargo's library mechanism. This replaces the PR's manual replay of native `-l` arguments. Cargo documents this arrangement explicitly. [Cargo native linkage](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)
+
+This follows the ownership pattern used by `libgit2-sys` and `openssl-sys`: a dependency owns native discovery and linkage. Their bundling options and larger abstraction layers are unnecessary here. [git2-rs build script](https://github.com/rust-lang/git2-rs/blob/master/libgit2-sys/build.rs), [rust-openssl discovery](https://github.com/sfackler/rust-openssl/blob/master/openssl-sys/build/find_normal.rs)
+
+## Why retain ncurses
+
+GNU Emacs uses native termcap lookup and tparm expansion. Native `tgetstr("me")` can differ from raw terminfo `sgr0`, so changing the database reader is a behavior change. Pure Rust expansion was also evaluated independently of lookup. Published candidates failed compatibility probes needed by the existing renderer; see [research](terminfo-native-research.md).
+
+`regex` validates a conservative numeric directive grammar; ncurses remains the interpreter. This reuses an established Rust parser engine without maintaining a second terminfo interpreter. It does not eliminate native code or claim a complete safety audit of ncurses.
+
+## Interface and ownership
+
+`Database::load(term, queries)` copies a finite query set under one native lock. Snapshots contain only Rust-owned bytes, numbers, and flags. String and boolean names explicitly distinguish termcap from terminfo. Missing queries behave like missing capabilities. No handles or raw pointers escape.
+
+`expand_numeric(bytes, [i32; 9])` validates every directive, including skipped branches, before calling native tparm with nine C long arguments. String directives are rejected. Native variable state remains process/current-terminal state, as in the original GNU-style wrapper; it is not attached to snapshots. Loading another terminal selects that native context.
+
+All unsafe code is restricted to one private module. Loading, lookup, expansion, and copying share one mutex. The crate must remain the sole ncurses caller in Neomacs: unrelated raw bindings cannot share its lock. The fixed 32 KiB string arena is removed; native strings are copied before releasing the lock. ncurses owns its bounded termcap cache, which must not be manually freed behind its back.
+
+Application code retains color precedence, padding removal, rendition comparisons, terminal suitability diagnostics, and keymap policy. RGB and Tc use terminfo boolean lookup, matching GNU; Su remains a termcap flag.
+
+## Build and validation
+
+Linux probes ncursesw then ncurses; macOS probes ncurses then ncursesw. pkg-config emits native link metadata. The dependency passes discovered runtime library directories to the application build script, which preserves rpaths for Nix and other nonstandard prefixes. Without pkg-config, the existing unsplit-library fallback remains with an explicit warning; split installations require valid pkg-config metadata. Other platforms return UnsupportedPlatform.
+
+Use `cargo nextest run -p neomacs-terminfo --locked` for fixture, expansion, failure-recovery, and concurrency checks. The fixture requires ncurses `tic`. `python3 crates/neomacs-terminfo/tests/linkage.py` builds actual consumer executables and runs nextest against synthetic split/unsplit, shared/static libraries. Application policy tests remain in the application crate.
+
+Linux runtime validation does not establish macOS runtime compatibility, and these checks are not a sanitizer audit. A future Rust backend needs lookup and expansion comparisons against ncurses before adoption.
+
+Numeric division and remainder require an immediately preceding nonnegative
+literal divisor, such as `%{256}%/`. Computed divisors are rejected because
+native signed division can trap on INT_MIN / -1. Constants are validated on
+directive boundaries so escaped literal text is preserved.
+
+## Recorded validation
+
+On Linux, the final focused nextest runs passed 38 application terminal tests
+and all six new crate tests. The four linkage fixture configurations passed.
+The crate passed Clippy with warnings denied, and application library checking
+with default features passed (with existing dependency warnings).
+
+The broad application library run used `--no-default-features --features
+neo-term`; it reached 118 passing tests before bootstrap tests reported Lisp
+`file-missing` errors. Remaining work in that run was interrupted. This is not
+a passing full-suite result. macOS and Windows cross-checks could not proceed
+because the active Nix toolchain did not contain their standard libraries.
+
+A final full application executable build did not complete: files disappeared
+from the original private checkout during compilation, including incremental
+cache files and its `.git` pointer. The committed checkout was restored inside
+its locked worktree metadata directory. The successful focused tests and
+synthetic executable linkage checks preceded this incident; a full application
+executable link and startup check remain unverified.

--- a/docs/design/terminfo-native-research.md
+++ b/docs/design/terminfo-native-research.md
@@ -1,0 +1,53 @@
+# Terminfo implementation research
+
+Research date: 2026-09-09. Neomacs baseline: PR #363 at `7384bd804`. GNU source examined locally at `/home/exec/Projects/github.com/emacs-mirror/emacs`, commit `a360712c9d272d950d8d8255ef74570f7e90b7d9`.
+
+## GNU behavior to preserve
+
+GNU `src/terminfo.c` wraps native tparm and copies its output. In `src/term.c`, color precedence is packed setf24/setb24, separate setrgbf/setrgbb, the terminfo RGB flag, then Tc/COLORTERM. The Tc fallback literal contains an unmatched `%;`, which ncurses accepts. Smulx and smxx use terminfo string names; Su uses termcap boolean lookup. These details make a strict new interpreter or a mechanical name substitution potentially incompatible. [GNU terminfo.c](https://github.com/emacs-mirror/emacs/blob/a360712c9d272d950d8d8255ef74570f7e90b7d9/src/terminfo.c), [GNU term.c](https://github.com/emacs-mirror/emacs/blob/a360712c9d272d950d8d8255ef74570f7e90b7d9/src/term.c)
+
+ncurses adjusts termcap `me` relative to raw `sgr0` for alternate-character-set reset compatibility. Retaining native lookup preserves that behavior. [ncurses termcap manual](https://invisible-island.net/ncurses/man/curs_termcap.3x.html)
+
+## Published Rust candidates
+
+We inspected published sources and ran focused expansion probes. The failures below describe the evaluated versions, not all future releases or a general judgment of their projects.
+
+| Candidate | Relevant evidence | Decision |
+| --- | --- | --- |
+| terminfo 0.9.0 | Used by WezTerm's termwiz; its expander rejects GNU's unmatched `%;` and has incorrect logical negation. Its compiled database parser contains unsafe code. | Established adoption, but not a drop-in replacement. |
+| term 1.2.1 | Rust project ancestry; upstream marks it unmaintained. Probes exposed p0/division-by-zero panics, negative boolean differences, and loss of bare dollar text. | Do not adopt or maintain a local fork. |
+| nshterm 0.1.2 | Published derivative of term; negative logical negation produced 1 for -1, and incomplete `%p` returned empty success. | Does not solve the compatibility requirement. |
+| tinf 0.14.0 | Rejects constants at least 10000, including the 65536 used for packed RGB extraction. | Does not cover existing rendering inputs. |
+| terminfokit 0.1.0 | Alpha, forbids unsafe; exposes parsing/analysis but uses i64 arithmetic and errors on division by zero. | Interesting future candidate; differs from ncurses' numeric behavior. |
+
+Primary sources: [terminfo 0.9.0](https://docs.rs/crate/terminfo/0.9.0/source/), [termwiz manifest](https://github.com/wezterm/wezterm/blob/main/termwiz/Cargo.toml), [term 1.2.1](https://docs.rs/crate/term/1.2.1/source/), [nshterm 0.1.2](https://docs.rs/crate/nshterm/0.1.2/source/), [tinf 0.14.0](https://docs.rs/crate/tinf/0.14.0/source/), [terminfokit 0.1.0](https://docs.rs/crate/terminfokit/0.1.0/source/).
+
+The selected implementation uses published regex for numeric syntax validation and ncurses for interpretation. No candidate interpreter is vendored or patched. This balances the preference for less hand-written Rust against GNU compatibility; it is not an assertion that no useful Rust terminal crate exists.
+
+## Native contracts
+
+The old application code had a cumulative 32768-byte output arena with no capacity check, unsynchronized global native access, and an eight-c_int tparm call. The new boundary removes that arena, serializes all operations and copies, and supplies nine c_long values. ncurses tparm and termcap queries use global state; a per-object mutex would not be sufficient. [Threading contracts](https://invisible-island.net/ncurses/man/curs_threads.3x.html), [tparm ABI](https://invisible-island.net/ncurses/man/curs_terminfo.3x.html)
+
+Correct argument width alone is insufficient: `%s` and `%l` can make numeric parameters into pointers. The Rust wrapper checks the entire byte sequence against a numeric-only grammar before calling C. It accepts GNU's unmatched `%;`, caps formatting widths/precision and numeric constants, and rejects string conversions, NULs, and unsupported directives. It does not implement or fully validate stack-machine semantics.
+
+For snapshots, set_curterm(NULL) prevents reuse of the previous terminal by setupterm; tgetent(NULL, name) reuses the same ncurses termcap cache slot. That cache owns and reclaims the previous entry. Calling del_curterm separately would leave its cache with a dangling owner. All returned strings are copied under the same lock, after null/error-sentinel checks. This relies specifically on ncurses, including Apple's ncurses implementation, rather than generic historical BSD termcap. [ncurses lib_termcap.c](https://github.com/mirror/ncurses/blob/master/ncurses/tinfo/lib_termcap.c), [Apple ncurses source](https://github.com/apple-oss-distributions/ncurses)
+
+The lock coordinates this crate's calls only. Native expansion variables remain attached to ncurses' current context, while query snapshots remain independent. Environment mutation and unrelated native bindings require separate process-wide coordination and are outside the interface.
+
+## Validation limits
+
+Checked-in fixtures cover extended/canceled capabilities, native error sentinels, repeated queries exceeding the old arena, interleaved snapshots, failure recovery, and concurrency. Numeric cases include GNU color literals, packed RGB, negative boolean values, zero division, signed overflow, padding text, and the ninth argument. Linkage fixtures cover actual Cargo dependency consumers using split/unsplit shared/static libraries.
+
+These focused Linux checks do not replace a native sanitizer audit or macOS runtime tests. Before adopting a Rust backend, compare database discovery, termcap normalization, and expansion against ncurses across the supported terminal corpus.
+
+Numeric division and remainder require an immediately preceding nonnegative
+literal divisor, such as `%{256}%/`. Computed divisors are rejected because
+native signed division can trap on INT_MIN / -1. Constants are validated on
+directive boundaries so escaped literal text is preserved.
+
+For formats containing division, the validator also bounds all possible stack
+pushes to 19 with explicit parameters or 10 with implicit parameters. This
+reserves space in ncurses' 20-slot stack, including up to nine implicit values;
+an overflowing push must not drop the checked divisor. See
+[ncurses stack definition](https://github.com/mirror/ncurses/blob/master/ncurses/term.priv.h)
+and [interpreter](https://github.com/mirror/ncurses/blob/master/ncurses/tinfo/lib_tparm.c).


### PR DESCRIPTION
Building on a distro that configures ncurses --with-termlib (Gentoo, Debian, Ubuntu, Arch) failed at the final link:

    rust-lld: error: undefined symbol: tgetent
    rust-lld: error: undefined symbol: tigetstr
    ...

Those distros move tgetent, tgetstr, tgetnum, tgetflag, tigetstr and tparm out of libncursesw and into libtinfow. Linking ncurses alone leaves them undefined, and no linker will resolve them through ncurses' transitive DT_NEEDED on libtinfow.

build.rs asked pkg-config for the right answer (-lncursesw -ltinfow) and then threw half of it away. It emitted cargo:rustc-link-lib, which Cargo applies to the package's *library* target, but the caller (terminal_capabilities) is a module of the neomacs *binary*, so the binary never saw those libraries. Its only linkage was the library that on these systems defines none of the symbols it needs.

Emit pkg-config's full answer as rustc-link-arg instead, which Cargo does pass to binaries and tests, and drop the attribute so linkage has a single source of truth. Where pkg-config reports one unsplit library (nixpkgs, macOS) the result is unchanged -- which is why CI and the nix dev shell never caught this.

Verified on Gentoo: the release binary and the unit-test binary built from main.rs both link, and ldd shows libtinfow.so.6.