### PR TITLE
fix(layout): use GNU font widths for scaled faces and fill indicators

### DIFF
--- a/crates/neomacs-layout-engine/src/buffer_source/face_resolution.rs
+++ b/crates/neomacs-layout-engine/src/buffer_source/face_resolution.rs
@@ -425,6 +425,7 @@ impl BufferSourceItemLayoutResolutionContext<'_> {
                 fallback_metrics: self.default_face_metrics,
             },
             factor,
+            source_render.concrete_font_metrics(),
         ) else {
             return active_face_state.clone();
         };

--- a/crates/neomacs-layout-engine/src/buffer_source/loop_context.rs
+++ b/crates/neomacs-layout-engine/src/buffer_source/loop_context.rs
@@ -179,6 +179,7 @@ impl BufferSourceLoopRequestContext {
                 self.frame_background,
                 self.fill_column_indicator,
                 self.fill_column_indicator_char,
+                self.metrics.char_width(),
             ),
         )
     }

--- a/crates/neomacs-layout-engine/src/buffer_source/row_lifecycle.rs
+++ b/crates/neomacs-layout-engine/src/buffer_source/row_lifecycle.rs
@@ -1629,6 +1629,10 @@ pub(crate) struct BufferSourceLineBreakRenderContext<'a> {
     frame_background: Color,
     fill_column_indicator: i32,
     fill_column_indicator_char: char,
+    /// Default-face character advance, the unit GNU locates the
+    /// fill-column indicator column in (`fill_column_indicator_column` uses
+    /// `default_face->font->average_width`, src/xdisp.c:24540-24546).
+    default_char_width: f32,
 }
 
 impl<'a> BufferSourceLineBreakRenderContext<'a> {
@@ -1652,6 +1656,7 @@ impl<'a> BufferSourceLineBreakRenderContext<'a> {
         frame_background: Color,
         fill_column_indicator: i32,
         fill_column_indicator_char: char,
+        default_char_width: f32,
     ) -> Self {
         Self {
             text,
@@ -1672,6 +1677,7 @@ impl<'a> BufferSourceLineBreakRenderContext<'a> {
             frame_background,
             fill_column_indicator,
             fill_column_indicator_char,
+            default_char_width,
         }
     }
 }
@@ -1806,6 +1812,7 @@ impl<'a> BufferSourceLineBreakRenderRequest<'a> {
                 height_px: metrics.row_height(),
                 ascent_px: metrics.ascent(),
                 fill_char_width: metrics.char_width(),
+                indicator_char_width: context.default_char_width,
             };
             source_render.render_line_end(&line_end_ctx, line_end_geometry, face_ids);
         }
@@ -1989,6 +1996,7 @@ impl<'a> BufferSourceLineBreakRenderRequest<'a> {
                     height_px: metrics.row_height(),
                     ascent_px: metrics.ascent(),
                     fill_char_width: metrics.char_width(),
+                    indicator_char_width: context.default_char_width,
                 },
                 face_ids,
             );

--- a/crates/neomacs-layout-engine/src/display_face_layout.rs
+++ b/crates/neomacs-layout-engine/src/display_face_layout.rs
@@ -1,5 +1,6 @@
 use crate::display_row::metrics::DisplayRowFallbackMetrics;
 use crate::display_row::width::DisplayRowCharWidthPolicy;
+use crate::font::metrics::FontMetricsService;
 use crate::neovm_bridge::ResolvedFace;
 
 pub(crate) struct DisplayHeightFaceBasis<'a> {
@@ -12,6 +13,7 @@ pub(crate) fn height_adjusted_face(
     source: &ResolvedFace,
     basis: DisplayHeightFaceBasis<'_>,
     factor: f32,
+    font_metrics: Option<&mut FontMetricsService>,
 ) -> Option<ResolvedFace> {
     if !factor.is_finite() || factor <= 0.0 {
         return None;
@@ -45,10 +47,98 @@ pub(crate) fn height_adjusted_face(
     resolved.font_ascent = (canonical_ascent * factor)
         .max(1.0)
         .min(resolved.font_line_height);
-    resolved.set_measured_char_width_px((canonical_char_width * factor).max(1.0));
+    // GNU re-measures the font after a relative `:height`
+    // (`font_load_for_lface` -> `x_set_font`), so the scaled advance is the
+    // font engine's answer at the SCALED pixel size, not the canonical advance
+    // times the factor. Scaling only approximates it and drifts whenever the
+    // advance is not linear in the size; keep it only as the no-measurement
+    // fallback (TTY / font service absent).
+    let measured_char_width = font_metrics
+        .map(|service| {
+            service
+                .font_metrics(
+                    &resolved.font_family,
+                    resolved.font_weight,
+                    resolved.italic,
+                    resolved.font_size,
+                )
+                .char_width
+        })
+        .filter(|width| width.is_finite() && *width > 0.0);
+    resolved.set_measured_char_width_px(
+        measured_char_width
+            .unwrap_or(canonical_char_width * factor)
+            .max(1.0),
+    );
     Some(resolved)
 }
 
 fn positive_f32(value: f32) -> Option<f32> {
     (value.is_finite() && value > 0.0).then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::display_row::metrics::DisplayRowFallbackMetrics;
+
+    fn face(family: &str, size: f32) -> ResolvedFace {
+        let mut face = ResolvedFace::default();
+        face.font_family = family.to_string();
+        face.font_weight = 400;
+        face.italic = false;
+        face.font_size = size;
+        face.font_line_height = size * 1.2;
+        face.font_ascent = size * 0.8;
+        face.set_measured_char_width_px(8.0);
+        face
+    }
+
+    fn basis<'a>(canonical: &'a ResolvedFace) -> DisplayHeightFaceBasis<'a> {
+        DisplayHeightFaceBasis {
+            canonical_face: canonical,
+            base_face: canonical,
+            fallback_metrics: DisplayRowFallbackMetrics::from_default_face_extents(8.0, 16.0, 12.0),
+        }
+    }
+
+    /// GNU re-measures the font at the scaled size (`font_load_for_lface` ->
+    /// `x_set_font`), so with a font service the face must carry the service's
+    /// advance for the SCALED pixel size; only the no-service fallback may scale
+    /// the canonical advance by the height factor.
+    #[test]
+    fn height_adjusted_face_measures_the_scaled_font_when_a_service_is_available() {
+        let _eval = neovm_core::emacs_core::Context::new();
+        let canonical = face("Monospace", 13.0);
+        let mut service = FontMetricsService::new();
+
+        let measured = height_adjusted_face(
+            &canonical,
+            basis(&canonical),
+            1.3,
+            Some(&mut service),
+        )
+        .expect("scaled face");
+        let expected = service
+            .font_metrics(
+                &measured.font_family,
+                measured.font_weight,
+                measured.italic,
+                measured.font_size,
+            )
+            .char_width;
+        assert_eq!(
+            measured.measured_char_width_px(),
+            expected,
+            "the scaled face must carry the font service's advance for the scaled size"
+        );
+
+        let fallback =
+            height_adjusted_face(&canonical, basis(&canonical), 1.3, None).expect("scaled face");
+        assert_eq!(
+            fallback.measured_char_width_px(),
+            8.0 * 1.3,
+            "without a service the canonical advance scales by the height factor"
+        );
+    }
 }

--- a/crates/neomacs-layout-engine/src/display_row/append_test.rs
+++ b/crates/neomacs-layout-engine/src/display_row/append_test.rs
@@ -2959,6 +2959,7 @@ fn buffer_text_line_break_render_request_emits_row_transition_and_syncs_position
             Color::from_pixel(0x00FFFFFF),
             -1,
             '|',
+            8.0,
         ),
     )
     .render_and_apply(

--- a/crates/neomacs-layout-engine/src/display_row/fill_column_indicator_test.rs
+++ b/crates/neomacs-layout-engine/src/display_row/fill_column_indicator_test.rs
@@ -137,3 +137,61 @@ fn extend_row_wraps_indicator_in_extend_stretches() {
     assert_eq!(glyphs[3].face_id, EXTEND_FACE, "tail keeps the highlight");
     assert_eq!(glyphs[3].pixel_width, 40.0);
 }
+
+struct TestFaces;
+
+impl super::LineEndFaceResolver for TestFaces {
+    fn trailing_whitespace_face_id(&mut self) -> FaceId {
+        unreachable!("no trailing-whitespace step in this test")
+    }
+
+    fn fill_column_indicator_face_id(
+        &mut self,
+        _extend_bg: Option<neomacs_display_protocol::types::Color>,
+    ) -> FaceId {
+        FCI_FACE
+    }
+}
+
+/// GNU locates the fill-column indicator column with the DEFAULT face's font
+/// width (`fill_column_indicator_column` is called with
+/// `default_face->font->average_width`, src/xdisp.c:24540-24546). A line that
+/// ends in another font -- a fixed-pitch `org-block` row, a `:height` run --
+/// must still put the indicator at the same column, so the position may not
+/// follow the face active at the line end.
+#[test]
+fn indicator_column_uses_the_default_face_advance_not_the_line_end_face() {
+    let ctx = super::LineEndContext {
+        newline_face_id: TEXT_FACE,
+        measurement_mode: crate::display_row::face_state::DisplayRowMeasurementMode::ConcreteFont,
+        pen_x: 8.0,
+        pen_col: 1,
+        right_edge_x: 400.0,
+        // The face active at the line end: 11px per cell.
+        char_width: 11.0,
+        indicator: Some(super::LineEndIndicator { col: 10, ch: '│' }),
+        extend: None,
+        frame_background: neomacs_display_protocol::types::Color::from_pixel(0x00FFFFFF),
+        trailing_whitespace_enabled: false,
+        box_vertical_edges: neomacs_display_protocol::face::BoxVerticalEdges::Neither,
+        box_run_membership: neomacs_display_protocol::face::BoxRunMembership::Unboxed,
+    };
+    let geometry = super::LineEndFillGeometry {
+        content_x: 8.0,
+        height_px: 16.0,
+        ascent_px: 12.0,
+        fill_char_width: 8.0,
+        // The default face: 8px per cell.
+        indicator_char_width: 8.0,
+    };
+
+    let fill = super::resolve_indicator_fill(&ctx, geometry, 8.0, &mut TestFaces);
+
+    // 8 (content_x) + 10 * 8 (default advance) - 8 (pen) = 80. Following the
+    // line-end face's 11px advance would give 110.
+    assert_eq!(
+        fill.gap_px, 80.0,
+        "the indicator column must be measured with the default face's advance"
+    );
+    assert_eq!(fill.char_width, 8.0);
+}

--- a/crates/neomacs-layout-engine/src/display_row/finalizer.rs
+++ b/crates/neomacs-layout-engine/src/display_row/finalizer.rs
@@ -131,6 +131,7 @@ impl DisplayRowLineEndFinalizer {
                         .char_width_px(self.fallback_metrics.char_width())
                 })
                 .unwrap_or_else(|| self.fallback_metrics.char_width()),
+            indicator_char_width: self.fallback_metrics.char_width(),
         };
         plan(&ctx)
             .resolve(&ctx, geometry, &mut NoNamedLineEndFaces)

--- a/crates/neomacs-layout-engine/src/display_row/line_end.rs
+++ b/crates/neomacs-layout-engine/src/display_row/line_end.rs
@@ -253,6 +253,13 @@ pub(crate) struct LineEndFillGeometry {
     /// come from the extend face's own metrics, unlike the appended glyph's
     /// `LineEndContext::char_width`).
     pub(crate) fill_char_width: f32,
+    /// Character advance used to locate the fill-column indicator column.
+    /// GNU measures it from the DEFAULT face's font
+    /// (`fill_column_indicator_column` takes `default_face->font->average_width`,
+    /// src/xdisp.c:24540-24546), NOT from the face active at the line end, so a
+    /// line that ends in another font still puts the indicator at the same
+    /// column.
+    pub(crate) indicator_char_width: f32,
 }
 
 /// Face-resolution services the executor needs. The named-face lookups
@@ -386,7 +393,7 @@ fn resolve_indicator_fill<R: LineEndFaceResolver>(
     let indicator = ctx
         .indicator
         .expect("plan() emits IndicatorFill only with an indicator config");
-    let char_width = ctx.char_width;
+    let char_width = geometry.indicator_char_width.max(1.0);
     let indicator_px = geometry.content_x + indicator.col as f32 * char_width;
     // Positioning stays pixel-based: when the text ends exactly at the
     // indicator column, `from_x` may be a hair past `indicator_px`, so clamp

--- a/crates/neomacs-layout-engine/src/display_row/source_render.rs
+++ b/crates/neomacs-layout-engine/src/display_row/source_render.rs
@@ -922,6 +922,16 @@ impl<'a> TextRowSourceRenderState<'a> {
         }
     }
 
+    /// The concrete-font service, when this row measures with real font
+    /// geometry. `None` on terminal rows, where GNU's character width is one
+    /// cell and there is no font to re-measure.
+    pub(crate) fn concrete_font_metrics(&mut self) -> Option<&mut FontMetricsService> {
+        self.measurement_mode
+            .uses_concrete_font_geometry()
+            .then_some(self.font_metrics.as_mut())
+            .flatten()
+    }
+
     pub(crate) fn output_render(&mut self) -> TextRowOutputRenderState<'_> {
         self.output_render.reborrow()
     }

--- a/crates/neomacs-layout-engine/src/display_source_resolver.rs
+++ b/crates/neomacs-layout-engine/src/display_source_resolver.rs
@@ -784,7 +784,10 @@ impl<'a> DisplaySourcePropertyResolver<'a> {
         }
 
         let source = self.state.resolved_face_for(face, face_basis.base_face());
-        let Some(resolved) = height_adjusted_face(&source, face_basis.height_basis(), factor)
+        // This resolver has no font service of its own; the installed active
+        // face is measured later, so only the stored `ResolvedFace` keeps the
+        // scaled-advance fallback here.
+        let Some(resolved) = height_adjusted_face(&source, face_basis.height_basis(), factor, None)
         else {
             return face;
         };


### PR DESCRIPTION
Layout used linearly scaled character widths for relative-height faces and used the face active at line end to position the fill-column indicator. Both can drift from GNU Emacs when fonts have non-linear metrics or a line ends in a different face.

Remeasure relative-height faces at their scaled font size when concrete font metrics are available, and position the fill-column indicator using the default face's character width.
