### PR TITLE
release: ship macOS x86_64 (Intel) builds from macos-15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,12 @@ jobs:
             label: linux-aarch64
           - runner: macos-latest
             label: macos-aarch64
+          # `macos-15-intel` is GitHub's last x86_64 runner image, promised
+          # only until August 2027 (actions/runner-images#13045).  Keep the
+          # workspace compiling for x86_64-apple-darwin here so the release
+          # job never discovers a breakage at tag time.
+          - runner: macos-15-intel
+            label: macos-x86_64
           - runner: windows-latest
             label: windows-msvc-x86_64
           - runner: windows-11-arm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: macos-notarization-diagnostics
+          name: macos-notarization-diagnostics-aarch64
           path: dist/notary/*.json
           if-no-files-found: ignore
 
@@ -229,6 +229,90 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos-aarch64
+          path: |
+            dist/*.dmg
+            dist/*.zip
+            dist/*.tar.gz
+          if-no-files-found: error
+
+  # ── macOS x86_64 (Intel) ──────────────────────────────────────────────
+  # `macos-15-intel` is GitHub's LAST x86_64 runner image, promised only
+  # until August 2027 (actions/runner-images#13045); macos-13, the previous
+  # Intel image, closed down in December 2025.  Build this target natively
+  # while the image exists -- afterwards the only path is cross-compiling
+  # x86_64-apple-darwin on an arm64 runner and running the bootstrap's pdump
+  # generation under Rosetta.
+  build-macos-x86_64:
+    name: build macOS x86_64
+    runs-on: macos-15-intel
+    timeout-minutes: 180
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: 1
+      # See the aarch64 job: vendoring rewrites load commands to longer
+      # @executable_path names, so every linked binary needs the reserved
+      # header space.
+      RUSTFLAGS: "-C link-arg=-Wl,-headerpad_max_install_names"
+      # Shared by the compile step and the bootstrap below so both describe
+      # one build.  darwin declares the same cargo-features for either
+      # architecture; a test pins this list to that table.
+      RELEASE_FEATURES: webview,neomacs-layout-engine/freetype-bundled
+    outputs:
+      distribution_mode: ${{ steps.macos-signing.outputs.distribution_mode }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust tooling
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-key: release-macos-x86_64
+          target: x86_64-apple-darwin
+
+      - name: Set version env
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      # Same contract as the aarch64 job: the args must match xtask's
+      # initial_cargo_build_args EXACTLY, including NEOMACS_BUILD_PROFILE,
+      # or the bootstrap refingerprints and rebuilds instead of reusing.
+      - name: Compile release binaries
+        env:
+          NEOMACS_BUILD_PROFILE: release
+        run: cargo build -p neomacs --features "$RELEASE_FEATURES" --profile release
+
+      - name: Bootstrap and dump
+        run: cargo xtask fresh-build --release --features "$RELEASE_FEATURES" --skip-build
+
+      - name: Configure Developer ID signing and notarization
+        id: macos-signing
+        env:
+          # The Developer ID certificate and App Store Connect key are
+          # architecture-agnostic; the same secrets sign both macOS jobs.
+          MACOS_REQUIRE_SIGNING: ${{ vars.MACOS_REQUIRE_SIGNING || '0' }}
+          MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+        run: ./scripts/configure-macos-signing-ci.sh
+
+      - name: Build and package complete macOS application
+        run: ./scripts/package-macos-app.sh --skip-build
+
+      - name: Upload notarization diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: macos-notarization-diagnostics-x86_64
+          path: dist/notary/*.json
+          if-no-files-found: ignore
+
+      - name: Upload macOS x86_64 artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: macos-x86_64
           path: |
             dist/*.dmg
             dist/*.zip
@@ -358,6 +442,7 @@ jobs:
     needs:
       - build-linux
       - build-macos-aarch64
+      - build-macos-x86_64
       - build-windows
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -565,13 +565,25 @@ jobs:
   # variables, exercising the runtime-root resolution through the
   # ~/.local/bin symlink chain.
   verify-macos-install-script:
-    name: verify install.sh on macOS from the published release
+    name: verify install.sh on macOS ${{ matrix.arch }} from the published release
     # This MUST depend on create-release: it reads an asset OF the release.
     # It previously ran inside a job that create-release itself depended on, so
     # the release could not be made until a step passed that could only pass
     # once the release existed - a cycle that can never be satisfied.
+    #
+    # install.sh selects the asset by uname, so each arch entry verifies its
+    # own published tarball end to end; the x86_64 entry rides GitHub's last
+    # Intel image (until August 2027, actions/runner-images#13045).
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            runner: macos-latest
+          - arch: x86_64
+            runner: macos-15-intel
     needs: create-release
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     steps:
       - name: Run the published installer

--- a/install.sh
+++ b/install.sh
@@ -176,9 +176,7 @@ case "$os:$arch" in
   linux:x86_64) triple=x86_64-unknown-linux-gnu ;;
   linux:aarch64|linux:arm64) triple=aarch64-unknown-linux-gnu ;;
   darwin:arm64|darwin:aarch64) triple=aarch64-apple-darwin ;;
-  darwin:x86_64)
-    die "no Intel Mac (x86_64) builds are published yet; see https://github.com/$repo/releases"
-    ;;
+  darwin:x86_64) triple=x86_64-apple-darwin ;;
   *)
     die "unsupported $os architecture: $arch"
     ;;

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -88,9 +88,12 @@ linux_x86_rpm="neomacs-$version-1.x86_64.rpm"
 linux_arm_rpm="neomacs-$version-1.aarch64.rpm"
 linux_x86_tarball="neomacs-$version-x86_64-unknown-linux-gnu.tar.gz"
 linux_arm_tarball="neomacs-$version-aarch64-unknown-linux-gnu.tar.gz"
-macos_dmg="neomacs-$version-aarch64-apple-darwin.dmg"
-macos_zip="neomacs-$version-aarch64-apple-darwin.zip"
-macos_tarball="neomacs-$version-aarch64-apple-darwin.tar.gz"
+macos_arm_dmg="neomacs-$version-aarch64-apple-darwin.dmg"
+macos_arm_zip="neomacs-$version-aarch64-apple-darwin.zip"
+macos_arm_tarball="neomacs-$version-aarch64-apple-darwin.tar.gz"
+macos_x86_dmg="neomacs-$version-x86_64-apple-darwin.dmg"
+macos_x86_zip="neomacs-$version-x86_64-apple-darwin.zip"
+macos_x86_tarball="neomacs-$version-x86_64-apple-darwin.tar.gz"
 windows_x86_installer="neomacs-$version-x86_64-pc-windows-msvc-user-setup.exe"
 windows_x86_zip="neomacs-$version-x86_64-pc-windows-msvc.zip"
 windows_arm_installer="neomacs-$version-aarch64-pc-windows-msvc-user-setup.exe"
@@ -107,9 +110,12 @@ required_assets=(
   "$linux_arm_rpm"
   "$linux_x86_tarball"
   "$linux_arm_tarball"
-  "$macos_dmg"
-  "$macos_zip"
-  "$macos_tarball"
+  "$macos_arm_dmg"
+  "$macos_arm_zip"
+  "$macos_arm_tarball"
+  "$macos_x86_dmg"
+  "$macos_x86_zip"
+  "$macos_x86_tarball"
   "$windows_x86_installer"
   "$windows_x86_zip"
   "$windows_arm_installer"
@@ -194,15 +200,25 @@ write_installation_methods() {
       <td><a href="$release_base/$linux_arm_rpm"><code>$linux_arm_rpm</code></a></td>
     </tr>
     <tr>
-      <td rowspan="3"><img src="https://cdn.simpleicons.org/apple/808080" width="32" height="32" alt="Apple logo"><br><strong>macOS</strong></td>
+      <td rowspan="6"><img src="https://cdn.simpleicons.org/apple/808080" width="32" height="32" alt="Apple logo"><br><strong>macOS</strong></td>
       <td rowspan="3" colspan="2">Apple Silicon<br><code>aarch64</code></td>
-      <td><a href="$release_base/$macos_dmg"><code>$macos_dmg</code></a></td>
+      <td><a href="$release_base/$macos_arm_dmg"><code>$macos_arm_dmg</code></a></td>
     </tr>
     <tr>
-      <td><a href="$release_base/$macos_zip"><code>$macos_zip</code></a></td>
+      <td><a href="$release_base/$macos_arm_zip"><code>$macos_arm_zip</code></a></td>
     </tr>
     <tr>
-      <td><a href="$release_base/$macos_tarball"><code>$macos_tarball</code></a></td>
+      <td><a href="$release_base/$macos_arm_tarball"><code>$macos_arm_tarball</code></a></td>
+    </tr>
+    <tr>
+      <td rowspan="3" colspan="2">Intel<br><code>x86_64</code></td>
+      <td><a href="$release_base/$macos_x86_dmg"><code>$macos_x86_dmg</code></a></td>
+    </tr>
+    <tr>
+      <td><a href="$release_base/$macos_x86_zip"><code>$macos_x86_zip</code></a></td>
+    </tr>
+    <tr>
+      <td><a href="$release_base/$macos_x86_tarball"><code>$macos_x86_tarball</code></a></td>
     </tr>
     <tr>
       <td rowspan="4"><img src="https://cdn.jsdelivr.net/gh/devicons/devicon@v2.17.0/icons/windows11/windows11-original.svg" width="32" height="32" alt="Windows logo"><br><strong>Windows</strong></td>

--- a/scripts/package-macos-app.sh
+++ b/scripts/package-macos-app.sh
@@ -26,9 +26,9 @@ Environment:
            App Store Connect API key used to notarize/staple the app and DMG.
 
 Output:
-  dist/neomacs-{version}-aarch64-apple-darwin.dmg
-  dist/neomacs-{version}-aarch64-apple-darwin.zip
-  dist/neomacs-{version}-aarch64-apple-darwin.tar.gz
+  dist/neomacs-{version}-{aarch64|x86_64}-apple-darwin.dmg
+  dist/neomacs-{version}-{aarch64|x86_64}-apple-darwin.zip
+  dist/neomacs-{version}-{aarch64|x86_64}-apple-darwin.tar.gz
   dist/neomacs.app
 USAGE
 }
@@ -76,7 +76,20 @@ version="$(get_version)"
 product_name="NEO Emacs"
 app_bundle_name="neomacs"
 app_bundle="$dist_dir/$app_bundle_name.app"
-artifact_stem="neomacs-${version}-aarch64-apple-darwin"
+# The artifact triple names the architecture this machine's binaries were
+# built for -- each release job compiles natively, so the host reports it.
+# vendor-macos-runtime.sh thins bundle images against the same value (its
+# MACOS_BUNDLE_ARCH default is uname -m too), so the asset name and the
+# bundle contents always describe one architecture.
+case "$(uname -m)" in
+  arm64) artifact_triple=aarch64-apple-darwin ;;
+  x86_64) artifact_triple=x86_64-apple-darwin ;;
+  *)
+    echo "unsupported macOS build architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+artifact_stem="neomacs-${version}-${artifact_triple}"
 dmg="$dist_dir/$artifact_stem.dmg"
 zip="$dist_dir/$artifact_stem.zip"
 tarball="$dist_dir/$artifact_stem.tar.gz"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -10,8 +10,9 @@ Build and package a Neomacs binary release archive.
 Options:
   --target TRIPLE Rust target triple, e.g. x86_64-unknown-linux-gnu.
                   Defaults to x86_64-unknown-linux-gnu on Linux,
-                  aarch64-apple-darwin on macOS, x86_64-pc-windows-msvc or
-                  aarch64-pc-windows-msvc on Windows.
+                  aarch64- or x86_64-apple-darwin on macOS,
+                  x86_64-pc-windows-msvc or aarch64-pc-windows-msvc on
+                  Windows.
   --skip-build    Package existing artifacts (target/release, or the directory
                   named by NEOMACS_RELEASE_DIR) without running
                   cargo xtask fresh-build --release.

--- a/scripts/test-generate-release-notes.sh
+++ b/scripts/test-generate-release-notes.sh
@@ -33,6 +33,9 @@ assets=(
   neomacs-9.8.7-aarch64-apple-darwin.dmg
   neomacs-9.8.7-aarch64-apple-darwin.zip
   neomacs-9.8.7-aarch64-apple-darwin.tar.gz
+  neomacs-9.8.7-x86_64-apple-darwin.dmg
+  neomacs-9.8.7-x86_64-apple-darwin.zip
+  neomacs-9.8.7-x86_64-apple-darwin.tar.gz
   neomacs-9.8.7-x86_64-pc-windows-msvc-user-setup.exe
   neomacs-9.8.7-x86_64-pc-windows-msvc.zip
   neomacs-9.8.7-aarch64-pc-windows-msvc-user-setup.exe
@@ -65,6 +68,7 @@ assert_contains '<th>Architecture</th>'
 assert_contains '<th>Install / download</th>'
 assert_contains '<td rowspan="11"><img'
 assert_contains '<td rowspan="3" colspan="2">Apple Silicon<br><code>aarch64</code></td>'
+assert_contains '<td rowspan="3" colspan="2">Intel<br><code>x86_64</code></td>'
 assert_contains '<td rowspan="2" colspan="2"><code>x86_64</code></td>'
 assert_contains 'alt="Archive file icon"> <strong>Portable archive</strong></td>'
 assert_contains 'alt="AppImage logo"> <strong>AppImage</strong></td>'
@@ -93,8 +97,8 @@ for asset in "${assets[@]}"; do
 done
 
 download_count="$(grep -o 'href="https://github.com/eval-exec/neomacs/releases/download/v9.8.7/[^\"]*"><code>[^<]*</code></a>' "$output" | wc -l | tr -d ' ')"
-if [[ "$download_count" != "15" ]]; then
-  echo "expected 15 package download links, found $download_count" >&2
+if [[ "$download_count" != "18" ]]; then
+  echo "expected 18 package download links, found $download_count" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Closes the last single-arch hole in the release matrix: Linux and Windows each ship x86_64 + aarch64; macOS shipped aarch64 only, and `install.sh` told Intel Macs "no Intel Mac (x86_64) builds are published yet".

**Why now:** `macos-15-intel` is GitHub's [last x86_64 runner image, promised only until August 2027](https://github.com/actions/runner-images/issues/13045) (`macos-13` closed in Dec 2025). Native builds are cheap while the image exists; afterwards the only path is cross-compiling + Rosetta for the pdump bootstrap.

- **release.yml** — new `build-macos-x86_64` job (copy of the aarch64 job, same `RELEASE_FEATURES`, same signing/notarization secrets); arch-suffixed notarization-diagnostics artifacts; `create-release` waits on it.
- **ci.yml** — check matrix gains `macos-x86_64`, so the target compiles on every PR instead of being discovered at tag time.
- **package-macos-app.sh** — artifact triple derived from the build host instead of hardcoded `aarch64-apple-darwin` (vendor-macos-runtime.sh already thins to the same value).
- **generate-release-notes.sh** + test — three x86_64 macOS containers in the required list and download table (18 links).
- **install.sh** — `darwin:x86_64` resolves the triple instead of dying.

Verification: `test-generate-release-notes.sh` passes; the xtask RELEASE_FEATURES pinning test passes; both workflows parse with the new wiring asserted; this PR's CI runs the new check entry, and a branch dispatch of the tmp macOS fresh-build workflow exercises compile + bootstrap + pdump natively on `macos-15-intel`.