### PR TITLE
fix(layout): realize inverse-video after merging faces

### DIFF
--- a/crates/neomacs-layout-engine/src/buffer_source/face_resolution.rs
+++ b/crates/neomacs-layout-engine/src/buffer_source/face_resolution.rs
@@ -443,8 +443,13 @@ impl BufferSourceItemLayoutResolutionContext<'_> {
         resolved_active_face
     }
 
-    /// Realize the legacy escape/nobreak face merge. Its foreground-only
-    /// no-op rule is intentional and keeps those paths unchanged.
+    /// Realize the legacy escape/nobreak face merge.
+    ///
+    /// The no-op rule compares both colour slots.  GNU swaps a merged
+    /// foreground into the background when the base face is `:inverse-video`
+    /// (`load_face_colors`, src/xfaces.c:1389-1400), and `nobreak-space` can
+    /// set `:background` outright (its `min-colors 8` branch), so a
+    /// foreground-only comparison would discard a real colour change.
     fn merge_named_active_face(
         &self,
         source_render: &mut TextRowSourceRenderState<'_>,
@@ -456,7 +461,11 @@ impl BufferSourceItemLayoutResolutionContext<'_> {
     ) -> Option<DisplayRowActiveFaceState> {
         let base = active_face_state.resolved_face();
         let merged = source_render.merge_named_face_over(base, face_name);
-        if merged.fg == base.fg && merged.use_default_foreground == base.use_default_foreground {
+        if merged.fg == base.fg
+            && merged.bg == base.bg
+            && merged.use_default_foreground == base.use_default_foreground
+            && merged.use_default_background == base.use_default_background
+        {
             return None;
         }
         Some(self.install_merged_active_face(source_render, face_ids, row_geometry, item, merged))

--- a/crates/neomacs-layout-engine/src/display_source_resolver.rs
+++ b/crates/neomacs-layout-engine/src/display_source_resolver.rs
@@ -1293,6 +1293,9 @@ pub(crate) fn same_resolved_face(lhs: &ResolvedFace, rhs: &ResolvedFace) -> bool
         && lhs.box_line_width == rhs.box_line_width
         && lhs.extend == rhs.extend
         && lhs.terminal_inverse_video == rhs.terminal_inverse_video
+        // `pending_inverse_video` decides how later sources merge over this
+        // face, so two faces that differ only in it must not share an id.
+        && lhs.pending_inverse_video == rhs.pending_inverse_video
         // A face that differs from the base ONLY in its realized `:stipple`
         // bitmap (e.g. `indent-bars` faces, which inherit the default colors and
         // add just a stipple) must NOT be collapsed onto the base id — doing so

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -11057,6 +11057,79 @@ fn layout_frame_rust_control_char_caret_uses_escape_glyph_foreground() {
     );
 }
 
+/// An inverse-video base face moves a merged semantic face's foreground into
+/// the background (`load_face_colors`, src/xfaces.c:1389-1400).  The
+/// escape/nobreak no-op rule must compare the background too, or the merge is
+/// discarded and the glyph keeps the base face's colours.
+#[test]
+fn layout_frame_rust_escape_glyph_lands_in_background_over_inverse_base() {
+    use neomacs_display_protocol::types::Color;
+
+    let mut eval = Context::new();
+    let buf_id = eval
+        .buffer_manager()
+        .current_buffer()
+        .expect("current buffer")
+        .id();
+    {
+        let buf = eval.buffer_manager_mut().get_mut(buf_id).expect("buffer");
+        buf.insert("a\u{0001}b\n");
+    }
+    let escape_fg = Color::from_pixel((0x46u32 << 16) | (0xD9u32 << 8) | 0xFFu32);
+
+    let frame_id =
+        eval.frame_manager_mut()
+            .create_frame("layout-escape-glyph-inverse-base", 640, 160, buf_id);
+    if let Some(frame) = eval.frame_manager_mut().get_mut(frame_id) {
+        frame.set_window_system(Some(Value::symbol("neo")));
+    }
+    assert!(eval.frame_manager_mut().select_frame(frame_id));
+    let results = eval.eval_str_each(
+        "(internal-set-lisp-face-attribute 'escape-glyph :foreground \"#46D9FF\" (selected-frame))
+         (put-text-property 2 3 'face '(:inverse-video t))",
+    );
+    assert!(
+        results.iter().all(Result::is_ok),
+        "setup failed: {results:?}"
+    );
+    let selected_window = eval
+        .frame_manager()
+        .get(frame_id)
+        .expect("frame")
+        .selected_window;
+
+    let mut engine = LayoutEngine::new();
+    engine.layout_frame_rust(&mut eval, frame_id);
+
+    let state = engine
+        .last_frame_display_state
+        .as_ref()
+        .expect("display state");
+    let entry = state
+        .window_matrices
+        .iter()
+        .find(|entry| entry.window_id.get() == selected_window.0 as i64)
+        .expect("selected window matrix");
+    let text_row = entry
+        .matrix
+        .rows
+        .iter()
+        .find(|row| row.enabled && row.role == GlyphRowRole::Text && row.displays_text)
+        .expect("text row");
+    let caret = text_row.glyphs[GlyphArea::Text.index()]
+        .iter()
+        .find(|g| matches!(g.glyph_type, GlyphType::Char { ch: '^' }))
+        .expect("caret '^' glyph");
+    let caret_face = state
+        .faces
+        .get(&caret.face_id)
+        .expect("escape-glyph face registered in the frame face table");
+    assert_eq!(
+        caret_face.background, escape_fg,
+        "over an inverse-video base the escape-glyph foreground must become the background"
+    );
+}
+
 /// Sibling guard: ordinary (non-control) text glyphs keep the surrounding base
 /// face -- the escape-glyph merge must NOT leak onto normal characters.
 #[test]

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -19994,7 +19994,8 @@ fn layout_frame_rust_applies_buffer_glyphless_table_to_header_line_strings() {
     }
     assert!(eval.frame_manager_mut().select_frame(frame_id));
     let results = eval.eval_str_each(
-        "(internal-set-lisp-face-attribute 'glyphless-char :foreground \"#123456\" (selected-frame))",
+        "(internal-set-lisp-face-attribute 'glyphless-char :foreground \"#123456\" (selected-frame))
+         (internal-set-lisp-face-attribute 'header-line :inverse-video nil (selected-frame))",
     );
     assert!(
         results.iter().all(Result::is_ok),
@@ -33517,8 +33518,16 @@ fn buffer_owned_mode_line_string_remaps_its_named_face() {
         );
     }
     assert!(eval.frame_manager_mut().select_frame(frame_id));
+    // The mode-line is inverse-video on a display the face machinery does not
+    // classify as color (the `(t :inverse-video t)` branch of `mode-line`).
+    // GNU realizes a mode-line string by copying the base face's lface and
+    // merging the string's faces before `lookup_face`
+    // (`face_at_string_position`, xfaces.c:7105), so under inverse video the
+    // remapped foreground would land in the background.  This test is about
+    // the remapping, not about inverse video, so pin the base face flat.
     let face_results = eval.eval_str_each(
-        "(internal-make-lisp-face 'mode-line-remap-probe)
+        "(internal-set-lisp-face-attribute 'mode-line :inverse-video nil (selected-frame))
+         (internal-make-lisp-face 'mode-line-remap-probe)
          (internal-set-lisp-face-attribute
           'mode-line-remap-probe :foreground \"#00ff00\" (selected-frame))",
     );

--- a/crates/neomacs-layout-engine/src/neovm_bridge.rs
+++ b/crates/neomacs-layout-engine/src/neovm_bridge.rs
@@ -1640,7 +1640,7 @@ fn frame_cursor_foreground_pixel(frame: &Frame, face_table: &FaceTable, obarray:
     // otherwise x_set_cursor_color uses FRAME_BACKGROUND_PIXEL.
     obarray
         .symbol_value("x-cursor-fore-pixel")
-        .and_then(|value| parse_color_pixel(&value))
+        .and_then(parse_color_pixel)
         .unwrap_or_else(|| frame_background_color_pixel(frame, face_table))
 }
 
@@ -3809,6 +3809,19 @@ pub struct ResolvedFace {
     pub overstrike: bool,
     /// Preserve terminal inverse-video when both colors are terminal defaults.
     pub terminal_inverse_video: bool,
+    /// GNU's merged `:inverse-video` attribute, still in effect for this face.
+    ///
+    /// [`Self::terminal_inverse_video`] records the realized *TTY* outcome; a
+    /// GUI frame cannot express it, because the swap is already materialized
+    /// into `fg`/`bg`.  But the swap is not final: GNU merges every source
+    /// (base face, text properties, overlays) into one lface vector and swaps
+    /// once, at realization (`load_face_colors`, src/xfaces.c:1389-1400).  A
+    /// base face carrying `:inverse-video` must therefore keep the attribute
+    /// visible to later merges — a foreground-only face merged on top has its
+    /// colour land in the *background*.  Recording it here lets
+    /// [`Self::apply_specified_face_over`] undo the base's realized swap, merge
+    /// the new source, and swap once at the end.
+    pub pending_inverse_video: bool,
     /// Per-face measured character advance width (from FontMetricsService, 0.0 = use default).
     font_char_width: f32,
     /// Per-face font ascent (from FontMetricsService, 0.0 = use default).
@@ -3856,6 +3869,7 @@ impl Default for ResolvedFace {
             extend: false,
             overstrike: false,
             terminal_inverse_video: false,
+            pending_inverse_video: false,
             font_char_width: 0.0,
             font_ascent: 0.0,
             font_line_height: 0.0,
@@ -4025,6 +4039,25 @@ fn apply_resolved_face_inverse_video(face: &mut ResolvedFace) {
     (face.bg, face.terminal_bg, face.use_default_background) =
         foreground.materialize_in(FaceColorSlot::Background);
     face.terminal_inverse_video = false;
+}
+
+/// Undo [`apply_resolved_face_inverse_video`] so a later source can merge
+/// against GNU's pre-inverse colors and the swap can be re-applied once.
+///
+/// The realized swap is its own inverse whenever both colors are concrete
+/// (GUI, and TTY colors the palette resolved).  The both-terminal-default TTY
+/// case never swapped, so clearing the flag is the whole undo.
+fn unapply_resolved_face_inverse_video(face: &mut ResolvedFace) {
+    if face.terminal_inverse_video {
+        face.terminal_inverse_video = false;
+        return;
+    }
+    std::mem::swap(&mut face.fg, &mut face.bg);
+    std::mem::swap(&mut face.terminal_fg, &mut face.terminal_bg);
+    std::mem::swap(
+        &mut face.use_default_foreground,
+        &mut face.use_default_background,
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -4424,11 +4457,20 @@ impl FaceResolver {
             resolved.face_id = BasicFaceId::SENTINEL;
         }
         resolved.terminal_inverse_video = false;
+        resolved.pending_inverse_video = false;
         resolved
     }
 
     fn apply_specified_face_over(&self, base: &ResolvedFace, face: &NeoFace) -> ResolvedFace {
         let mut rf = base.clone();
+        // GNU swaps fg/bg for `:inverse-video` once, after every source has
+        // been merged (src/xfaces.c:1389-1400).  The base face's swap is
+        // already realized, so undo it, merge this source against the
+        // pre-inverse colors, then swap once below.
+        let base_inverse_video = rf.pending_inverse_video;
+        if base_inverse_video {
+            unapply_resolved_face_inverse_video(&mut rf);
+        }
         if let Some(c) = &face.foreground {
             rf.set_foreground(c);
         }
@@ -4436,8 +4478,20 @@ impl FaceResolver {
             rf.set_background(c);
         }
         match face.inverse_video {
-            Some(true) => apply_resolved_face_inverse_video(&mut rf),
-            Some(false) => rf.terminal_inverse_video = false,
+            Some(true) => {
+                apply_resolved_face_inverse_video(&mut rf);
+                rf.pending_inverse_video = true;
+            }
+            Some(false) => {
+                rf.terminal_inverse_video = false;
+                rf.pending_inverse_video = false;
+            }
+            // Inherited from the base face: keep it in effect for the rest of
+            // the merge chain.
+            None if base_inverse_video => {
+                apply_resolved_face_inverse_video(&mut rf);
+                rf.pending_inverse_video = true;
+            }
             None => {}
         }
 
@@ -5375,8 +5429,14 @@ impl FaceResolver {
         }
         // Inverse video: swap fg and bg
         match face.inverse_video {
-            Some(true) => apply_resolved_face_inverse_video(&mut rf),
-            Some(false) => rf.terminal_inverse_video = false,
+            Some(true) => {
+                apply_resolved_face_inverse_video(&mut rf);
+                rf.pending_inverse_video = true;
+            }
+            Some(false) => {
+                rf.terminal_inverse_video = false;
+                rf.pending_inverse_video = false;
+            }
             None => {}
         }
 

--- a/crates/neomacs-layout-engine/src/neovm_bridge.rs
+++ b/crates/neomacs-layout-engine/src/neovm_bridge.rs
@@ -4585,11 +4585,18 @@ impl FaceResolver {
             rf.overstrike = true;
         }
 
-        // Distant-foreground: swap fg when too close to bg
+        // Distant-foreground: GNU substitutes it when the realized foreground
+        // and background are too close.  With `:inverse-video` the substitution
+        // lands in the background, not the foreground (`load_face_colors`,
+        // src/xfaces.c:1417-1425).
         if let Some(dfg) = &face.distant_foreground
             && colors_close(rf.fg, rf.bg)
         {
-            rf.set_foreground(dfg);
+            if rf.pending_inverse_video {
+                rf.set_background(dfg);
+            } else {
+                rf.set_foreground(dfg);
+            }
         }
 
         // Stipple: a face that specifies `:stipple` overrides the inherited
@@ -5536,13 +5543,18 @@ impl FaceResolver {
             rf.overstrike = true;
         }
 
-        // Distant-foreground: GNU Emacs (xfaces.c) uses this when the
-        // foreground is too close to the background, improving readability.
-        // Check if fg ≈ bg and substitute distant-foreground if available.
+        // Distant-foreground: GNU substitutes it when the realized foreground
+        // and background are too close.  With `:inverse-video` the substitution
+        // lands in the background, not the foreground (`load_face_colors`,
+        // src/xfaces.c:1417-1425).
         if let Some(dfg) = &face.distant_foreground
             && colors_close(rf.fg, rf.bg)
         {
-            rf.set_foreground(dfg);
+            if rf.pending_inverse_video {
+                rf.set_background(dfg);
+            } else {
+                rf.set_foreground(dfg);
+            }
         }
 
         // Stipple: realize the `:stipple` spec to the XBM pattern the renderer

--- a/crates/neomacs-layout-engine/src/neovm_bridge_test.rs
+++ b/crates/neomacs-layout-engine/src/neovm_bridge_test.rs
@@ -3281,6 +3281,39 @@ fn face_resolver_realizes_base_face_inverse_video_after_merging_text_property_fa
     assert_eq!(resolved.bg, 0x009370DB);
 }
 
+/// GNU's `:distant-foreground` replaces the background, not the foreground,
+/// when the face is `:inverse-video` (`load_face_colors`, src/xfaces.c:1417-1425).
+#[test]
+fn face_resolver_applies_distant_foreground_to_the_inverse_video_slot() {
+    let _evaluator = neovm_core::emacs_core::Context::new();
+    let mut table = FaceTable::new();
+
+    let mut plain = NeoFace::new("plain-distant");
+    plain.foreground = Some(NeoColor::rgb(0x33, 0x33, 0x33));
+    plain.background = Some(NeoColor::rgb(0x33, 0x33, 0x34));
+    plain.distant_foreground = Some(NeoColor::rgb(0xFF, 0x00, 0x00));
+    table.define("plain-distant", plain);
+
+    let mut inverse = NeoFace::new("inverse-distant");
+    inverse.foreground = Some(NeoColor::rgb(0x33, 0x33, 0x33));
+    inverse.background = Some(NeoColor::rgb(0x33, 0x33, 0x34));
+    inverse.inverse_video = Some(true);
+    inverse.distant_foreground = Some(NeoColor::rgb(0xFF, 0x00, 0x00));
+    table.define("inverse-distant", inverse);
+
+    let resolver = FaceResolver::new(&table, 0x00FFFFFF, 0x00000000, 14.0, Some("neo".into()));
+
+    let plain = resolver.resolve_named_face("plain-distant");
+    assert_eq!(plain.fg, 0x00FF0000);
+    assert_eq!(plain.bg, 0x00333334);
+
+    // The swap runs first (fg <-> bg), then the distant color replaces the
+    // background because `:inverse-video` is still in effect.
+    let inverse = resolver.resolve_named_face("inverse-distant");
+    assert_eq!(inverse.fg, 0x00333334);
+    assert_eq!(inverse.bg, 0x00FF0000);
+}
+
 #[test]
 fn test_face_resolver_can_ignore_inverse_video_for_gui_menu_bar() {
     let mut table = FaceTable::new();

--- a/crates/neomacs-layout-engine/src/neovm_bridge_test.rs
+++ b/crates/neomacs-layout-engine/src/neovm_bridge_test.rs
@@ -3242,6 +3242,45 @@ fn face_resolver_applies_inverse_video_after_text_and_overlay_faces_are_merged()
     assert_eq!(resolved.bg, 0x00b0e2ff);
 }
 
+/// A row base face with `:inverse-video` (the `header-line` face in themes like
+/// tsdh-dark) must swap only after the row string's text-property faces have
+/// merged.  GNU accumulates one lface vector and swaps once in
+/// `load_face_colors` (src/xfaces.c:1389-1400), so a foreground-only face
+/// merged on top renders as a *background* pill.
+#[test]
+fn face_resolver_realizes_base_face_inverse_video_after_merging_text_property_face() {
+    let _evaluator = neovm_core::emacs_core::Context::new();
+    let mut table = FaceTable::new();
+
+    let mut default = NeoFace::new("default");
+    default.foreground = Some(NeoColor::rgb(0xF5, 0xF5, 0xF5)); // white smoke
+    default.background = Some(NeoColor::rgb(0x33, 0x33, 0x33)); // gray20
+    table.define("default", default);
+
+    let mut header_line = NeoFace::new("header-line");
+    header_line.inverse_video = Some(true);
+    table.define("header-line", header_line);
+
+    let mut model_name = NeoFace::new("model-name");
+    model_name.foreground = Some(NeoColor::rgb(0x93, 0x70, 0xDB)); // medium purple
+    table.define("model-name", model_name);
+
+    let resolver = FaceResolver::new(&table, 0x00F5F5F5, 0x00333333, 14.0, Some("neo".into()));
+    let base = resolver.resolve_named_face("header-line");
+    assert_eq!(base.fg, 0x00333333);
+    assert_eq!(base.bg, 0x00F5F5F5);
+
+    let resolved = resolver
+        .resolve_face_value_over(&base, &Value::symbol("model-name"))
+        .expect("model-name resolves over header-line");
+
+    assert_eq!(
+        resolved.fg, 0x00333333,
+        "the merged foreground becomes the background under the base face's inverse-video"
+    );
+    assert_eq!(resolved.bg, 0x009370DB);
+}
+
 #[test]
 fn test_face_resolver_can_ignore_inverse_video_for_gui_menu_bar() {
     let mut table = FaceTable::new();


### PR DESCRIPTION
Inverse-video faces were realized before later string and semantic faces were merged. This could put merged colors in the wrong slot, discard escape/nobreak color changes, and apply distant-foreground to the wrong side.

Preserve the pending inverse-video attribute through face resolution, merge later sources against the unswapped colors, and realize the swap once after merging. The escape/nobreak no-op check now compares both color slots, and distant-foreground follows the inverse-video slot.
