### PR TITLE
fix(layout): place cursors using rendered glyph advances

### DIFF
--- a/crates/neomacs-layout-engine/src/buffer_source/render_plan.rs
+++ b/crates/neomacs-layout-engine/src/buffer_source/render_plan.rs
@@ -273,12 +273,32 @@ impl FastPathCursorPlacement {
                 mut output_cursor,
                 char_width,
             } => {
-                let coordinates = CursorVisualColumnResolutionRequest::from_cursor(&output_cursor)
-                    .resolve_cursor_coordinates(output.builder().cursor_visual_column_context())
-                    .unwrap_or_else(|| ResolvedCursorCoordinatePair::same(output_cursor.slot_id));
-                coordinates.apply_display_to(&mut output_cursor);
-                output_cursor.x =
-                    text_area_left + f32::from(output_cursor.col) * char_width.max(1.0);
+                let coordinates = match output
+                    .builder()
+                    .resolve_cursor_placement_after_row_decoration(&output_cursor, char_width)
+                {
+                    Some(placement) => {
+                        let coordinates = placement.coordinates();
+                        placement.apply_to(&mut output_cursor);
+                        coordinates
+                    }
+                    // No retained row to measure (or the slot is outside the
+                    // materialized text): fall back to the nominal cell grid.
+                    None => {
+                        let coordinates =
+                            CursorVisualColumnResolutionRequest::from_cursor(&output_cursor)
+                                .resolve_cursor_coordinates(
+                                    output.builder().cursor_visual_column_context(),
+                                )
+                                .unwrap_or_else(|| {
+                                    ResolvedCursorCoordinatePair::same(output_cursor.slot_id)
+                                });
+                        coordinates.apply_display_to(&mut output_cursor);
+                        output_cursor.x = text_area_left
+                            + f32::from(output_cursor.col) * char_width.max(1.0);
+                        coordinates
+                    }
+                };
                 ResolvedFastPathCursorPlacement {
                     presented: output_cursor,
                     coordinates,
@@ -1225,12 +1245,11 @@ impl BufferSourceOutputSetup {
         } else {
             remaining_visibility_retries
         };
-        if !params.force_start {
-            if let Some(decision) = retry_plan.viewport_resolution(retry_budget) {
+        if !params.force_start
+            && let Some(decision) = retry_plan.viewport_resolution(retry_budget) {
                 output.restore_retry_checkpoint(retry_checkpoint);
                 return BufferSourceRenderAttemptOutcome::ResolveViewport { decision };
             }
-        }
         if let Some(window_start) = retry_plan.should_retry(retry_budget) {
             // GNU `w->force_start` (redisplay_window force_start branch): an
             // explicitly scrolled/set start is kept, and POINT moves into the

--- a/crates/neomacs-layout-engine/src/display_cursor.rs
+++ b/crates/neomacs-layout-engine/src/display_cursor.rs
@@ -381,6 +381,10 @@ pub(crate) struct ResolvedDecoratedCursorPlacement {
 }
 
 impl ResolvedDecoratedCursorPlacement {
+    pub(crate) const fn coordinates(&self) -> ResolvedCursorCoordinatePair {
+        self.coordinates
+    }
+
     pub(crate) fn apply_to(self, cursor: &mut neomacs_display_protocol::frame_glyphs::PhysCursor) {
         self.coordinates.apply_display_to(cursor);
         cursor.x = self.x;

--- a/crates/neomacs-layout-engine/src/display_row/finalizer.rs
+++ b/crates/neomacs-layout-engine/src/display_row/finalizer.rs
@@ -442,10 +442,10 @@ impl<'cursor> GlyphRowFinalizer<'cursor> {
         POINTER_RUN_GLYPH_VISITS.with(|visits| {
             visits.set(visits.get().saturating_add(row.total_glyphs()));
         });
-        self.apply_phys_cursor_remap(remapped_cursor_col);
+        self.apply_phys_cursor_remap(row, remapped_cursor_col);
     }
 
-    fn apply_phys_cursor_remap(&mut self, remapped_cursor_col: Option<u16>) {
+    fn apply_phys_cursor_remap(&mut self, row: &GlyphRow, remapped_cursor_col: Option<u16>) {
         let Some(col) = remapped_cursor_col else {
             return;
         };
@@ -460,9 +460,26 @@ impl<'cursor> GlyphRowFinalizer<'cursor> {
         cursor.slot_id.col = col;
         if self.matrix_ncols > 0 {
             let char_w = self.context.window_pixel_bounds.width / self.matrix_ncols as f32;
-            cursor.x = self.context.window_pixel_bounds.x + col as f32 * char_w;
+            // Measure the remapped visual column from the row's materialized
+            // glyph advances. `col * char_w` assumes every glyph is one frame
+            // cell wide, so a bidi row holding another face's font, a wide
+            // glyph, or a stretch put the caret off the glyph it decorates.
+            cursor.x = self.context.window_pixel_bounds.x
+                + text_glyph_index_pixel_x(row, col, char_w);
         }
     }
+}
+
+/// Pixel pen consumed by the text glyphs before `target_index`, where the
+/// index counts entries of the TEXT_AREA glyph array (padding cells included
+/// as zero-advance gaps, as `reorder_row_bidi` numbers them).
+fn text_glyph_index_pixel_x(row: &GlyphRow, target_index: u16, char_width: f32) -> f32 {
+    row.glyphs[GlyphArea::Text.index()]
+        .iter()
+        .take(target_index as usize)
+        .filter(|glyph| !glyph.padding)
+        .map(|glyph| glyph.materialized_pixel_advance(char_width))
+        .sum()
 }
 
 #[cfg(test)]

--- a/crates/neomacs-layout-engine/src/display_row/finalizer_test.rs
+++ b/crates/neomacs-layout-engine/src/display_row/finalizer_test.rs
@@ -134,3 +134,31 @@ fn leaves_nonmatching_phys_cursor_unchanged() {
     assert_eq!(cursor.slot_id.col, 0);
     assert_eq!(cursor.x, 0.0);
 }
+
+/// The visual-column remap must measure the caret from the row's own glyph
+/// advances. `col * char_w` assumed every glyph was one frame cell wide, so a
+/// row whose font differs from the frame's default (or a wide glyph, or a
+/// stretch) put the caret off the glyph it decorates.
+#[test]
+fn remap_measures_cursor_from_row_glyph_advances() {
+    let mut row = GlyphRow::new(GlyphRowRole::Text);
+    crate::glyph_row_writer::push_char_to_row(&mut row, 'a', FaceId::new(0), 0, 20.0);
+    crate::glyph_row_writer::push_char_to_row(&mut row, 'b', FaceId::new(0), 1, 12.0);
+    row.cursor_col = Some(1);
+
+    // window x=4, 10 matrix columns over an 80px window => 8px nominal cell.
+    let mut cursor = phys_cursor(1, 0, 1);
+    GlyphRowFinalizationContext::new(1, 0, Rect::new(4.0, 0.0, 80.0, 16.0)).finalize_row(
+        &mut row,
+        10,
+        Some(&mut cursor),
+    );
+
+    assert_eq!(cursor.col, 1);
+    assert_eq!(cursor.slot_id.col, 1);
+    assert_eq!(
+        cursor.x, 24.0,
+        "cursor x must be the row origin plus the preceding glyph's 20px advance, \
+         not 4 + 1 * 8px nominal cell"
+    );
+}

--- a/crates/neomacs-layout-engine/src/engine_test.rs
+++ b/crates/neomacs-layout-engine/src/engine_test.rs
@@ -3522,6 +3522,75 @@ fn cursor_only_move_preserves_gnu_box_cursor_glyph_foreground() {
     );
 }
 
+/// The cursor-only fast path re-decorates a retained row without walking it, so
+/// it must place the caret from the row's materialized glyph advances. Deriving
+/// the pixel x from `col * char_width` assumes every glyph is one frame cell
+/// wide; a row whose glyphs use another face font (here a doubled height) is
+/// wider than the cell grid, and the caret landed past the end of the text.
+#[test]
+fn cursor_only_fast_path_places_cursor_on_the_row_glyph_advances() {
+    let text = "abWWWWcd\n";
+    let (mut eval, frame_id, buf_id, _window) = incr_editing_frame(text, 800, 600);
+    realize_test_gui_frame(&mut eval, frame_id);
+    // A face twice the default height widens every glyph it covers, so the
+    // row's pen is not `col * char_width`.
+    eval.eval_str(
+        "(progn
+           (internal-set-lisp-face-attribute 'wide-cursor-test :height 200 (selected-frame))
+           (put-text-property 3 7 'face 'wide-cursor-test))",
+    )
+    .expect("realize the wide face and apply it to the W run");
+
+    // Line numbers materialize as leading Text-area marks, so the retained
+    // row's pen also has to include their advance.
+    eval.buffer_manager_mut()
+        .get_mut(buf_id)
+        .expect("buffer")
+        .set_buffer_local("display-line-numbers", Value::T);
+    let mut engine = LayoutEngine::new();
+    // Full walk with point just past the wide run: the reference placement.
+    eval.buffer_manager_mut()
+        .get_mut(buf_id)
+        .expect("buffer")
+        .goto_emacs_byte_pos(EmacsBytePos::new(6));
+    engine.layout_frame_rust(&mut eval, frame_id);
+    let reference = engine
+        .last_frame_display_state
+        .as_ref()
+        .and_then(|state| state.phys_cursor.as_ref())
+        .expect("reference cursor")
+        .clone();
+
+    // Move away and back: both redisplays reuse the retained body rows.
+    eval.buffer_manager_mut()
+        .get_mut(buf_id)
+        .expect("buffer")
+        .goto_emacs_byte_pos(EmacsBytePos::new(0));
+    engine.layout_frame_rust(&mut eval, frame_id);
+    eval.buffer_manager_mut()
+        .get_mut(buf_id)
+        .expect("buffer")
+        .goto_emacs_byte_pos(EmacsBytePos::new(6));
+    engine.layout_frame_rust(&mut eval, frame_id);
+    assert_eq!(
+        engine.last_layout_stats().cursor_only_windows,
+        1,
+        "precondition: the returned cursor must take the cursor-only fast path"
+    );
+    let replayed = engine
+        .last_frame_display_state
+        .as_ref()
+        .and_then(|state| state.phys_cursor.as_ref())
+        .expect("replayed cursor");
+
+    assert_eq!(
+        replayed.x, reference.x,
+        "cursor-only replay must reuse the full walk's measured pen, not col * char_width"
+    );
+    assert_eq!(replayed.col, reference.col);
+    assert_eq!(replayed.row, reference.row);
+}
+
 /// GNU `init_iterator` resolves the displayed buffer's remapped default face
 /// for every window redisplay, including the blank cells owned by that window.
 /// Reusing body rows must therefore retain the same background-fill contract as

--- a/crates/neomacs-layout-engine/src/output/builder.rs
+++ b/crates/neomacs-layout-engine/src/output/builder.rs
@@ -8,6 +8,7 @@
 
 use crate::display_cursor::{
     CursorVisualColumnResolutionContext, CursorVisualColumnResolutionRequest,
+    ResolvedDecoratedCursorPlacement,
 };
 #[cfg(test)]
 use crate::display_row::face_state::resolved_display_row_face;
@@ -33,12 +34,11 @@ use crate::output::window_state::OutputWindowBuildState;
 use neomacs_display_protocol::face::Face;
 #[cfg(test)]
 use neomacs_display_protocol::frame_glyphs::CursorStyle;
+use neomacs_display_protocol::frame_glyphs::PhysCursor;
 #[cfg(test)]
 use neomacs_display_protocol::frame_glyphs::DisplaySlotId;
 #[cfg(test)]
 use neomacs_display_protocol::frame_glyphs::GlyphRowRole;
-#[cfg(test)]
-use neomacs_display_protocol::frame_glyphs::PhysCursor;
 use neomacs_display_protocol::frame_glyphs::{ContentTransitionHint, WindowInfo};
 use neomacs_display_protocol::glyph_matrix::*;
 use neomacs_display_protocol::types::FaceId;
@@ -185,12 +185,8 @@ impl DisplayOutputBuilder {
         let Some(mut cursor) = self.frame_state.phys_cursor().cloned() else {
             return;
         };
-        let Some(placement) = CursorVisualColumnResolutionRequest::from_cursor(&cursor)
-            .resolve_after_row_decoration(
-                self.cursor_visual_column_context(),
-                self.window_state.current_window_text_pixel_bounds(),
-                char_width,
-            )
+        let Some(placement) =
+            self.resolve_cursor_placement_after_row_decoration(&cursor, char_width)
         else {
             return;
         };
@@ -200,6 +196,27 @@ impl DisplayOutputBuilder {
         let style = cursor.style;
         self.install_output_frame_artifact(OutputFrameArtifactInstallRequest::phys_cursor(cursor));
         self.install_output_row_lifecycle(OutputRowLifecycleRequest::cursor(row, col, style));
+    }
+
+    /// Resolve a cursor's slot coordinates and pixel x from the retained row's
+    /// materialized glyph advances.
+    ///
+    /// The pixel x is the pen position the row's glyphs actually consume, not
+    /// `col * char_width`: a row can hold glyphs whose advance differs from the
+    /// frame's nominal cell width (a face with another font or size, a line
+    /// prefix, a stretch). The cursor-only and scroll fast paths reconstruct
+    /// their cursor from a row they did not walk, so they must read the same
+    /// advances the renderer uses instead of rebuilding them from the column.
+    pub(crate) fn resolve_cursor_placement_after_row_decoration(
+        &self,
+        cursor: &PhysCursor,
+        char_width: f32,
+    ) -> Option<ResolvedDecoratedCursorPlacement> {
+        CursorVisualColumnResolutionRequest::from_cursor(cursor).resolve_after_row_decoration(
+            self.cursor_visual_column_context(),
+            self.window_state.current_window_text_pixel_bounds(),
+            char_width,
+        )
     }
 
     /// Find the current window's buffer-text row containing `charpos` (Phase 2


### PR DESCRIPTION
Cursor replay and visual-column remapping derived the cursor's pixel position from a nominal cell width. Rows containing differently sized fonts, wide glyphs, stretches, or decorations could therefore place the cursor away from the glyph it represents.

Measure cursor placement from the retained row's materialized glyph advances, matching the geometry used to render the row across full and fast redisplay paths.
